### PR TITLE
Finalize QFS-L2 checkpoint envelope contract

### DIFF
--- a/rfcs/0037-phase8a-qfs-l2-checkpoint-envelope-contract-v1.md
+++ b/rfcs/0037-phase8a-qfs-l2-checkpoint-envelope-contract-v1.md
@@ -30,6 +30,14 @@ Defines a versioned QFS-L2 checkpoint envelope for runtime state snapshot/restor
 - Integrity: checksum set + signature reference.
 - Provenance: compiler/optimizer/model versions, backend profile, seed.
 - Guardrails: declared byte size, estimated restore cost, TTL class.
+- Trace links (mandatory): `artifact_manifest_ref`, `dataset_metadata_ref`, `checkpoint_chain_ref`.
+
+### Decoding and upgrade notes
+
+- Readers must first decode `schema_version` and route by SemVer major.
+- `1.x` readers must reject missing trace-link fields and report `QFSL2_INVALID_ENVELOPE`.
+- Future `1.x` extensions are allowed only via additive optional fields with deterministic defaults.
+- `2.0.0+` may introduce incompatible required-field or semantic changes and must ship migration notes.
 
 ### API semantics
 
@@ -62,6 +70,7 @@ Defines a versioned QFS-L2 checkpoint envelope for runtime state snapshot/restor
 
 - **Version impact:** QFS-L2 envelope contract `1.0.0`.
 - **Compatibility:** additive optional metadata is `MINOR`; required header/payload semantic changes are `MAJOR`.
+- **Reader policy:** fail closed on unknown major, fail closed on missing mandatory trace-link fields.
 
 ## Open questions
 

--- a/src/rust/crates/qfs/src/lib.rs
+++ b/src/rust/crates/qfs/src/lib.rs
@@ -8,6 +8,7 @@
 #![forbid(unsafe_code)]
 
 mod local_circuit_fs;
+mod qfs_l2_checkpoint;
 
 pub use local_circuit_fs::{
     CircuitFsError, CircuitFsLocal, CompiledArtifacts, CompiledMetadata, ErrorDetails,
@@ -15,3 +16,9 @@ pub use local_circuit_fs::{
     SourceMetadata, DEFAULT_CIRCUIT_FS_ROOT,
 };
 
+pub use qfs_l2_checkpoint::{
+    CheckpointArtifactRef, CheckpointCompatibilityWindow, CheckpointEnvelopeV1,
+    CheckpointEnvelopeValidationError, CheckpointExtensions, CheckpointGuardrails,
+    CheckpointIntegrity, CheckpointPayloadRefs, CheckpointProvenance, CheckpointTraceLinks,
+    CHECKPOINT_ENVELOPE_SCHEMA_VERSION,
+};

--- a/src/rust/crates/qfs/src/qfs_l2_checkpoint.rs
+++ b/src/rust/crates/qfs/src/qfs_l2_checkpoint.rs
@@ -1,0 +1,101 @@
+use serde::{Deserialize, Serialize};
+
+pub const CHECKPOINT_ENVELOPE_SCHEMA_VERSION: &str = "1.0.0";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckpointEnvelopeV1 {
+    pub schema_version: String,
+    pub checkpoint_id: String,
+    pub job_id: String,
+    pub created_at: String,
+    pub runtime_version: String,
+    pub payload_refs: CheckpointPayloadRefs,
+    pub integrity: CheckpointIntegrity,
+    pub provenance: CheckpointProvenance,
+    pub trace_links: CheckpointTraceLinks,
+    pub guardrails: CheckpointGuardrails,
+    #[serde(default)]
+    pub compatibility: CheckpointCompatibilityWindow,
+    #[serde(default)]
+    pub extensions: CheckpointExtensions,
+}
+
+impl CheckpointEnvelopeV1 {
+    pub fn validate(&self) -> Result<(), CheckpointEnvelopeValidationError> {
+        if self.schema_version != CHECKPOINT_ENVELOPE_SCHEMA_VERSION {
+            return Err(CheckpointEnvelopeValidationError::SchemaVersionMismatch {
+                expected: CHECKPOINT_ENVELOPE_SCHEMA_VERSION.to_string(),
+                got: self.schema_version.clone(),
+            });
+        }
+        if self.trace_links.artifact_manifest_ref.is_empty()
+            || self.trace_links.dataset_metadata_ref.is_empty()
+            || self.trace_links.checkpoint_chain_ref.is_empty()
+        {
+            return Err(CheckpointEnvelopeValidationError::MissingTraceLink);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckpointPayloadRefs {
+    pub state_segments: Vec<CheckpointArtifactRef>,
+    pub memory_graph_ref: String,
+    pub execution_cursor_ref: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckpointArtifactRef {
+    pub path: String,
+    pub content_hash: String,
+    pub size_bytes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckpointIntegrity {
+    pub checksum_set: String,
+    pub signature_ref: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckpointProvenance {
+    pub compiler_version: String,
+    pub optimizer_version: String,
+    pub model_version: String,
+    pub backend_profile: String,
+    pub deterministic_seed: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckpointTraceLinks {
+    pub artifact_manifest_ref: String,
+    pub dataset_metadata_ref: String,
+    pub checkpoint_chain_ref: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckpointGuardrails {
+    pub declared_size_bytes: u64,
+    pub estimated_restore_cost_units: u64,
+    pub ttl_class: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct CheckpointCompatibilityWindow {
+    pub min_reader_version: Option<String>,
+    pub max_reader_version: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct CheckpointExtensions {
+    pub extension_keys: Vec<String>,
+}
+
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub enum CheckpointEnvelopeValidationError {
+    #[error("checkpoint schema version mismatch: expected {expected}, got {got}")]
+    SchemaVersionMismatch { expected: String, got: String },
+    #[error("mandatory trace-link fields must be non-empty")]
+    MissingTraceLink,
+}

--- a/src/rust/crates/qfs/tests/checkpoint_contract_compatibility.rs
+++ b/src/rust/crates/qfs/tests/checkpoint_contract_compatibility.rs
@@ -1,0 +1,36 @@
+use std::fs;
+use std::path::PathBuf;
+
+use qfs::{
+    CHECKPOINT_ENVELOPE_SCHEMA_VERSION, CheckpointEnvelopeV1, CheckpointEnvelopeValidationError,
+};
+
+fn fixture(path: &str) -> String {
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("checkpoint_contracts");
+    fs::read_to_string(base.join(path)).expect("fixture file must exist")
+}
+
+#[test]
+fn qfs_l2_checkpoint_envelope_v1_fixture_decodes_and_validates() {
+    let raw = fixture("qfs_l2_checkpoint_envelope_v1_0_0.json");
+    let envelope: CheckpointEnvelopeV1 =
+        serde_json::from_str(&raw).expect("fixture must be valid envelope json");
+
+    assert_eq!(envelope.schema_version, CHECKPOINT_ENVELOPE_SCHEMA_VERSION);
+    envelope.validate().expect("fixture must pass validation");
+}
+
+#[test]
+fn qfs_l2_checkpoint_trace_links_are_mandatory() {
+    let raw = fixture("qfs_l2_checkpoint_envelope_v1_0_0.json");
+    let mut envelope: CheckpointEnvelopeV1 =
+        serde_json::from_str(&raw).expect("fixture must be valid envelope json");
+
+    envelope.trace_links.dataset_metadata_ref.clear();
+
+    let err = envelope.validate().expect_err("must reject missing trace-link");
+    assert_eq!(err, CheckpointEnvelopeValidationError::MissingTraceLink);
+}

--- a/src/rust/crates/qfs/tests/fixtures/checkpoint_contracts/qfs_l2_checkpoint_envelope_v1_0_0.json
+++ b/src/rust/crates/qfs/tests/fixtures/checkpoint_contracts/qfs_l2_checkpoint_envelope_v1_0_0.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "1.0.0",
+  "checkpoint_id": "chkpt-0001",
+  "job_id": "job-phase8a-01",
+  "created_at": "2026-05-16T00:00:00Z",
+  "runtime_version": "eigen-kernel@0.8.0",
+  "payload_refs": {
+    "state_segments": [
+      {
+        "path": "qfs://jobs/job-phase8a-01/checkpoints/chkpt-0001/state-segment-0.bin",
+        "content_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000001",
+        "size_bytes": 1024
+      }
+    ],
+    "memory_graph_ref": "qfs://jobs/job-phase8a-01/checkpoints/chkpt-0001/memory-graph.pb",
+    "execution_cursor_ref": "qfs://jobs/job-phase8a-01/checkpoints/chkpt-0001/execution-cursor.json"
+  },
+  "integrity": {
+    "checksum_set": "sha256",
+    "signature_ref": "qfs://jobs/job-phase8a-01/checkpoints/chkpt-0001/signature.sig"
+  },
+  "provenance": {
+    "compiler_version": "eigen-compiler@0.8.0",
+    "optimizer_version": "eigen-optimizer@0.8.0",
+    "model_version": "model-family-x@2026.05",
+    "backend_profile": "sim:local",
+    "deterministic_seed": 42
+  },
+  "trace_links": {
+    "artifact_manifest_ref": "qfs://jobs/job-phase8a-01/results/manifest.json",
+    "dataset_metadata_ref": "qfs://jobs/job-phase8a-01/meta/dataset-metadata.json",
+    "checkpoint_chain_ref": "qfs://jobs/job-phase8a-01/checkpoints/chain.json"
+  },
+  "guardrails": {
+    "declared_size_bytes": 1048576,
+    "estimated_restore_cost_units": 500,
+    "ttl_class": "hot"
+  },
+  "compatibility": {
+    "min_reader_version": "1.0.0",
+    "max_reader_version": null
+  },
+  "extensions": {
+    "extension_keys": []
+  }
+}


### PR DESCRIPTION
## Summary

- Finalized RFC 0037 on QFS-L2: added mandatory trace-link fields to the envelope structure and explicit decode/upgrade rules for the 1.x branch and future 2.x changes (with a fail-closed policy for incompatible cases).
- Added a strongly typed CheckpointEnvelopeV1 (v1.0.0) contract to crate qfs and validation: schema version check + trace-link fields (artifact_manifest_ref, dataset_metadata_ref, checkpoint_chain_ref).
- Exported the new contract module via the qfs public API for use in runtime/integration points without stubs and duplication of structures.
- Added a gold fixture qfs_l2_checkpoint_envelope_v1_0_0.json with a full set of fields (payload refs, integrity, provenance, trace links, guardrails, compatibility/extensions).

Added fixture-based contract tests:

- successful decode + validate v1 fixture;
- negative case on the mandatory trace-link fields (validation should fall).


## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR -- added a new stable contract type + fixture tests, without breaking existing interfaces.
- **Affected Interfaces**: QFS
- **Compatibility**: Breaking (requires MAJOR) -- No
- **Breaking Marker**: false 
- **Migration Notes**: None 

## Release Notes Draft

### Added
- QFS crate: new `CheckpointEnvelopeV1` data contract model with explicit `1.0.0` schema marker and validator.
- Contract fixture `qfs_l2_checkpoint_envelope_v1_0_0.json` for QFS-L2 checkpoint envelope governance.

### Changed
- RFC 0037 now explicitly mandates trace-link fields and documents decode/upgrade policy for 1.x vs 2.x evolution.

### Fixed
- Added fail-closed validation for missing mandatory trace-link fields in QFS-L2 checkpoint envelopes.