### PR TITLE
Finalize Continuous Learning Control Plane Contract

### DIFF
--- a/rfcs/0036-continuous-learning-control-plane-contract-v1.md
+++ b/rfcs/0036-continuous-learning-control-plane-contract-v1.md
@@ -1,0 +1,6 @@
+# RFC 0036: Continuous Learning Control Plane Contract v1
+
+> Canonical RFC file moved to keep phase naming uniform:
+> [`0036-phase8a-continuous-learning-control-plane-contract-v1.md`](./0036-phase8a-continuous-learning-control-plane-contract-v1.md).
+
+This compatibility alias is kept so issue links and docs references remain stable.

--- a/scripts/ci/contract-version-manifest.json
+++ b/scripts/ci/contract-version-manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": "1.3.0",
+  "manifest_version": "1.4.0",
   "artifacts": [
     {
       "path": "proto/eigen/api/v1/device_service.proto",
@@ -48,7 +48,7 @@
     {
       "path": "src/services/system-api/tests/fixtures/contracts/knowledge_base_v1/error_model_v1_0_0.json",
       "sha256": "06bcabb1b49239b93bf78307bc849bfb9bee6f906fb9fbb7f35c48e10e26d337"
-      },
+    },
     {
       "path": "proto/eigen/internal/v1/optimizer_service.proto",
       "sha256": "9abb8c8ccb47a8525717217faddd556c0f5c7934809af139d33b3b27f8fb5d8d"
@@ -56,6 +56,10 @@
     {
       "path": "src/services/system-api/tests/fixtures/contracts/optimizer_v1/service_contract_v1_0_0.json",
       "sha256": "cd2a6582c2c816c48841fc64fa72bd3427505e8f005133b4f95f0f2bf0cfa7fa"
+    },
+    {
+      "path": "src/services/system-api/tests/fixtures/contracts/learning_control_plane_v1/control_plane_contract_v1_0_0.json",
+      "sha256": "585f2cca4615b66776c7e6d91b34c0584984e86d9993e9cb0a9a1deffd097692"
     }
   ]
 }

--- a/src/services/system-api/tests/fixtures/contracts/learning_control_plane_v1/control_plane_contract_v1_0_0.json
+++ b/src/services/system-api/tests/fixtures/contracts/learning_control_plane_v1/control_plane_contract_v1_0_0.json
@@ -1,0 +1,48 @@
+{
+  "contract": "continuous_learning_control_plane",
+  "version": "1.0.0",
+  "lifecycle": {
+    "states": ["DRAFT", "TRAINED", "VALIDATED", "SHADOW", "CANARY", "PROMOTED", "RETIRED"],
+    "allowed_transitions": {
+      "DRAFT": ["TRAINED", "RETIRED"],
+      "TRAINED": ["VALIDATED", "RETIRED"],
+      "VALIDATED": ["SHADOW", "RETIRED"],
+      "SHADOW": ["CANARY", "RETIRED"],
+      "CANARY": ["PROMOTED", "ROLLBACK_TO_VALIDATED", "RETIRED"],
+      "PROMOTED": ["ROLLBACK_TO_VALIDATED", "RETIRED"],
+      "RETIRED": []
+    }
+  },
+  "commands": ["StartTraining", "RunEvaluation", "PromoteModel", "RollbackModel", "GetModelLifecycle"],
+  "idempotency": {
+    "required_fields": ["command", "model_version", "idempotency_key"],
+    "same_key_same_payload": "return_previous_result",
+    "same_key_different_payload": "LEARN_IDEMPOTENCY_KEY_REUSED_WITH_DIFFERENT_PAYLOAD"
+  },
+  "replay": {
+    "required_fields": ["replay_of_command_id", "replay_attempt"],
+    "max_side_effects": 1,
+    "result_consistency": "deterministic"
+  },
+  "audit_required_fields": ["command_id", "requested_by", "requested_at", "trace_id", "from_state", "to_state", "decision", "gate_results"],
+  "observability": {
+    "metrics": [
+      "learning_control_plane_transition_total",
+      "learning_control_plane_gate_failures_total",
+      "learning_control_plane_promotion_lead_time_seconds",
+      "learning_control_plane_rollback_total"
+    ]
+  },
+  "reason_codes": [
+    "LEARN_INVALID_STATE_TRANSITION",
+    "LEARN_EVAL_FAILED",
+    "LEARN_PROMOTION_BLOCKED",
+    "LEARN_ROLLBACK_FAILED",
+    "LEARN_IDEMPOTENCY_KEY_REUSED_WITH_DIFFERENT_PAYLOAD",
+    "LEARN_INTERNAL"
+  ],
+  "deprecation_policy": {
+    "min_supported_minor_releases": 2,
+    "min_supported_days": 90
+  }
+}

--- a/src/services/system-api/tests/test_learning_control_plane_contract_fixture.py
+++ b/src/services/system-api/tests/test_learning_control_plane_contract_fixture.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_learning_control_plane_fixture_is_frozen_v1() -> None:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "contracts"
+        / "learning_control_plane_v1"
+        / "control_plane_contract_v1_0_0.json"
+    )
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+    assert payload["contract"] == "continuous_learning_control_plane"
+    assert payload["version"] == "1.0.0"
+    assert payload["lifecycle"]["states"] == ["DRAFT", "TRAINED", "VALIDATED", "SHADOW", "CANARY", "PROMOTED", "RETIRED"]
+    assert payload["lifecycle"]["allowed_transitions"]["CANARY"] == ["PROMOTED", "ROLLBACK_TO_VALIDATED", "RETIRED"]
+    assert payload["idempotency"] == {
+        "required_fields": ["command", "model_version", "idempotency_key"],
+        "same_key_same_payload": "return_previous_result",
+        "same_key_different_payload": "LEARN_IDEMPOTENCY_KEY_REUSED_WITH_DIFFERENT_PAYLOAD",
+    }
+    assert payload["deprecation_policy"] == {
+        "min_supported_minor_releases": 2,
+        "min_supported_days": 90,
+    }


### PR DESCRIPTION
## Summary

- Added a fixed contract fixture v1.0.0 for Continuous Learning Control Plane with explicit lifecycle state/transition invariants, idempotency/replay rules, audit/observability fields, reason codes, and deprecation policy (2 minor or 90 days).
- Added a test that fixes/verifies the immutability of key invariants of this contract (version, states, CANARY transitions, idempotency semantics, deprecation policy).
- Updated the contract manifest for fail-closed drift checking: raised the manifest version to 1.4.0 and added the new artifact + SHA256.
- Added a compatible RFC alias file rfcs/0036-continuous-learning-control-plane-contract-v1.md so that links from issue/docs remain valid and point to the canonical RFC.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: API, Compatibility matrix
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added

- Added continuous learning control-plane v1.0.0 frozen contract fixture with explicit lifecycle transitions, idempotency/replay semantics, governance/audit fields, and observability metrics.
- Added compatibility alias RFC path: `rfcs/0036-continuous-learning-control-plane-contract-v1.md`.

### Changed

- Updated `scripts/ci/contract-version-manifest.json` to `manifest_version: 1.4.0` and registered the new learning control-plane contract artifact hash.

### Fixed

- Fixed broken/mismatched RFC reference path expected by Phase-8A issue/docs links by adding a stable alias file.
