### PR TITLE
Implement checkpoint/restore API improvements

### DIFF
--- a/docs/reference/formats/qfs-layout.md
+++ b/docs/reference/formats/qfs-layout.md
@@ -124,6 +124,18 @@ Current behavior should preserve read compatibility for legacy jobs where only `
 - Retention cleanup reason codes are frozen:
   - `RETENTION_EXPIRED`
   - `ORPHAN_NOT_INDEXED`
+
+## Phase-8B QFS-L2 Checkpoint/Restore Hardening (`1.1.0`, MINOR)
+
+- Checkpoint restore admission now has deterministic budget guardrails for:
+  - `declared_size_bytes` (checkpoint payload size budget).
+  - `estimated_restore_cost_units` (restore execution cost budget).
+- Guardrail denials expose stable reason codes:
+  - `SIZE_BUDGET_EXCEEDED`
+  - `RESTORE_COST_BUDGET_EXCEEDED`
+- Each rejection includes a deterministic hint payload that states the observed and allowed values.
+- Contract fixture tests verify deterministic decode/validation and restore admission reason-code behavior.
+ 
 ## Gaps / What Is Missing
 
 The following are not yet fully specified or uniformly enforced and should be tracked as system gaps:

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -109,11 +109,11 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cli"
-version = "0.17.0"
+version = "0.18.0"
 
 [[package]]
 name = "eigen-kernel"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "observability",
  "parking_lot",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "tracing",
 ]
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "qfs"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "qrtx"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "thiserror 1.0.69",
 ]
@@ -815,7 +815,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "resource-manager"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "serde_json",
 ]
@@ -847,7 +847,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-module"
-version = "0.17.0"
+version = "0.18.0"
 
 [[package]]
 name = "semver"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "0.17.0"
+version = "0.18.0"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/src/rust/crates/qfs/src/lib.rs
+++ b/src/rust/crates/qfs/src/lib.rs
@@ -17,8 +17,10 @@ pub use local_circuit_fs::{
 };
 
 pub use qfs_l2_checkpoint::{
-    CheckpointArtifactRef, CheckpointCompatibilityWindow, CheckpointEnvelopeV1,
+    CheckpointAdmissionReasonCode, CheckpointAdmissionRejection, CheckpointArtifactRef,
+    CheckpointBudgetPolicy, CheckpointCompatibilityWindow, CheckpointEnvelopeV1,
     CheckpointEnvelopeValidationError, CheckpointExtensions, CheckpointGuardrails,
     CheckpointIntegrity, CheckpointPayloadRefs, CheckpointProvenance, CheckpointTraceLinks,
-    CHECKPOINT_ENVELOPE_SCHEMA_VERSION,
+    CHECKPOINT_ENVELOPE_SCHEMA_VERSION, CHECKPOINT_RUNTIME_API_VERSION,
+    DEFAULT_MAX_CHECKPOINT_SIZE_BYTES, DEFAULT_MAX_RESTORE_COST_UNITS,
 };

--- a/src/rust/crates/qfs/src/qfs_l2_checkpoint.rs
+++ b/src/rust/crates/qfs/src/qfs_l2_checkpoint.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 
 pub const CHECKPOINT_ENVELOPE_SCHEMA_VERSION: &str = "1.0.0";
+pub const CHECKPOINT_RUNTIME_API_VERSION: &str = "1.1.0";
+pub const DEFAULT_MAX_CHECKPOINT_SIZE_BYTES: u64 = 512 * 1024 * 1024;
+pub const DEFAULT_MAX_RESTORE_COST_UNITS: u64 = 1_000;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CheckpointEnvelopeV1 {
@@ -33,6 +36,31 @@ impl CheckpointEnvelopeV1 {
             || self.trace_links.checkpoint_chain_ref.is_empty()
         {
             return Err(CheckpointEnvelopeValidationError::MissingTraceLink);
+        }
+        Ok(())
+    }
+
+    pub fn evaluate_restore_admission(
+        &self,
+        policy: &CheckpointBudgetPolicy,
+    ) -> Result<(), CheckpointAdmissionRejection> {
+        if self.guardrails.declared_size_bytes > policy.max_checkpoint_size_bytes {
+            return Err(CheckpointAdmissionRejection::new(
+                CheckpointAdmissionReasonCode::SizeBudgetExceeded,
+                format!(
+                    "declared_size_bytes={} exceeds max_checkpoint_size_bytes={}",
+                    self.guardrails.declared_size_bytes, policy.max_checkpoint_size_bytes
+                ),
+            ));
+        }
+        if self.guardrails.estimated_restore_cost_units > policy.max_restore_cost_units {
+            return Err(CheckpointAdmissionRejection::new(
+                CheckpointAdmissionReasonCode::RestoreCostBudgetExceeded,
+                format!(
+                    "estimated_restore_cost_units={} exceeds max_restore_cost_units={}",
+                    self.guardrails.estimated_restore_cost_units, policy.max_restore_cost_units
+                ),
+            ));
         }
         Ok(())
     }
@@ -98,4 +126,38 @@ pub enum CheckpointEnvelopeValidationError {
     SchemaVersionMismatch { expected: String, got: String },
     #[error("mandatory trace-link fields must be non-empty")]
     MissingTraceLink,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckpointBudgetPolicy {
+    pub max_checkpoint_size_bytes: u64,
+    pub max_restore_cost_units: u64,
+}
+
+impl Default for CheckpointBudgetPolicy {
+    fn default() -> Self {
+        Self {
+            max_checkpoint_size_bytes: DEFAULT_MAX_CHECKPOINT_SIZE_BYTES,
+            max_restore_cost_units: DEFAULT_MAX_RESTORE_COST_UNITS,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckpointAdmissionRejection {
+    pub reason_code: CheckpointAdmissionReasonCode,
+    pub hint: String,
+}
+
+impl CheckpointAdmissionRejection {
+    fn new(reason_code: CheckpointAdmissionReasonCode, hint: String) -> Self {
+        Self { reason_code, hint }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum CheckpointAdmissionReasonCode {
+    SizeBudgetExceeded,
+    RestoreCostBudgetExceeded,
 }

--- a/src/rust/crates/qfs/tests/checkpoint_contract_compatibility.rs
+++ b/src/rust/crates/qfs/tests/checkpoint_contract_compatibility.rs
@@ -2,7 +2,8 @@ use std::fs;
 use std::path::PathBuf;
 
 use qfs::{
-    CHECKPOINT_ENVELOPE_SCHEMA_VERSION, CheckpointEnvelopeV1, CheckpointEnvelopeValidationError,
+    CheckpointAdmissionReasonCode, CheckpointBudgetPolicy, CHECKPOINT_ENVELOPE_SCHEMA_VERSION,
+    CheckpointEnvelopeV1, CheckpointEnvelopeValidationError,
 };
 
 fn fixture(path: &str) -> String {
@@ -33,4 +34,41 @@ fn qfs_l2_checkpoint_trace_links_are_mandatory() {
 
     let err = envelope.validate().expect_err("must reject missing trace-link");
     assert_eq!(err, CheckpointEnvelopeValidationError::MissingTraceLink);
+}
+
+#[test]
+fn qfs_l2_checkpoint_restore_admission_rejects_size_budget_with_stable_reason_code() {
+    let raw = fixture("qfs_l2_checkpoint_envelope_v1_0_0.json");
+    let envelope: CheckpointEnvelopeV1 =
+        serde_json::from_str(&raw).expect("fixture must be valid envelope json");
+
+    let policy = CheckpointBudgetPolicy {
+        max_checkpoint_size_bytes: 1,
+        max_restore_cost_units: u64::MAX,
+    };
+    let err = envelope
+        .evaluate_restore_admission(&policy)
+        .expect_err("size budget must be rejected");
+    assert_eq!(err.reason_code, CheckpointAdmissionReasonCode::SizeBudgetExceeded);
+    assert!(err.hint.contains("declared_size_bytes"));
+}
+
+#[test]
+fn qfs_l2_checkpoint_restore_admission_rejects_cost_budget_with_stable_reason_code() {
+    let raw = fixture("qfs_l2_checkpoint_envelope_v1_0_0.json");
+    let envelope: CheckpointEnvelopeV1 =
+        serde_json::from_str(&raw).expect("fixture must be valid envelope json");
+
+    let policy = CheckpointBudgetPolicy {
+        max_checkpoint_size_bytes: u64::MAX,
+        max_restore_cost_units: 100,
+    };
+    let err = envelope
+        .evaluate_restore_admission(&policy)
+        .expect_err("cost budget must be rejected");
+    assert_eq!(
+        err.reason_code,
+        CheckpointAdmissionReasonCode::RestoreCostBudgetExceeded
+    );
+    assert!(err.hint.contains("estimated_restore_cost_units"));
 }


### PR DESCRIPTION
## Summary

- Implemented deterministic checkpoint restore admission guardrails in QFS-L2 via evaluate_restore_admission, with explicit policy thresholds for checkpoint size and restore cost. Rejections now return stable machine-readable reason codes and deterministic hint text.

- Added new versioned/runtime constants and default guardrail budgets (CHECKPOINT_RUNTIME_API_VERSION = 1.1.0, plus default size/cost limits), and exposed these through the crate public API.

- Extended fixture-based compatibility tests to validate deterministic rejection behavior for both size and cost guardrail failures (including reason code stability and hint presence).

- Updated docs with a dedicated Phase-8B QFS-L2 hardening section describing the new budget checks and stable rejection reason codes.

- Bumped workspace version to 0.18.0 (MINOR impact) to reflect backward-compatible contract/API additions. 

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: QFS
- **Compatibility**: Breaking (requires MAJOR) — No
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Deterministic QFS-L2 checkpoint restore admission API with explicit budget policy controls.
- Stable guardrail rejection reason codes and operator-facing hints for size/cost budget violations.

### Changed
- QFS runtime contract version metadata now includes checkpoint runtime API `1.1.0`.
- Workspace version bumped to `0.18.0` (MINOR).

### Fixed
- Fixture-level compatibility coverage now validates guardrail rejection determinism for restore/replay admission checks.