### PR TITLE
Implement QFS-L3 artifact layout and indexing

### DIFF
--- a/docs/reference/formats/qfs-layout.md
+++ b/docs/reference/formats/qfs-layout.md
@@ -1,7 +1,7 @@
 # QFS Layout — Current MVP Contract (CircuitFS)
 
 - Phase: MVP
-- Status date: **2026-05-09**
+- Status date: **2026-05-17**
 - Scope: stable artifact layout used by runtime/kernel and System API result retrieval.
 
 ## Summary
@@ -111,6 +111,19 @@ Current behavior should preserve read compatibility for legacy jobs where only `
 - `compiled/circuit.aqo.json` must remain schema-compatible with current AQO reference.
 - Missing optional files must not break result retrieval when required files exist.
 
+## Phase-8B QFS-L3 Hardening Additions (`1.0.0`, MINOR)
+
+- Strict layout validation now returns deterministic diagnostics in the stable form
+  `MISSING_REQUIRED:qfs://jobs/{job_id}/...` for required refs.
+- Metadata envelopes for indexed artifacts validate deterministic fields:
+  `qfs_ref`, `job_id`, `trace_id`, `stage`, `artifact_type`,
+  `created_at_epoch_ms`, `retention_until_epoch_ms`.
+- Trace-linked lookup path support is defined as:
+  - `trace_id -> [qfs_ref...]`
+  - `job_id -> [qfs_ref...]`
+- Retention cleanup reason codes are frozen:
+  - `RETENTION_EXPIRED`
+  - `ORPHAN_NOT_INDEXED`
 ## Gaps / What Is Missing
 
 The following are not yet fully specified or uniformly enforced and should be tracked as system gaps:

--- a/src/services/system-api/pyproject.toml
+++ b/src/services/system-api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "system-api"
-version = "0.5.1"
+version = "0.6.0"
 description = "Eigen OS system-api (MVP gRPC skeleton)."
 requires-python = ">=3.12"
 dependencies = [

--- a/src/services/system-api/src/system_api/qfs_store.py
+++ b/src/services/system-api/src/system_api/qfs_store.py
@@ -6,6 +6,7 @@ import os
 import threading
 import time
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Callable, Protocol
 
 
@@ -204,3 +205,122 @@ def _build_qfs_store_from_env() -> QFSStore:
 
 
 QFS_STORE = _build_qfs_store_from_env()
+
+QFS_L3_ARTIFACT_CONTRACT_VERSION = "1.0.0"
+
+_JOB_LAYOUT_REQUIRED_REFS = (
+    "input/job.yaml",
+    "input/program.eigen.py",
+    "compiled/circuit.aqo.json",
+)
+
+
+@dataclass(frozen=True)
+class ArtifactMetadata:
+    qfs_ref: str
+    job_id: str
+    trace_id: str
+    stage: str
+    artifact_type: str
+    created_at_epoch_ms: int
+    retention_until_epoch_ms: int
+
+
+@dataclass(frozen=True)
+class LayoutValidationResult:
+    ok: bool
+    diagnostics: list[str]
+    missing_required: list[str]
+
+
+@dataclass(frozen=True)
+class RetentionCleanupEvent:
+    qfs_ref: str
+    reason_code: str
+
+
+class QFSLayoutValidator:
+    """Deterministic QFS-L3 layout validator with stable diagnostics."""
+
+    @staticmethod
+    def validate_job_layout(*, store: QFSStore, job_id: str, require_results: bool = False) -> LayoutValidationResult:
+        base = f"qfs://jobs/{job_id}/"
+        refs = set(store.list_refs(base))
+        required = [f"{base}{suffix}" for suffix in _JOB_LAYOUT_REQUIRED_REFS]
+        if require_results:
+            required.append(f"{base}results.parquet")
+        missing = sorted(ref for ref in required if ref not in refs)
+        diagnostics = [f"MISSING_REQUIRED:{ref}" for ref in missing]
+        return LayoutValidationResult(ok=not missing, diagnostics=diagnostics, missing_required=missing)
+
+    @staticmethod
+    def validate_metadata(meta: ArtifactMetadata) -> list[str]:
+        violations: list[str] = []
+        if not meta.qfs_ref.startswith(f"qfs://jobs/{meta.job_id}/"):
+            violations.append("INVALID_REF_SCOPE:qfs_ref must be under job scope")
+        if not meta.trace_id.strip():
+            violations.append("INVALID_TRACE_ID:trace_id is required")
+        if not meta.stage.strip():
+            violations.append("INVALID_STAGE:stage is required")
+        if not meta.artifact_type.strip():
+            violations.append("INVALID_ARTIFACT_TYPE:artifact_type is required")
+        if meta.retention_until_epoch_ms < meta.created_at_epoch_ms:
+            violations.append("INVALID_RETENTION_WINDOW:retention_until must be >= created_at")
+        return sorted(violations)
+
+
+class QFSMetadataIndex:
+    """In-memory metadata index for trace-linked artifact lookup paths."""
+
+    def __init__(self):
+        self._items: list[ArtifactMetadata] = []
+        self._lock = threading.RLock()
+
+    def upsert(self, meta: ArtifactMetadata) -> None:
+        violations = QFSLayoutValidator.validate_metadata(meta)
+        if violations:
+            raise ValueError(f"INVALID_METADATA:{'|'.join(violations)}")
+        with self._lock:
+            self._items = [item for item in self._items if item.qfs_ref != meta.qfs_ref]
+            self._items.append(meta)
+            self._items.sort(key=lambda item: (item.job_id, item.trace_id, item.stage, item.qfs_ref))
+
+    def find_by_trace(self, trace_id: str) -> list[ArtifactMetadata]:
+        with self._lock:
+            return [item for item in self._items if item.trace_id == trace_id]
+
+    def find_by_job(self, job_id: str) -> list[ArtifactMetadata]:
+        with self._lock:
+            return [item for item in self._items if item.job_id == job_id]
+
+    def all(self) -> list[ArtifactMetadata]:
+        with self._lock:
+            return list(self._items)
+
+
+class QFSRetentionExecutor:
+    """Retention cleanup executor with deterministic reason codes."""
+
+    REASON_RETENTION_EXPIRED = "RETENTION_EXPIRED"
+    REASON_ORPHAN_NOT_INDEXED = "ORPHAN_NOT_INDEXED"
+
+    @staticmethod
+    def run(
+        *,
+        store: QFSStore,
+        index: QFSMetadataIndex,
+        now_epoch_ms: int | None = None,
+    ) -> list[RetentionCleanupEvent]:
+        now_ms = now_epoch_ms if now_epoch_ms is not None else int(datetime.now(tz=UTC).timestamp() * 1000)
+        events: list[RetentionCleanupEvent] = []
+        indexed_refs = {item.qfs_ref: item for item in index.all()}
+        for ref in sorted(store.list_refs("qfs://jobs/")):
+            meta = indexed_refs.get(ref)
+            if meta is None:
+                store.delete_bytes(ref)
+                events.append(RetentionCleanupEvent(qfs_ref=ref, reason_code=QFSRetentionExecutor.REASON_ORPHAN_NOT_INDEXED))
+                continue
+            if now_ms >= meta.retention_until_epoch_ms:
+                store.delete_bytes(ref)
+                events.append(RetentionCleanupEvent(qfs_ref=ref, reason_code=QFSRetentionExecutor.REASON_RETENTION_EXPIRED))
+        return events

--- a/src/services/system-api/tests/test_qfs_blob_backends.py
+++ b/src/services/system-api/tests/test_qfs_blob_backends.py
@@ -2,7 +2,16 @@ from __future__ import annotations
 
 import io
 
-from system_api.qfs_store import LocalBlobBackend, QFSStore, RetryConfig, S3BlobBackend
+from system_api.qfs_store import (
+    ArtifactMetadata,
+    LocalBlobBackend,
+    QFSLayoutValidator,
+    QFSMetadataIndex,
+    QFSRetentionExecutor,
+    QFSStore,
+    RetryConfig,
+    S3BlobBackend,
+)
 
 
 class _FlakyBackend(LocalBlobBackend):
@@ -88,3 +97,67 @@ def test_s3_backend_upload_download_list_and_atomic_write():
         "qfs://jobs/1/file.bin",
         "qfs://jobs/1/results.parquet",
     ]
+
+def test_qfs_layout_validator_has_stable_diagnostics():
+    store = QFSStore([LocalBlobBackend()])
+    job_id = "job-layout"
+    store.put_bytes(f"qfs://jobs/{job_id}/input/job.yaml", b"a")
+
+    result = QFSLayoutValidator.validate_job_layout(store=store, job_id=job_id, require_results=True)
+
+    assert result.ok is False
+    assert result.missing_required == [
+        f"qfs://jobs/{job_id}/compiled/circuit.aqo.json",
+        f"qfs://jobs/{job_id}/input/program.eigen.py",
+        f"qfs://jobs/{job_id}/results.parquet",
+    ]
+    assert result.diagnostics == [
+        f"MISSING_REQUIRED:qfs://jobs/{job_id}/compiled/circuit.aqo.json",
+        f"MISSING_REQUIRED:qfs://jobs/{job_id}/input/program.eigen.py",
+        f"MISSING_REQUIRED:qfs://jobs/{job_id}/results.parquet",
+    ]
+
+
+def test_qfs_retention_executor_uses_deterministic_reason_codes():
+    store = QFSStore([LocalBlobBackend()])
+    index = QFSMetadataIndex()
+    now = 2_000
+    kept_ref = "qfs://jobs/j1/results.parquet"
+    expired_ref = "qfs://jobs/j1/logs/dispatch.log"
+    orphan_ref = "qfs://jobs/j2/tmp/request.json"
+    store.put_bytes(kept_ref, b"k")
+    store.put_bytes(expired_ref, b"e")
+    store.put_bytes(orphan_ref, b"o")
+    index.upsert(
+        ArtifactMetadata(
+            qfs_ref=kept_ref,
+            job_id="j1",
+            trace_id="tr-1",
+            stage="execute",
+            artifact_type="results",
+            created_at_epoch_ms=1_000,
+            retention_until_epoch_ms=5_000,
+        )
+    )
+    index.upsert(
+        ArtifactMetadata(
+            qfs_ref=expired_ref,
+            job_id="j1",
+            trace_id="tr-1",
+            stage="execute",
+            artifact_type="log",
+            created_at_epoch_ms=1_000,
+            retention_until_epoch_ms=1_500,
+        )
+    )
+
+    events = QFSRetentionExecutor.run(store=store, index=index, now_epoch_ms=now)
+
+    assert [(item.qfs_ref, item.reason_code) for item in events] == [
+        (expired_ref, QFSRetentionExecutor.REASON_RETENTION_EXPIRED),
+        (orphan_ref, QFSRetentionExecutor.REASON_ORPHAN_NOT_INDEXED),
+    ]
+    assert store.get_bytes(kept_ref) == b"k"
+    assert store.get_bytes(expired_ref) is None
+    assert store.get_bytes(orphan_ref) is None
+    


### PR DESCRIPTION
## Summary

- Implemented QFS-L3 hardening primitives in system_api.qfs_store:

    - contract/version marker (QFS_L3_ARTIFACT_CONTRACT_VERSION = "1.0.0"),

    - deterministic layout validator (QFSLayoutValidator),

    - strict metadata model/validation (ArtifactMetadata + validation rules),

    - metadata index for trace/job lookup (QFSMetadataIndex),

   -  retention executor with deterministic reason codes (QFSRetentionExecutor: RETENTION_EXPIRED, ORPHAN_NOT_INDEXED).

- Added/updated tests to cover:

    - deterministic missing-required diagnostics ordering/content,

    - deterministic retention cleanup reason codes and behavior across kept/expired/orphan artifacts.

- Updated QFS contract documentation with Phase-8B additions:

    - exact deterministic diagnostics format,

    - metadata fields for indexing,

    - trace/job lookup paths,

    - frozen retention reason codes.

- Bumped system-api package version from 0.5.1 → 0.6.0 (MINOR, backward-compatible additions).

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR 
- **Affected Interfaces**: QFS | Compatibility matrix
- **Compatibility**: Breaking (requires MAJOR)
- **Breaking Marker**: false 
- **Migration Notes**: None 

## Release Notes Draft

### Added
- QFS-L3 deterministic artifact layout validator with stable diagnostics.
- Metadata indexing primitives for trace-linked and job-linked artifact lookup.
- Retention executor with stable cleanup reason codes (`RETENTION_EXPIRED`, `ORPHAN_NOT_INDEXED`).

### Changed
- `system-api` version bumped to `0.6.0`.
- QFS layout reference docs updated for Phase-8B hardening additions.

### Fixed
- Cleanup path now yields deterministic reason classification across retention edge-cases.