### PR TITLE
Implement scheduler policy pack features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Before `1.0.0`, breaking changes may occur in minor versions. After `1.0.0`, bre
 
 ### Added
 
+- Phase-8B P8B-02 scheduler policy pack (`system-api` package `0.6.0`) with deterministic priority+quota dispatch hooks, starvation-protection promotion guard, explicit topology/noise telemetry fallback markers, and fixture-oriented scheduler policy tests.
 - Phase-8B P8B-01 QRTX DAG resolver + lifecycle idempotency hardening (`system-api` package `0.5.1`) with deterministic DAG reason codes (`DAG_RESOLVE_OK`, `DAG_UNKNOWN_NODE`, `DAG_SELF_DEPENDENCY`, `DAG_CYCLE_DETECTED`), replay-safe lifecycle signal handling for cancel/retry sequencing, and fixture tests for repeated/out-of-order control signals.
 - Phase-7 P7-06 RFC package and ADR synchronization closure (`governance-docs` package `0.11.0`) with RFC 0032/0033 accepted status alignment, new ADR 0018/0019 records, synchronized RFC/development pointers, and published Phase-7 readiness + compatibility reports.
 - Phase-7 P7-05 tooling baseline integration (`cli` in Rust workspace `0.17.0`) with single-command formatter/linter/unit-test workflow (`scripts/dev/run-tooling-baseline.sh`), CI lint entrypoint (`scripts/ci/lint.sh`), and richer plugin scaffold templates (`README.md`, `src/lib.rs`, `tests/manifest_contract.rs`) that validate by default.

--- a/docs/development/phase-8b/phase-8b-issue-pack.md
+++ b/docs/development/phase-8b/phase-8b-issue-pack.md
@@ -85,6 +85,11 @@ This document is a ready-to-use set of GitHub issues for the **Phase-8B** stage 
 - Policy modules are configurable and deterministic under fixed fixtures.
 - Fallback behavior is explicit when topology/noise telemetry is missing.
 - Policy regressions fail CI via policy fixture suite.
+**Operator policy inputs (v1 defaults)**
+- `EIGEN_SCHED_QUOTA_PER_TARGET` (default `8`, min `1`) limits queued jobs per selected backend before quota throttling activates.
+- `EIGEN_SCHED_STARVATION_SEC` (default `2.0`, min `0.0`) promotes aged jobs with starvation protection.
+- `metadata.topology_telemetry` + `metadata.topology_fallback` control topology hook status and deterministic fallback target marker.
+- `metadata.noise_score` + `metadata.noise_threshold` control noise hook status; missing telemetry emits explicit fallback markers.
 
 **RFC link**
 - `rfcs/0038-phase8b-qrtx-scheduling-and-lifecycle-hardening-contract-v1.md`

--- a/src/services/system-api/src/system_api/grpc_impl.py
+++ b/src/services/system-api/src/system_api/grpc_impl.py
@@ -122,6 +122,8 @@ class JobService:
         self._batch_wait_window_sec = max(float(os.getenv("EIGEN_BATCH_WAIT_WINDOW_SEC", "0.2")), 0.0)
         self._batch_dispatch_gap_sec = max(float(os.getenv("EIGEN_BATCH_DISPATCH_GAP_SEC", "0.15")), 0.0)
         self._batch_inflight_limit = max(int(os.getenv("EIGEN_BATCH_INFLIGHT_LIMIT", "64")), self._batch_size)
+        self._quota_per_target = max(int(os.getenv("EIGEN_SCHED_QUOTA_PER_TARGET", "8")), 1)
+        self._starvation_threshold_sec = max(float(os.getenv("EIGEN_SCHED_STARVATION_SEC", "2.0")), 0.0)
         self._dispatch_slot_seq = 0
 
     def _request_fingerprint(self, request) -> str:
@@ -600,10 +602,20 @@ class JobService:
             "topology_attempt": topology["attempt"],
             "topology_envelope_ref": f"qfs://jobs/{job_id}/topology/envelope.json",
         }
+        noise_score = metadata.get("noise_score", "").strip()
+        noise_threshold = metadata.get("noise_threshold", "").strip() or "0.03"
+        topology_telemetry = metadata.get("topology_telemetry", "").strip().lower() in {"1", "true", "yes", "on"}
+        topology_fallback = metadata.get("topology_fallback", "").strip() or "cluster-local/default"
+        noise_fallback = "NOISE_TELEMETRY_MISSING"
+        if noise_score:
+            noise_fallback = "NO_FALLBACK"
+        topology_fallback_reason = "TOPOLOGY_TELEMETRY_MISSING"
+        if topology_telemetry:
+            topology_fallback_reason = "NO_FALLBACK"
         dispatch_rationale = {
-            "version": "2.2.0",
-            "policy_version": metadata.get("dispatch_policy_version", "2.1.0"),
-            "reason_codes": ["WEIGHTED_FAIRNESS", "DEVICE_SCORE", "SINGLE_DISPATCH"],
+           "version": "2.3.0",
+            "policy_version": metadata.get("dispatch_policy_version", "2.2.0"),
+            "reason_codes": ["WEIGHTED_FAIRNESS", "DEVICE_SCORE", "PRIORITY_QUOTA", "SINGLE_DISPATCH"],
             "selected_backend": request.target or "sim:local",
             "selected_queue": f"priority-{int(request.priority)}",
             "attributes": {
@@ -612,9 +624,14 @@ class JobService:
                 "job_name": request.name,
                 "batch_mode_enabled": str(self._batch_mode_enabled).lower(),
                 "policy_branch": "single_dispatch",
-                "fallback_reason": "NO_FALLBACK",
-                "artifact_version": "1.1.0",
+                "fallback_reason": f"{topology_fallback_reason}|{noise_fallback}",
+                "artifact_version": "1.2.0",
                 "topology_contract_version": topology["contract_version"],
+                "topology_hook_status": "present" if topology_telemetry else "fallback",
+                "topology_fallback_target": topology_fallback,
+                "noise_hook_status": "present" if noise_score else "fallback",
+                "noise_score": noise_score or "unavailable",
+                "noise_threshold": noise_threshold,
             },
             "lineage": [
                 {
@@ -735,7 +752,7 @@ class JobService:
     def _assign_single_dispatch_delay(self, record: _JobRecord) -> None:
         slot = self._dispatch_slot_seq
         self._dispatch_slot_seq += 1
-        record.queue_delay_sec = float(slot) * self._batch_dispatch_gap_sec
+        record.queue_delay_sec += float(slot) * self._batch_dispatch_gap_sec
 
     def _inflight_batch_jobs(self) -> int:
         terminal_values = {getattr(self._types_pb, name) for name in TERMINAL_JOB_STATES}
@@ -840,6 +857,30 @@ class JobService:
                 members = members[self._batch_size :]
 
     def _assign_scheduler_slot(self, record: _JobRecord) -> None:
+        queued_for_target = sum(
+            1
+            for rec in self._jobs.values()
+            if rec.dispatch_rationale.get("selected_backend", "sim:local")
+            == record.dispatch_rationale.get("selected_backend", "sim:local")
+            and rec.updates
+            and rec.updates[-1].stage == "QUEUED"
+        )
+        age_sec = (datetime.now(timezone.utc) - record.created_at_dt).total_seconds()
+        if queued_for_target >= self._quota_per_target:
+            penalty_slots = max(queued_for_target - self._quota_per_target + 1, 1)
+            record.queue_delay_sec += float(penalty_slots) * self._batch_dispatch_gap_sec
+            record.dispatch_rationale["reason_codes"].append("TARGET_QUOTA_DELAY")
+            record.dispatch_rationale["attributes"]["quota_state"] = "throttled"
+            record.dispatch_rationale["attributes"]["quota_penalty_slots"] = str(penalty_slots)
+        else:
+            record.dispatch_rationale["attributes"]["quota_state"] = "eligible"
+            record.dispatch_rationale["attributes"]["quota_penalty_slots"] = "0"
+        if age_sec >= self._starvation_threshold_sec:
+            record.queue_delay_sec = 0.0
+            record.dispatch_rationale["reason_codes"].append("STARVATION_PROTECTION")
+            record.dispatch_rationale["attributes"]["starvation_guard"] = "promoted"
+        else:
+            record.dispatch_rationale["attributes"]["starvation_guard"] = "none"
         if not self._batch_mode_enabled:
             self._assign_single_dispatch_delay(record)
             return

--- a/src/services/system-api/tests/test_batch_execution_optimizer.py
+++ b/src/services/system-api/tests/test_batch_execution_optimizer.py
@@ -106,3 +106,36 @@ def test_benchmark_batching_improves_throughput_within_latency_bound(monkeypatch
     batched_max_delay = max(batched._jobs[job_id].queue_delay_sec for job_id in batched_ids)
     unbatched_max_delay = max(unbatched._jobs[job_id].queue_delay_sec for job_id in unbatched_ids)
     assert batched_max_delay <= unbatched_max_delay + max_latency_regression_sec
+
+def test_priority_quota_and_starvation_hooks_are_deterministic(monkeypatch):
+    monkeypatch.setenv("EIGEN_SCHED_QUOTA_PER_TARGET", "1")
+    monkeypatch.setenv("EIGEN_SCHED_STARVATION_SEC", "0.0")
+    service = _make_service(monkeypatch, batch_mode="0")
+
+    first_id = _submit(service, name="quota-1")
+    second_id = _submit(service, name="quota-2")
+    first = service.GetDispatchRationale(job_pb.GetDispatchRationaleRequest(job_id=first_id), _Context()).rationale
+    second = service.GetDispatchRationale(job_pb.GetDispatchRationaleRequest(job_id=second_id), _Context()).rationale
+
+    assert first.attributes["quota_state"] == "eligible"
+    assert second.attributes["quota_state"] == "throttled"
+    assert "TARGET_QUOTA_DELAY" in second.reason_codes
+    assert first.attributes["starvation_guard"] == "promoted"
+    assert "STARVATION_PROTECTION" in first.reason_codes
+
+
+def test_topology_noise_fallback_is_explicit(monkeypatch):
+    service = _make_service(monkeypatch, batch_mode="0")
+    req = job_pb.SubmitJobRequest(
+        name="fallback-hooks",
+        target="sim:local",
+        priority=42,
+        metadata={"topology_fallback": "cluster-fallback/partition-0"},
+        eigen_lang=types_pb.EigenLangSource(source=b"def main():\n return 'ok'\n", entrypoint="main"),
+    )
+    job_id = service.SubmitJob(req, _Context()).job_id
+    rationale = service.GetDispatchRationale(job_pb.GetDispatchRationaleRequest(job_id=job_id), _Context()).rationale
+    assert rationale.attributes["topology_hook_status"] == "fallback"
+    assert rationale.attributes["noise_hook_status"] == "fallback"
+    assert rationale.attributes["fallback_reason"] == "TOPOLOGY_TELEMETRY_MISSING|NOISE_TELEMETRY_MISSING"
+    


### PR DESCRIPTION
## Summary

- Implemented scheduler policy pack hooks in JobService:

    - new configurable quota/starvation knobs (EIGEN_SCHED_QUOTA_PER_TARGET, EIGEN_SCHED_STARVATION_SEC);

    - quota-based throttling with deterministic penalty slots;

    - starvation protection promotion marker;

    - explicit topology/noise hook statuses and deterministic fallback reasons in dispatch rationale.

- Bumped scheduler rationale version markers for additive behavior (version to 2.3.0, policy_version default to 2.2.0, artifact_version to 1.2.0) and added PRIORITY_QUOTA reason code.

- Added/updated policy tests for:

    - deterministic quota + starvation behavior;

    - explicit topology/noise fallback behavior.

- Updated Phase-8B issue pack documentation with concrete operator inputs/defaults/constraints for the policy hooks.

- Updated changelog with P8B-02 entry and version impact (system-api 0.6.0).

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: Job dispatch rationale payload
- **Compatibility**: Breaking (requires MAJOR)
- **Breaking Marker**: false 
- **Migration Notes**: None 
- 
## Release Notes Draft

### Added
- Scheduler policy pack hooks for per-target quota throttling, starvation-protection promotion, and topology/noise fallback markers.

### Changed
- Dispatch rationale policy metadata/version markers advanced to cover the new scheduler policy hooks.
- Phase-8B issue pack now documents scheduler policy inputs/defaults/override constraints.

### Fixed
- Missing topology/noise telemetry now produces explicit deterministic fallback markers in dispatch rationale.