### PR TITLE
Implement Observability Join Model and Alert Pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Before `1.0.0`, breaking changes may occur in minor versions. After `1.0.0`, bre
 
 ### Added
 
+- Phase-8B P8B-05 observability join model + runtime/data alert pack (`runtime-observability` assets `0.4.0`) with lifecycle span correlation requirements (`queue -> schedule -> dispatch -> execute -> persist -> checkpoint`), deterministic queue/compiler/driver regression alerts, and runbook-linked actionable diagnostics for CI/ops workflows.
 - Phase-8B P8B-02 scheduler policy pack (`system-api` package `0.6.0`) with deterministic priority+quota dispatch hooks, starvation-protection promotion guard, explicit topology/noise telemetry fallback markers, and fixture-oriented scheduler policy tests.
 - Phase-8B P8B-01 QRTX DAG resolver + lifecycle idempotency hardening (`system-api` package `0.5.1`) with deterministic DAG reason codes (`DAG_RESOLVE_OK`, `DAG_UNKNOWN_NODE`, `DAG_SELF_DEPENDENCY`, `DAG_CYCLE_DETECTED`), replay-safe lifecycle signal handling for cancel/retry sequencing, and fixture tests for repeated/out-of-order control signals.
 - Phase-7 P7-06 RFC package and ADR synchronization closure (`governance-docs` package `0.11.0`) with RFC 0032/0033 accepted status alignment, new ADR 0018/0019 records, synchronized RFC/development pointers, and published Phase-7 readiness + compatibility reports.

--- a/docs/howto/run-observability.md
+++ b/docs/howto/run-observability.md
@@ -64,3 +64,10 @@ Prometheus must include `intelligent-runtime-alerts.yaml` in `rule_files` and sc
 - Runbook: `docs/howto/cluster-runtime-observability-runbook.md`
 
 Prometheus must include `cluster-runtime-alerts.yaml` in `rule_files` and scrape the cluster runtime target exposing `eigen_cluster_*` series (default `127.0.0.1:9096`).
+
+## Phase-8B runtime/data observability pack
+
+- Alerts: `monitoring/metrics/prometheus/runtime-data-alerts.yaml`
+- Runbook: `docs/howto/runtime-data-observability-runbook.md`
+
+Prometheus must include `runtime-data-alerts.yaml` in `rule_files` and scrape runtime + queue + cluster targets exposing `eigen_stage_*`, `eigen_orch_*`, and `eigen_cluster_*` series.

--- a/docs/howto/runtime-data-observability-runbook.md
+++ b/docs/howto/runtime-data-observability-runbook.md
@@ -1,0 +1,86 @@
+# Runtime/Data Observability Runbook (Phase-8B)
+
+Use this runbook to triage runtime/storage regressions that require unified diagnostics across queue, scheduler, compiler, driver, and checkpoint persistence stages.
+
+## Contract and version markers
+
+Phase-8B runtime/data observability contract is additive and SemVer-governed.
+
+- `runtime_data_observability_contract_version: 1.0.0`
+- Required correlation keys:
+  - `trace_id`
+  - `job_id`
+  - `dispatch_id`
+  - `assignment_id`
+  - `checkpoint_id`
+  - `hardware_session_id`
+
+### Lifecycle span model (required)
+
+All runtime/data telemetry must preserve a single lifecycle chain in this strict order:
+
+1. `queue`
+2. `schedule`
+3. `dispatch`
+4. `execute`
+5. `persist`
+6. `checkpoint`
+
+Each stage must emit `stage`, `started_at`, `finished_at`, and carry all required correlation keys.
+
+## Alert pack (deterministic thresholds)
+
+Prometheus alerts:
+
+- `monitoring/metrics/prometheus/runtime-data-alerts.yaml`
+
+### Queue pressure
+
+- Trigger: `eigen_orch_queue_depth > 300` and `eigen_orch_queue_oldest_age_seconds > 180` for 10m.
+- Why it matters: sustained depth + age indicates user-visible starvation risk.
+- First response:
+  1. Verify dispatch throughput and admission ratios per tenant.
+  2. Confirm no stalled control-plane workers.
+  3. Apply safe capacity policy rollback if threshold was introduced in the latest rollout.
+
+### Compiler regressions
+
+- Trigger warning: compile stage p95 > 1.2s for 15m.
+- Trigger critical: compile stage p99 > 2.4s for 15m.
+- First response:
+  1. Compare compile-latency distribution to last known-good release.
+  2. Validate compile cache hit rate and backend selection drift.
+  3. Roll back compiler policy bundle if regression correlates with a policy/version bump.
+
+### Driver degradation
+
+- Trigger: execute-stage error rate > 3% for 10m.
+- First response:
+  1. Group failures by `hardware_session_id` and backend/driver version.
+  2. Confirm whether degradation is localized to a single hardware pool.
+  3. Isolate failing pool and re-route new assignments until driver rollback completes.
+
+### Correlation breakage
+
+- Trigger: any increase in `eigen_cluster_trace_breakage_total` over 10m.
+- First response:
+  1. Block promotion and mark the build as unsafe for release.
+  2. Validate propagation of `trace_id`, `dispatch_id`, `assignment_id`, and `checkpoint_id` through queue envelopes and persistence records.
+  3. Roll back the most recent telemetry propagation changes.
+
+## CI/ops diagnostics requirements
+
+Critical regressions must produce deterministic diagnostics payloads with:
+
+- `reason_code` (stable enum-like marker)
+- `severity`
+- `correlation_keys_present` (boolean)
+- `mitigation_hint`
+
+Recommended reason codes:
+
+- `QUEUE_PRESSURE_CRITICAL`
+- `COMPILE_P95_REGRESSION`
+- `COMPILE_P99_REGRESSION`
+- `DRIVER_DEGRADATION_ERROR_RATE`
+- `CORRELATION_LINEAGE_BREAKAGE`

--- a/monitoring/metrics/prometheus/config.yaml
+++ b/monitoring/metrics/prometheus/config.yaml
@@ -8,6 +8,7 @@ rule_files:
   - benchmark-alerts.yaml
   - intelligent-runtime-alerts.yaml
   - cluster-runtime-alerts.yaml
+  - runtime-data-alerts.yaml
 
 scrape_configs:
   - job_name: eigen-kernel-stage-metrics

--- a/monitoring/metrics/prometheus/runtime-data-alerts.yaml
+++ b/monitoring/metrics/prometheus/runtime-data-alerts.yaml
@@ -1,0 +1,44 @@
+groups:
+  - name: eigen-runtime-data-signals
+    interval: 30s
+    rules:
+      - alert: EigenRuntimeDataQueuePressureCritical
+        expr: eigen_orch_queue_depth > 300 and eigen_orch_queue_oldest_age_seconds > 180
+        for: 10m
+        labels: { severity: critical, team: sre }
+        annotations:
+          summary: "Queue pressure sustained across depth and oldest-age thresholds"
+          runbook: "docs/howto/runtime-data-observability-runbook.md#queue-pressure"
+
+      - alert: EigenRuntimeDataCompileRegressionP95
+        expr: eigen_stage_latency_seconds{stage="compile",quantile="0.95"} > 1.2
+        for: 15m
+        labels: { severity: warning, team: runtime }
+        annotations:
+          summary: "Compile p95 latency regressed beyond deterministic threshold"
+          runbook: "docs/howto/runtime-data-observability-runbook.md#compiler-regressions"
+
+      - alert: EigenRuntimeDataCompileRegressionP99Critical
+        expr: eigen_stage_latency_seconds{stage="compile",quantile="0.99"} > 2.4
+        for: 15m
+        labels: { severity: critical, team: runtime }
+        annotations:
+          summary: "Compile p99 latency indicates release-risking compiler regression"
+          runbook: "docs/howto/runtime-data-observability-runbook.md#compiler-regressions"
+
+      - alert: EigenRuntimeDataDriverDegradationErrorRate
+        expr: eigen_stage_error_rate{stage="execute"} > 0.03
+        for: 10m
+        labels: { severity: critical, team: runtime }
+        annotations:
+          summary: "Driver degradation signaled by execute-stage error-rate breach"
+          runbook: "docs/howto/runtime-data-observability-runbook.md#driver-degradation"
+
+      - alert: EigenRuntimeDataCorrelationBreakage
+        expr: increase(eigen_cluster_trace_breakage_total[10m]) > 0
+        for: 5m
+        labels: { severity: critical, team: sre }
+        annotations:
+          summary: "Correlation lineage break detected across scheduler/hardware/runtime path"
+          runbook: "docs/howto/runtime-data-observability-runbook.md#correlation-breakage"
+          

--- a/monitoring/metrics/tests/test_stage_observability.py
+++ b/monitoring/metrics/tests/test_stage_observability.py
@@ -94,3 +94,19 @@ def test_benchmark_metrics_exporter_renders_stable_contract_metrics():
     assert "eigen_bench_runs_failed_total 8" in text
     assert "eigen_bench_ingestion_failures_total 3" in text
     assert "eigen_bench_stalled_runs 1" in text
+
+def test_runtime_data_alert_pack_has_required_rules_and_runbooks():
+    text = open("monitoring/metrics/prometheus/runtime-data-alerts.yaml", "r", encoding="utf-8").read()
+    expected_alerts = {
+        "EigenRuntimeDataQueuePressureCritical",
+        "EigenRuntimeDataCompileRegressionP95",
+        "EigenRuntimeDataCompileRegressionP99Critical",
+        "EigenRuntimeDataDriverDegradationErrorRate",
+        "EigenRuntimeDataCorrelationBreakage",
+    }
+
+    for alert in expected_alerts:
+        assert f"alert: {alert}" in text
+
+    assert text.count('runbook: "docs/howto/runtime-data-observability-runbook.md#') == 5
+    


### PR DESCRIPTION
## Summary

- Implemented the Phase-8B runtime/data alert pack with deterministic thresholds for queue pressure, compiler regressions, driver degradation, and correlation-lineage breakage, each with explicit runbook anchors.

- Added a dedicated Phase-8B runtime/data runbook documenting:

    - the lifecycle join model (queue -> schedule -> dispatch -> execute -> persist -> checkpoint),

    - required stable correlation keys,

    - deterministic alert-response playbooks,

    - required CI/ops diagnostic payload fields and reason codes.

- Wired the new alert file into Prometheus rule loading and updated observability operator docs to include the Phase-8B pack.

- Extended observability tests to validate that all required Phase-8B alerts exist and that each includes a runbook link.

- Updated changelog with the P8B-05 entry and version impact (runtime-observability assets 0.4.0, additive/MINOR).

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: Prometheus alert bundles, operator runbooks
- **Compatibility**: Non-breaking
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

```markdown
### Added

- Phase-8B runtime/data observability runbook with lifecycle/correlation join model.

- Phase-8B runtime/data Prometheus alert pack with deterministic thresholds and runbook links.

### Changed

- Prometheus config now includes runtime-data-alerts.yaml.

- Observability test suite now checks required runtime/data alert coverage.

### Fixed
N/A 