### PR TITLE
Implement phase-8a deterministic path

### DIFF
--- a/docs/development/phase-8a-execution-plan.md
+++ b/docs/development/phase-8a-execution-plan.md
@@ -77,3 +77,14 @@ Phase-8A is complete only when:
 - [ ] Vertical-slice integration test passing in CI.
 - [ ] Phase-8A probe fixtures committed and runnable.
 - [ ] Compatibility impact statement published in release notes draft.
+
+## Feature flag defaults and rollout notes (P8A-05)
+
+| Flag | Default | Rollout note |
+|---|---|---|
+| `feature.kb_v1` | `false` | Enable first in replay/fixture environments to verify stable `results_ref`/record linkage before shared environments. |
+| `feature.optimizer_v1` | `false` | Enable after deterministic replay is green; keep disabled for non-hybrid jobs to preserve baseline behavior. |
+| `feature.learning_pipeline_v1` | `false` | Enable only with bounded fixture datasets and trace-linked artifacts for auditability. |
+| `feature.qfs_l2_checkpoint_v1` | `false` | Enable after checkpoint envelope conformance checks are passing in CI for target branch. |
+
+All flags must remain explicitly set during phased rollout; missing flags resolve to deterministic safe defaults (`false`).

--- a/src/rust/crates/eigen-kernel/src/rpc.rs
+++ b/src/rust/crates/eigen-kernel/src/rpc.rs
@@ -253,10 +253,12 @@ async fn run_pipeline(
     req: EnqueueJobRequest,
     trace_ctx: TraceContext,
 ) -> Result<(), PipelineError> {
+    let flags = Phase8aFeatureFlags::from_metadata(&req.metadata);
     let mut results_metadata = HashMap::from([(
         "results_ref".to_string(),
         format!("jobs/{job_id}/results.parquet"),
     )]);
+     results_metadata.extend(flags.as_results_metadata());
 
     store
         .apply_event(job_id, JobEvent::StartCompiling)
@@ -381,6 +383,58 @@ async fn run_pipeline(
 struct VqeLoopOutcome {
     last_execution: ExecuteCircuitResponse,
     results_metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Phase8aFeatureFlags {
+    kb_v1: bool,
+    optimizer_v1: bool,
+    learning_pipeline_v1: bool,
+    qfs_l2_checkpoint_v1: bool,
+}
+
+impl Phase8aFeatureFlags {
+    fn from_metadata(metadata: &HashMap<String, String>) -> Self {
+        Self {
+            kb_v1: parse_bool(metadata.get("feature.kb_v1").map(String::as_str)),
+            optimizer_v1: parse_bool(metadata.get("feature.optimizer_v1").map(String::as_str)),
+            learning_pipeline_v1: parse_bool(
+                metadata
+                    .get("feature.learning_pipeline_v1")
+                    .map(String::as_str),
+            ),
+            qfs_l2_checkpoint_v1: parse_bool(
+                metadata
+                    .get("feature.qfs_l2_checkpoint_v1")
+                    .map(String::as_str),
+            ),
+        }
+    }
+
+    fn as_results_metadata(&self) -> HashMap<String, String> {
+        HashMap::from([
+            ("feature.kb_v1".to_string(), self.kb_v1.to_string()),
+            (
+                "feature.optimizer_v1".to_string(),
+                self.optimizer_v1.to_string(),
+            ),
+            (
+                "feature.learning_pipeline_v1".to_string(),
+                self.learning_pipeline_v1.to_string(),
+            ),
+            (
+                "feature.qfs_l2_checkpoint_v1".to_string(),
+                self.qfs_l2_checkpoint_v1.to_string(),
+            ),
+        ])
+    }
+}
+
+fn parse_bool(raw: Option<&str>) -> bool {
+    matches!(
+        raw.map(|v| v.trim().to_ascii_lowercase()),
+        Some(v) if v == "1" || v == "true" || v == "yes" || v == "on"
+    )
 }
 
 async fn run_vqe_loop(
@@ -1035,6 +1089,7 @@ mod tests {
     use crate::proto::driver_manager_service_server::DriverManagerServiceServer;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Mutex, OnceLock};
+    use std::path::PathBuf;
     use tempfile::TempDir;
     use tokio::time::{Duration, sleep};
 
@@ -1587,6 +1642,111 @@ def vqe_program():
             }
             sleep(Duration::from_millis(30)).await;
         }
+
+        assert!(compiler_trace_store().lock().unwrap().iter().any(|entry| {
+            entry.traceparent.as_deref() == Some(traceparent)
+                && entry.trace_id.as_deref() == Some(trace_id)
+        }));
+        assert!(driver_trace_store().lock().unwrap().iter().any(|entry| {
+            entry.traceparent.as_deref() == Some(traceparent)
+                && entry.trace_id.as_deref() == Some(trace_id)
+        }));
+    }
+
+    #[tokio::test]
+    async fn integration_phase8a_vertical_slice_fixture_replay_is_deterministic() {
+        driver_attempt_counter().store(0, Ordering::SeqCst);
+        compiler_trace_store().lock().unwrap().clear();
+        driver_trace_store().lock().unwrap().clear();
+        let fixture_raw = std::fs::read_to_string(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/phase8a/vertical_slice_replay_v1.json"),
+        )
+        .unwrap();
+        let fixture: serde_json::Value = serde_json::from_str(&fixture_raw).unwrap();
+
+        let temp_qfs = TempDir::new().unwrap();
+        let compiler_addr: SocketAddr = "127.0.0.1:50181".parse().unwrap();
+        let driver_addr: SocketAddr = "127.0.0.1:50182".parse().unwrap();
+
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(CompilationServiceServer::new(MockCompiler))
+                .serve(compiler_addr)
+                .await
+                .unwrap();
+        });
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(DriverManagerServiceServer::new(MockDriver))
+                .serve(driver_addr)
+                .await
+                .unwrap();
+        });
+        sleep(Duration::from_millis(80)).await;
+
+        let svc = KernelGatewaySvc {
+            store: JobStore::default(),
+            deps: PipelineDeps {
+                compiler_endpoint: "http://127.0.0.1:50181".to_string(),
+                driver_endpoint: "http://127.0.0.1:50182".to_string(),
+                default_device_id: "sim:local".to_string(),
+                qfs: CircuitFsLocal::new(temp_qfs.path()),
+            },
+        };
+
+        let mut metadata = HashMap::new();
+        for (k, v) in fixture["feature_flags"].as_object().unwrap() {
+            metadata.insert(k.clone(), v.as_str().unwrap().to_string());
+        }
+        metadata.insert("shots".to_string(), "1024".to_string());
+
+        let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let trace_id = "4bf92f3577b34da6a3ce929d0e0e4736";
+        let mut req = Request::new(EnqueueJobRequest {
+            name: "phase8a-vertical-slice".to_string(),
+            program: b"x".to_vec(),
+            program_format: "eigen-lang".to_string(),
+            target: "sim:local".to_string(),
+            priority: 1,
+            compiler_options: HashMap::new(),
+            metadata,
+        });
+        req.metadata_mut()
+            .insert("traceparent", traceparent.parse().unwrap());
+        req.metadata_mut()
+            .insert("trace_id", trace_id.parse().unwrap());
+
+        let job_id = svc.enqueue_job(req).await.unwrap().into_inner().job_id;
+        for _ in 0..40 {
+            let status = svc
+                .get_job_status(Request::new(GetJobStatusRequest {
+                    job_id: job_id.clone(),
+                }))
+                .await
+                .unwrap()
+                .into_inner();
+            if status.state == TaskState::Done as i32 {
+                break;
+            }
+            sleep(Duration::from_millis(30)).await;
+        }
+
+        let results = svc
+            .get_job_results(Request::new(GetJobResultsRequest { job_id: job_id.clone() }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(results.state, TaskState::Done as i32);
+
+        for key in fixture["required_results_metadata_keys"].as_array().unwrap() {
+            assert!(results.metadata.contains_key(key.as_str().unwrap()));
+        }
+        assert_eq!(results.metadata.get("feature.kb_v1"), Some(&"true".to_string()));
+        assert_eq!(results.metadata.get("feature.optimizer_v1"), Some(&"true".to_string()));
+        assert!(results.metadata["results_ref"].starts_with("jobs/"));
+        assert!(results.metadata["result_envelope_ref"].contains(&job_id));
+        assert!(results.metadata["result_manifest_ref"].contains(&job_id));
 
         assert!(compiler_trace_store().lock().unwrap().iter().any(|entry| {
             entry.traceparent.as_deref() == Some(traceparent)

--- a/src/rust/crates/eigen-kernel/tests/fixtures/phase8a/vertical_slice_replay_v1.json
+++ b/src/rust/crates/eigen-kernel/tests/fixtures/phase8a/vertical_slice_replay_v1.json
@@ -1,0 +1,19 @@
+{
+  "feature_flags": {
+    "feature.kb_v1": "true",
+    "feature.optimizer_v1": "true",
+    "feature.learning_pipeline_v1": "true",
+    "feature.qfs_l2_checkpoint_v1": "true"
+  },
+  "required_results_metadata_keys": [
+    "results_ref",
+    "artifact_version",
+    "producer_version",
+    "result_envelope_ref",
+    "result_manifest_ref",
+    "feature.kb_v1",
+    "feature.optimizer_v1",
+    "feature.learning_pipeline_v1",
+    "feature.qfs_l2_checkpoint_v1"
+  ]
+}


### PR DESCRIPTION
## Summary

- Implemented phase feature flags for vertical-slice paths (feature.kb_v1, feature.optimizer_v1, feature.learning_pipeline_v1, feature.qfs_l2_checkpoint_v1) with safe deterministic default=false, and started saving their effective values in the results_metadata of the job result for replay/audit.

- Added deterministic fixture for P8A-05 (vertical_slice_replay_v1.json) with enabled flags and a list of required end-to-end metadata keys of the result.

- Added e2e integration test for a vertical slice that:

    - runs compile → execute → persist,

    - checks the required metadata keys from the fixture,

    - validates stable trace propagation (traceparent/trace_id) to compiler and driver.

- Updated the Phase-8A documentation: added a table of safe defaults and rollout notes for all 4 flags.  

## Validation

- [ ] Tests added/updated
- [ ] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR -- additive behavior (new metadata fields and a flag-driven path with safe defaults), without breaking existing contracts.
- **Affected Interfaces**: JobSpec | QFS | MetricsJobSpec | AQO | QFS | Metrics -->
- **Compatibility**: Breaking (requires MAJOR)
- **Breaking Marker**: false 
- **Migration Notes**: None 

## Release Notes Draft

### Added
- Deterministic Phase-8A vertical-slice fixture (`vertical_slice_replay_v1.json`) and e2e replay test for compile -> execute -> persist path.
- Phase-8A feature-flag states are now persisted into job results metadata for deterministic replay/audit.

### Changed
- Phase-8A execution plan now documents safe defaults and rollout notes for:
  `feature.kb_v1`, `feature.optimizer_v1`, `feature.learning_pipeline_v1`, `feature.qfs_l2_checkpoint_v1`.

### Fixed
- N/A