### PR TITLE
Implement DAG resolver and lifecycle hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Before `1.0.0`, breaking changes may occur in minor versions. After `1.0.0`, bre
 
 ### Added
 
+- Phase-8B P8B-01 QRTX DAG resolver + lifecycle idempotency hardening (`system-api` package `0.5.1`) with deterministic DAG reason codes (`DAG_RESOLVE_OK`, `DAG_UNKNOWN_NODE`, `DAG_SELF_DEPENDENCY`, `DAG_CYCLE_DETECTED`), replay-safe lifecycle signal handling for cancel/retry sequencing, and fixture tests for repeated/out-of-order control signals.
 - Phase-7 P7-06 RFC package and ADR synchronization closure (`governance-docs` package `0.11.0`) with RFC 0032/0033 accepted status alignment, new ADR 0018/0019 records, synchronized RFC/development pointers, and published Phase-7 readiness + compatibility reports.
 - Phase-7 P7-05 tooling baseline integration (`cli` in Rust workspace `0.17.0`) with single-command formatter/linter/unit-test workflow (`scripts/dev/run-tooling-baseline.sh`), CI lint entrypoint (`scripts/ci/lint.sh`), and richer plugin scaffold templates (`README.md`, `src/lib.rs`, `tests/manifest_contract.rs`) that validate by default.
 - Phase-6 P6-07 SRE pack for plugin health/trust/sandbox visibility (`runtime-observability` assets `0.3.0`) with stable `eigen_plugin_*` metrics contract (`1.0.0`), plugin runtime Grafana dashboard, Prometheus failure/SLO/trust/sandbox alerts, and deterministic triage + rollback runbook.

--- a/src/services/system-api/pyproject.toml
+++ b/src/services/system-api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "system-api"
-version = "0.5.0"
+version = "0.5.1"
 description = "Eigen OS system-api (MVP gRPC skeleton)."
 requires-python = ">=3.12"
 dependencies = [

--- a/src/services/system-api/src/system_api/grpc_impl.py
+++ b/src/services/system-api/src/system_api/grpc_impl.py
@@ -18,6 +18,8 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from .errors import abort_invalid_argument, abort_with_error_info
+from .lifecycle import apply_signal
+from .scheduling import resolve_dag
 from .observability import log_request_end, log_request_start, new_request_context
 from .qfs_store import QFS_STORE
 from .security import enforce_authn, enforce_authz
@@ -855,6 +857,11 @@ class JobService:
         if violations:
             abort_invalid_argument(context, "validation failed", violations)
 
+        dag_nodes = sorted({request.name, *list(request.dependencies)})
+        dag = resolve_dag(dag_nodes, {request.name: list(request.dependencies)})
+        if not dag.ok:
+            context.abort(grpc.StatusCode.INVALID_ARGUMENT, f"dag resolution failed: {dag.reason_code}: {dag.detail}")
+
         idem_key = self._idempotency_key(request)
         request_fingerprint = self._request_fingerprint(request)
 
@@ -973,7 +980,12 @@ class JobService:
                 context.abort(grpc.StatusCode.NOT_FOUND, f"job_id not found: {request.job_id}")
             self._advance_job(record)
             terminal_values = {getattr(self._types_pb, name) for name in TERMINAL_JOB_STATES}
-            if record.updates[-1].state not in terminal_values and not record.cancel_requested:
+            decision = apply_signal(
+                current_stage=record.updates[-1].stage,
+                signal="cancel",
+                already_requested=record.cancel_requested,
+            )
+            if decision.accepted and record.updates[-1].state not in terminal_values:
                 record.cancel_requested = True
                 self._advance_job(record)
                 accepted = True

--- a/src/services/system-api/src/system_api/lifecycle.py
+++ b/src/services/system-api/src/system_api/lifecycle.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+TERMINAL_STAGES = {"COMPLETED", "ERROR", "CANCELLED", "TIMEOUT"}
+
+
+@dataclass(frozen=True)
+class LifecycleDecision:
+    accepted: bool
+    reason_code: str
+
+
+def apply_signal(*, current_stage: str, signal: str, already_requested: bool = False) -> LifecycleDecision:
+    stage = current_stage.upper()
+    sig = signal.lower()
+    if sig == "cancel":
+        if stage in TERMINAL_STAGES:
+            return LifecycleDecision(False, "LIFECYCLE_TERMINAL_NOOP")
+        if already_requested:
+            return LifecycleDecision(False, "LIFECYCLE_CANCEL_DUPLICATE")
+        return LifecycleDecision(True, "LIFECYCLE_CANCEL_ACCEPTED")
+    if sig == "retry":
+        if stage in {"ERROR", "CANCELLED", "TIMEOUT"}:
+            return LifecycleDecision(True, "LIFECYCLE_RETRY_ACCEPTED")
+        if stage in TERMINAL_STAGES:
+            return LifecycleDecision(False, "LIFECYCLE_RETRY_ILLEGAL_STATE")
+        return LifecycleDecision(False, "LIFECYCLE_RETRY_OUT_OF_ORDER")
+    return LifecycleDecision(False, "LIFECYCLE_SIGNAL_UNSUPPORTED")

--- a/src/services/system-api/src/system_api/scheduling.py
+++ b/src/services/system-api/src/system_api/scheduling.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DagResolutionResult:
+    ok: bool
+    order: tuple[str, ...]
+    reason_code: str
+    detail: str
+
+
+_REASON_OK = "DAG_RESOLVE_OK"
+_REASON_UNKNOWN_NODE = "DAG_UNKNOWN_NODE"
+_REASON_SELF_DEP = "DAG_SELF_DEPENDENCY"
+_REASON_CYCLE = "DAG_CYCLE_DETECTED"
+
+
+def resolve_dag(nodes: list[str], dependencies: dict[str, list[str]]) -> DagResolutionResult:
+    ordered_nodes = sorted(dict.fromkeys(nodes))
+    node_set = set(ordered_nodes)
+
+    for node in sorted(dependencies):
+        if node not in node_set:
+            return DagResolutionResult(False, tuple(), _REASON_UNKNOWN_NODE, f"unknown node: {node}")
+        for dep in sorted(dependencies[node]):
+            if dep not in node_set:
+                return DagResolutionResult(False, tuple(), _REASON_UNKNOWN_NODE, f"unknown dependency: {node}->{dep}")
+            if dep == node:
+                return DagResolutionResult(False, tuple(), _REASON_SELF_DEP, f"self dependency: {node}")
+
+    indegree = {n: 0 for n in ordered_nodes}
+    outgoing = {n: [] for n in ordered_nodes}
+    for node in sorted(dependencies):
+        for dep in sorted(dict.fromkeys(dependencies[node])):
+            outgoing[dep].append(node)
+            indegree[node] += 1
+
+    ready = sorted([n for n in ordered_nodes if indegree[n] == 0])
+    result: list[str] = []
+    while ready:
+        current = ready.pop(0)
+        result.append(current)
+        for nxt in sorted(outgoing[current]):
+            indegree[nxt] -= 1
+            if indegree[nxt] == 0:
+                ready.append(nxt)
+                ready.sort()
+
+    if len(result) != len(ordered_nodes):
+        cycle_nodes = sorted([n for n, degree in indegree.items() if degree > 0])
+        return DagResolutionResult(False, tuple(result), _REASON_CYCLE, f"cycle nodes: {','.join(cycle_nodes)}")
+
+    return DagResolutionResult(True, tuple(result), _REASON_OK, "resolved")

--- a/src/services/system-api/tests/test_qrtx_dag_and_lifecycle.py
+++ b/src/services/system-api/tests/test_qrtx_dag_and_lifecycle.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import grpc
+
+from system_api.lifecycle import apply_signal
+from system_api.proto_gen import ensure_generated
+from system_api.scheduling import resolve_dag
+
+ensure_generated()
+
+from eigen.api.v1 import job_service_pb2 as job_pb  # noqa: E402
+from eigen.api.v1 import job_service_pb2_grpc as job_pb_grpc  # noqa: E402
+from eigen.api.v1 import types_pb2 as types_pb  # noqa: E402
+
+
+def test_dag_resolver_is_deterministic_for_valid_graph() -> None:
+    res = resolve_dag(["c", "a", "b"], {"c": ["a", "b"], "b": ["a"]})
+    assert res.ok is True
+    assert res.reason_code == "DAG_RESOLVE_OK"
+    assert res.order == ("a", "b", "c")
+
+
+def test_dag_resolver_reason_codes_for_malformed_graph() -> None:
+    cycle = resolve_dag(["a", "b"], {"a": ["b"], "b": ["a"]})
+    assert cycle.ok is False
+    assert cycle.reason_code == "DAG_CYCLE_DETECTED"
+
+    unknown = resolve_dag(["a"], {"a": ["missing"]})
+    assert unknown.ok is False
+    assert unknown.reason_code == "DAG_UNKNOWN_NODE"
+
+
+def test_lifecycle_cancel_idempotency_and_out_of_order_retry() -> None:
+    accepted = apply_signal(current_stage="RUNNING", signal="cancel", already_requested=False)
+    assert accepted.accepted is True
+    assert accepted.reason_code == "LIFECYCLE_CANCEL_ACCEPTED"
+
+    duplicate = apply_signal(current_stage="RUNNING", signal="cancel", already_requested=True)
+    assert duplicate.accepted is False
+    assert duplicate.reason_code == "LIFECYCLE_CANCEL_DUPLICATE"
+
+    out_of_order = apply_signal(current_stage="QUEUED", signal="retry")
+    assert out_of_order.accepted is False
+    assert out_of_order.reason_code == "LIFECYCLE_RETRY_OUT_OF_ORDER"
+
+
+def test_cancel_is_replay_safe_for_repeated_control_signal(grpc_addr: str) -> None:
+    channel = grpc.insecure_channel(grpc_addr)
+    stub = job_pb_grpc.JobServiceStub(channel)
+    submit = stub.SubmitJob(
+        job_pb.SubmitJobRequest(
+            name="cancel-idem",
+            target="emu:real-hifi",
+            metadata={"simulate_runtime_sec": "4"},
+            eigen_lang=types_pb.EigenLangSource(source=b"fn main() {}\n", entrypoint="main"),
+        )
+    )
+    first = stub.CancelJob(job_pb.CancelJobRequest(job_id=submit.job_id))
+    second = stub.CancelJob(job_pb.CancelJobRequest(job_id=submit.job_id))
+
+    assert first.accepted is True
+    assert second.accepted is False
+    


### PR DESCRIPTION
## Summary

- A deterministic DAG resolver for QRTX scheduling with robust reason codes (DAG_RESOLVE_OK, DAG_UNKNOWN_NODE, DAG_SELF_DEPENDENCY, DAG_CYCLE_DETECTED) and stable topological order has been implemented.

- Added lifecycle decision helper for replay-safe/idempotent handling of control signals (cancel/retry) with explicit reason codes for duplicate/out-of-order/terminal cases.

- Integrated DAG validation into the SubmitJob stage and lifecycle decision into CancelJob so that duplicate/invalid signals are handled invariantly.

- Added tests for:

    - deterministic DAG resolution,

    - malformed DAG reason codes,

    - lifecycle idempotency,

    - replay-safe repeated cancel signal.

- The package version of the system-api has been raised from 0.5.0 to 0.5.1 (PATCH), and the changelog has been updated for P8B-01.


## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

### Added
- Deterministic QRTX DAG resolver with stable reason codes for unknown nodes, self-dependencies, and cycle detection.
- Lifecycle signal decision helper for replay-safe cancel/retry handling invariants.

### Changed
- `SubmitJob` now performs deterministic DAG validation prior to admission.
- `CancelJob` now uses explicit lifecycle transition decisioning for idempotent repeated control signals.

### Fixed
- Replay/out-of-order lifecycle handling hardening for cancel/retry paths in runtime scheduling core.