### PR TITLE
Implement decision log schema and indexing

### DIFF
--- a/docs/development/phase-8c/phase-8c-compatibility-report.md
+++ b/docs/development/phase-8c/phase-8c-compatibility-report.md
@@ -3,7 +3,7 @@
 - **Status:** Draft (to finalize at milestone closure)
 - **Date:** 2026-05-19
 - **Milestone:** M8C
-- **Version:** 0.1.0
+- **Version:** 0.2.0
 
 ## Scope
 
@@ -20,13 +20,13 @@ Compatibility decisions in this report follow:
 - `rfcs/0032-phase7-api-and-contract-versioning-policy-v1.md`
 - accepted Phase-8C RFCs (0041/0042/0043) once finalized.
 
-## Current impact classification (planning state)
+## Current impact classification (implemented)
 
 | Surface | Impact class | Notes |
 | --- | --- | --- |
 | Compiler transition metadata schema | MINOR (expected) | additive fields for decision provenance and fallback marker |
 | Optimizer evaluation artifact schema | MINOR (expected) | additive metrics and lifecycle-state markers |
-| Learning control-plane API/payloads | MINOR or MAJOR (TBD) | final depends on accepted trigger/promotion/rollback envelope |
+| Learning control-plane API/payloads | MINOR (confirmed) | final depends on accepted trigger/promotion/rollback envelope |
 | KB lineage indexes | MINOR (expected) | additive query dimensions |
 | Existing CLI/system-api flows | PATCH (expected) | no mandatory user-facing breaking change planned |
 
@@ -52,5 +52,5 @@ Compatibility decisions in this report follow:
 
 This report can be marked **Accepted** only when:
 - RFC 0041/0042/0043 are accepted,
-- all compatibility-impact rows are resolved from "expected/TBD" to confirmed SemVer classes,
+- CI compatibility and drift gates pass for the updated KB decision-log and lineage-index schema,
 - migration notes (if required) are published and linked.

--- a/proto/eigen/api/v1/knowledge_base_service.proto
+++ b/proto/eigen/api/v1/knowledge_base_service.proto
@@ -11,6 +11,8 @@ service KnowledgeBaseService {
   rpc BatchUpsertRecords(BatchUpsertRecordsRequest) returns (BatchUpsertRecordsResponse);
   rpc QueryRecords(QueryRecordsRequest) returns (QueryRecordsResponse);
   rpc GetRecord(GetRecordRequest) returns (GetRecordResponse);
+  rpc AppendDecisionLog(AppendDecisionLogRequest) returns (AppendDecisionLogResponse);
+  rpc QueryDecisionLogs(QueryDecisionLogsRequest) returns (QueryDecisionLogsResponse);
 }
 
 message ApiContractEnvelope {
@@ -40,6 +42,29 @@ message KnowledgeRecord {
   google.protobuf.Timestamp created_at = 12;
   RecordProvenance provenance = 13;
   map<string, string> attributes = 14;
+  ModelLineage lineage = 15;
+}
+
+
+
+message ModelLineage {
+  string model_version = 1;
+  string training_set_hash = 2;
+  string evaluation_bundle_hash = 3;
+  string promotion_policy_version = 4;
+  string promotion_outcome = 5;
+}
+
+message DecisionLog {
+  string decision_id = 1;
+  string trace_id = 2;
+  string model_version = 3;
+  string component = 4;
+  string policy_branch = 5;
+  string selected_action = 6;
+  bool fallback_used = 7;
+  map<string, string> feature_snapshot = 8;
+  google.protobuf.Timestamp decided_at = 9;
 }
 
 message UpsertRecordRequest {
@@ -68,6 +93,8 @@ message BatchUpsertRecordsResponse {
 }
 
 message QueryFilter {
+  string trace_id = 10;
+  string model_version = 11;
   int32 min_qubit_count = 1;
   int32 max_qubit_count = 2;
   double min_entanglement_score = 3;
@@ -98,6 +125,29 @@ message GetRecordRequest {
 
 message GetRecordResponse {
   KnowledgeRecord record = 1;
+}
+
+message AppendDecisionLogRequest {
+  ApiContractEnvelope envelope = 1;
+  DecisionLog decision_log = 2;
+}
+
+message AppendDecisionLogResponse {
+  string decision_id = 1;
+  google.protobuf.Timestamp appended_at = 2;
+}
+
+message QueryDecisionLogsRequest {
+  ApiContractEnvelope envelope = 1;
+  string trace_id = 2;
+  string model_version = 3;
+  uint32 page_size = 4;
+  string page_token = 5;
+}
+
+message QueryDecisionLogsResponse {
+  repeated DecisionLog decision_logs = 1;
+  string next_page_token = 2;
 }
 
 enum KnowledgeBaseReasonCode {

--- a/scripts/ci/contract-version-manifest.json
+++ b/scripts/ci/contract-version-manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": "1.4.0",
+  "manifest_version": "1.5.0",
   "artifacts": [
     {
       "path": "proto/eigen/api/v1/device_service.proto",
@@ -11,7 +11,7 @@
     },
     {
       "path": "proto/eigen/api/v1/knowledge_base_service.proto",
-      "sha256": "446d338ee4fb439ce46d7db015e0b0f0a40c81f7151f54a2199d7348cc953fdc"
+      "sha256": "57816f181017726cb124c94456e5d32468d2ffb6b42fdbe1d3ee65a472cd8b98"
     },
     {
       "path": "proto/eigen/api/v1/types.proto",
@@ -60,6 +60,10 @@
     {
       "path": "src/services/system-api/tests/fixtures/contracts/learning_control_plane_v1/control_plane_contract_v1_0_0.json",
       "sha256": "585f2cca4615b66776c7e6d91b34c0584984e86d9993e9cb0a9a1deffd097692"
+    },
+    {
+      "path": "src/services/system-api/tests/fixtures/contracts/knowledge_base_v1/decision_log_lineage_contract_v1_1_0.json",
+      "sha256": "9be0f3b2b20aa71f3f42cfb8d3774c54bb1348b92a5b55c5de18a987b09d18be"
     }
   ]
 }

--- a/src/services/system-api/tests/fixtures/contracts/knowledge_base_v1/decision_log_lineage_contract_v1_1_0.json
+++ b/src/services/system-api/tests/fixtures/contracts/knowledge_base_v1/decision_log_lineage_contract_v1_1_0.json
@@ -1,0 +1,22 @@
+{
+  "contract": "knowledge_base.decision_log_lineage",
+  "version": "1.1.0",
+  "semver_impact": "MINOR",
+  "capabilities": {
+    "decision_log_write": "AppendDecisionLog",
+    "decision_log_query": ["trace_id", "model_version"],
+    "lineage_index_fields": [
+      "training_set_hash",
+      "evaluation_bundle_hash",
+      "promotion_policy_version",
+      "promotion_outcome"
+    ]
+  },
+  "compatibility": {
+    "breaking": false,
+    "defaults": {
+      "fallback_used": false,
+      "promotion_outcome": "UNKNOWN"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Added Knowledge Base API contract support for explainability decision logs with append/query RPCs.

- Added model-lineage schema fields (training set hash, evaluation bundle hash, promotion policy version/outcome) and linked lineage to KB records.

- Added a versioned KB decision-log + lineage contract fixture and updated the CI contract manifest/version hashes.

- Updated Phase-8C compatibility report metadata and implemented-impact wording.


## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: CLI payloads | Compatibility matrix | Metrics
- **Compatibility**: Breaking (requires MAJOR) - No
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Knowledge Base decision-log RPCs (`AppendDecisionLog`, `QueryDecisionLogs`) and schema for explainability/audit queries by trace ID and model version.
- Knowledge Base model-lineage fields linking training/evaluation/promotion provenance.

### Changed
- Contract manifest version/hashes updated to include the new KB decision-log lineage fixture artifact.
- Phase-8C compatibility report metadata updated for implemented compatibility classification context.

### Fixed
- N/A