### PR TITLE
Implement trigger and rollback automation

### DIFF
--- a/src/services/benchmark-service/pyproject.toml
+++ b/src/services/benchmark-service/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "benchmark-service"
-version = "0.9.0"
+version = "0.10.0"
 description = "Eigen OS benchmark-service core run lifecycle contracts."
 requires-python = ">=3.12"
 dependencies = []

--- a/src/services/benchmark-service/src/benchmark_service/optimizer_evaluation.py
+++ b/src/services/benchmark-service/src/benchmark_service/optimizer_evaluation.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from .compare_api import BenchmarkCompareApi
 
-OPTIMIZER_EVAL_CONTRACT_VERSION = "1.0.0"
+OPTIMIZER_EVAL_CONTRACT_VERSION = "1.1.0"
 OPTIMIZER_BASELINE_VERSION = "1.0.0"
 
 
@@ -94,4 +94,73 @@ class OptimizerEvaluationHarness:
             "recommendation": recommendation,
             "gate_reasons": gate_reasons,
             "offline_bundle": offline,
+        }
+
+LEARNING_PIPELINE_POLICY_VERSION = "1.1.0"
+DEFAULT_TRIGGER_CIRCUITS = 1000
+ROLLBACK_RUNBOOK_REF = "docs/howto/intelligent-runtime-observability-runbook.md"
+
+
+class ContinuousLearningPipeline:
+    """Deterministic trigger/promotion/rollback policy bundle for Phase-8C."""
+
+    def __init__(self) -> None:
+        self._harness = OptimizerEvaluationHarness()
+
+    def evaluate(self, fixture: dict[str, Any]) -> dict[str, Any]:
+        trigger_policy = fixture.get("trigger_policy", {})
+        threshold = int(trigger_policy.get("new_circuit_threshold", DEFAULT_TRIGGER_CIRCUITS))
+        observed_new_circuits = int(fixture.get("observed_new_circuits", 0))
+        should_retrain = observed_new_circuits >= threshold
+
+        if not should_retrain:
+            return {
+                "contract_version": OPTIMIZER_EVAL_CONTRACT_VERSION,
+                "policy_version": LEARNING_PIPELINE_POLICY_VERSION,
+                "trigger": {
+                    "threshold": threshold,
+                    "observed_new_circuits": observed_new_circuits,
+                    "should_retrain": False,
+                },
+                "artifact": None,
+                "promotion": None,
+                "rollback": None,
+            }
+
+        artifact = {
+            "artifact_version": fixture.get("artifact_version", "model-v-next"),
+            "lineage": {
+                "dataset_ref": fixture["dataset_ref"],
+                "dataset_hash": fixture["dataset_hash"],
+                "seed": int(fixture["seed"]),
+            },
+        }
+
+        promotion = self._harness.evaluate_shadow(fixture)
+
+        rollback = None
+        if promotion["recommendation"] != "PROMOTE":
+            rollback_reasons = [
+                f"CANARY_{reason}"
+                for reason in promotion["gate_reasons"]
+                if reason in {"REGRESSION_VS_BASELINE_HEURISTIC", "INSUFFICIENT_SHADOW_SAMPLES"}
+            ]
+            if rollback_reasons:
+                rollback = {
+                    "action": "ROLLBACK_TO_STABLE",
+                    "reason_codes": sorted(rollback_reasons),
+                    "runbook_ref": ROLLBACK_RUNBOOK_REF,
+                }
+
+        return {
+            "contract_version": OPTIMIZER_EVAL_CONTRACT_VERSION,
+            "policy_version": LEARNING_PIPELINE_POLICY_VERSION,
+            "trigger": {
+                "threshold": threshold,
+                "observed_new_circuits": observed_new_circuits,
+                "should_retrain": True,
+            },
+            "artifact": artifact,
+            "promotion": promotion,
+            "rollback": rollback,
         }

--- a/src/services/benchmark-service/tests/fixtures/optimizer_evaluation/offline_online_fixture.json
+++ b/src/services/benchmark-service/tests/fixtures/optimizer_evaluation/offline_online_fixture.json
@@ -3,24 +3,56 @@
   "dataset_hash": "sha256:phase8cfrozenfixture001",
   "seed": 42,
   "topology": {
-    "nodes": ["q0", "q1", "q2"],
+    "nodes": [
+      "q0",
+      "q1",
+      "q2"
+    ],
     "edges": [
-      {"source": "q0", "target": "q1", "fidelity": 0.99},
-      {"source": "q1", "target": "q2", "fidelity": 0.91}
+      {
+        "source": "q0",
+        "target": "q1",
+        "fidelity": 0.99
+      },
+      {
+        "source": "q1",
+        "target": "q2",
+        "fidelity": 0.91
+      }
     ]
   },
   "baseline_snapshot": {
     "run_id": "baseline-frozen-001",
     "metrics": [
-      {"name": "latency_ms", "mean": 90.0, "stddev": 2.0, "sample_size": 20},
-      {"name": "fidelity", "mean": 0.991, "stddev": 0.002, "sample_size": 20}
+      {
+        "name": "latency_ms",
+        "mean": 90.0,
+        "stddev": 2.0,
+        "sample_size": 20
+      },
+      {
+        "name": "fidelity",
+        "mean": 0.991,
+        "stddev": 0.002,
+        "sample_size": 20
+      }
     ]
   },
   "candidate_snapshot": {
     "run_id": "candidate-frozen-001",
     "metrics": [
-      {"name": "latency_ms", "mean": 103.0, "stddev": 2.0, "sample_size": 20},
-      {"name": "fidelity", "mean": 0.992, "stddev": 0.002, "sample_size": 20}
+       {
+        "name": "latency_ms",
+        "mean": 103.0,
+        "stddev": 2.0,
+        "sample_size": 20
+      },
+      {
+        "name": "fidelity",
+        "mean": 0.992,
+        "stddev": 0.002,
+        "sample_size": 20
+      }
     ]
   },
   "compare_policy": {
@@ -34,5 +66,10 @@
   "observed_shadow_samples": 12,
   "cohort_filters": {
     "backend_class": "simulator"
-  }
+  },
+  "trigger_policy": {
+    "new_circuit_threshold": 1000
+  },
+  "observed_new_circuits": 1000,
+  "artifact_version": "phase8c-candidate-0007"
 }

--- a/src/services/benchmark-service/tests/test_optimizer_evaluation_harness.py
+++ b/src/services/benchmark-service/tests/test_optimizer_evaluation_harness.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from benchmark_service.optimizer_evaluation import OptimizerEvaluationHarness
+from benchmark_service.optimizer_evaluation import (
+    ContinuousLearningPipeline,
+    OptimizerEvaluationHarness,
+)
 
 FIXTURE = Path(__file__).parent / "fixtures" / "optimizer_evaluation" / "offline_online_fixture.json"
 
@@ -32,3 +35,30 @@ def test_shadow_harness_emits_block_recommendation_with_gate_reasons() -> None:
     assert result["recommendation"] == "BLOCK_PROMOTION"
     assert "REGRESSION_VS_BASELINE_HEURISTIC" in result["gate_reasons"]
     assert "INSUFFICIENT_SHADOW_SAMPLES" in result["gate_reasons"]
+
+def test_pipeline_generates_artifact_and_rollback_reason_codes_when_regression_detected() -> None:
+    pipeline = ContinuousLearningPipeline()
+    fixture = _fixture()
+
+    result = pipeline.evaluate(fixture)
+
+    assert result["trigger"]["should_retrain"] is True
+    assert result["artifact"]["artifact_version"] == "phase8c-candidate-0007"
+    assert result["promotion"]["recommendation"] == "BLOCK_PROMOTION"
+    assert result["rollback"]["action"] == "ROLLBACK_TO_STABLE"
+    assert result["rollback"]["reason_codes"] == [
+        "CANARY_INSUFFICIENT_SHADOW_SAMPLES",
+        "CANARY_REGRESSION_VS_BASELINE_HEURISTIC",
+    ]
+
+def test_pipeline_does_not_trigger_retrain_before_threshold() -> None:
+    pipeline = ContinuousLearningPipeline()
+    fixture = _fixture()
+    fixture["observed_new_circuits"] = 999
+
+    result = pipeline.evaluate(fixture)
+
+    assert result["trigger"]["should_retrain"] is False
+    assert result["artifact"] is None
+    assert result["promotion"] is None
+    assert result["rollback"] is None


### PR DESCRIPTION
## Summary

- Implemented Phase-8C continuous learning trigger/promotion/rollback automation in benchmark-service via a deterministic ContinuousLearningPipeline.

- Added default trigger policy (1000 new circuits), versioned candidate artifact lineage, shadow/canary fail-closed promotion decisioning, and rollback payloads with stable reason codes.

- Upgraded optimizer evaluation contract version to 1.1.0 and benchmark-service package version to 0.10.0.

- Extended fixture + tests to validate trigger threshold behavior, canary regression blocking, and automated rollback semantics.


## Validation

- [x] Tests added/updated
- [ ] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: Compatibility matrix | Metrics
- **Compatibility**: Breaking (requires MAJOR) - No
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Deterministic continuous learning trigger/promotion/rollback pipeline for Phase-8C with default 1000-circuit retrain trigger.

### Changed
- Optimizer evaluation contract version bumped to 1.1.0.
- benchmark-service package version bumped to 0.10.0.

### Fixed
- Enforced fail-closed canary non-regression behavior with deterministic rollback reason codes.