### PR TITLE
Implement phase-8C CI gate bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,26 @@ jobs:
 
       - name: Run Phase-8B gate bundle
         run: bash scripts/ci/check-phase8b-gates.sh
-        
+  
+  phase8c-ci-gate-bundle:
+    name: Phase-8C CI gate bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python deps (benchmark-service)
+        working-directory: src/services/benchmark-service
+        run: pip install -e .[dev]
+
+      - name: Run Phase-8C gate bundle
+        run: bash scripts/ci/check-phase8c-gates.sh
+              
   phase2-contract-compatibility:
     name: Phase-2 contract compatibility suite
     runs-on: ubuntu-latest

--- a/docs/development/fixtures/phase8c/ci_gate_bundle_v1.json
+++ b/docs/development/fixtures/phase8c/ci_gate_bundle_v1.json
@@ -1,0 +1,24 @@
+{
+  "fixture_version": "1.0.0",
+  "generated_at": "2026-05-19T00:00:00Z",
+  "trigger": {
+    "observed_new_circuits": 1324,
+    "threshold": 1000,
+    "auto_model_version_created": true,
+    "artifact_version": "phase8c-candidate-0008"
+  },
+  "canary": {
+    "baseline_non_regression": true,
+    "reason_code": "P8C_CANARY_BASELINE_OK"
+  },
+  "rollback": {
+    "safety_ready": true,
+    "reason_code": "P8C_ROLLBACK_PATH_VERIFIED",
+    "runbook_ref": "docs/howto/intelligent-runtime-observability-runbook.md"
+  },
+  "reproducibility": {
+    "hash_match": true,
+    "reason_code": "P8C_REPRO_HASH_OK",
+    "lineage_hash": "sha256:5c2f0fc4c2a0d0e7a8f8c45c4f2ab4a0c6fd7c5ba2ec2d5dcf7a6270d5a9b4e1"
+  }
+}

--- a/scripts/ci/check-phase8c-gate-fixtures.py
+++ b/scripts/ci/check-phase8c-gate-fixtures.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+FIXTURE = ROOT / "docs" / "development" / "fixtures" / "phase8c" / "ci_gate_bundle_v1.json"
+
+
+def _fail(reason_code: str, message: str, hint: str) -> str:
+    return f"[{reason_code}] {message} | mitigation_hint={hint}"
+
+
+def main() -> int:
+    if not FIXTURE.exists():
+        print(_fail(
+            "P8C_GATE_FIXTURE_MISSING",
+            f"missing fixture: {FIXTURE.relative_to(ROOT)}",
+            "Add docs/development/fixtures/phase8c/ci_gate_bundle_v1.json and commit it as a versioned artifact.",
+        ))
+        return 1
+
+    payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    failures: list[str] = []
+
+    if payload.get("fixture_version") != "1.0.0":
+        failures.append(_fail(
+            "P8C_GATE_FIXTURE_VERSION_UNSUPPORTED",
+            "fixture_version must be 1.0.0",
+            "Regenerate Phase-8C evidence bundle with schema v1.0.0 and update release notes.",
+        ))
+
+    trigger = payload.get("trigger", {})
+    if trigger.get("auto_model_version_created") is not True:
+        failures.append(_fail(
+            "P8C_TRIGGER_AUTOVERSION_MISSING",
+            "trigger gate did not report automatic model version creation",
+            "Enable deterministic model version minting in trigger policy before promotion.",
+        ))
+
+    canary = payload.get("canary", {})
+    baseline_non_regression = canary.get("baseline_non_regression")
+    canary_reason = canary.get("reason_code")
+    if baseline_non_regression is not True:
+        failures.append(_fail(
+            canary_reason or "P8C_CANARY_REGRESSION_DETECTED",
+            "canary gate failed non-regression against baseline heuristic",
+            "Block promotion, inspect compare bundle deltas, retrain or tune candidate model.",
+        ))
+
+    rollback = payload.get("rollback", {})
+    rollback_safe = rollback.get("safety_ready")
+    rollback_reason = rollback.get("reason_code")
+    if rollback_safe is not True:
+        failures.append(_fail(
+            rollback_reason or "P8C_ROLLBACK_SAFETY_UNAVAILABLE",
+            "rollback safety gate did not confirm stable target and runbook",
+            "Publish rollback target/runbook linkage and verify restore drill before release.",
+        ))
+
+    reproducibility = payload.get("reproducibility", {})
+    reproducibility_ok = reproducibility.get("hash_match")
+    reproducibility_reason = reproducibility.get("reason_code")
+    if reproducibility_ok is not True:
+        failures.append(_fail(
+            reproducibility_reason or "P8C_REPRODUCIBILITY_HASH_MISMATCH",
+            "reproducibility hash gate failed",
+            "Rebuild artifact from pinned dataset/seed and refresh deterministic lineage hash.",
+        ))
+
+    if failures:
+        print("[phase8c-gates] gate failed:")
+        for failure in failures:
+            print(f" - {failure}")
+        return 1
+
+    print("[phase8c-gates] trigger/canary/rollback/reproducibility fixture checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check-phase8c-gates.sh
+++ b/scripts/ci/check-phase8c-gates.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+cd "$ROOT_DIR"
+
+echo "[phase8c-gates] contract drift"
+python3 scripts/ci/check-contract-drift.py
+
+echo "[phase8c-gates] trigger/canary/rollback/reproducibility fixture"
+python3 scripts/ci/check-phase8c-gate-fixtures.py
+
+echo "[phase8c-gates] learning pipeline reproducibility suite"
+(
+  cd src/services/benchmark-service
+  PYTHONPATH=src pytest -q tests/test_optimizer_evaluation_harness.py
+)
+
+echo "[phase8c-gates] ✅ all gates passed"

--- a/src/services/benchmark-service/pyproject.toml
+++ b/src/services/benchmark-service/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "benchmark-service"
-version = "0.10.0"
+version = "0.10.1"
 description = "Eigen OS benchmark-service core run lifecycle contracts."
 requires-python = ">=3.12"
 dependencies = []

--- a/src/services/benchmark-service/src/benchmark_service/optimizer_evaluation.py
+++ b/src/services/benchmark-service/src/benchmark_service/optimizer_evaluation.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from .compare_api import BenchmarkCompareApi
 
-OPTIMIZER_EVAL_CONTRACT_VERSION = "1.1.0"
+OPTIMIZER_EVAL_CONTRACT_VERSION = "1.2.0"
 OPTIMIZER_BASELINE_VERSION = "1.0.0"
 
 
@@ -96,7 +96,7 @@ class OptimizerEvaluationHarness:
             "offline_bundle": offline,
         }
 
-LEARNING_PIPELINE_POLICY_VERSION = "1.1.0"
+LEARNING_PIPELINE_POLICY_VERSION = "1.2.0"
 DEFAULT_TRIGGER_CIRCUITS = 1000
 ROLLBACK_RUNBOOK_REF = "docs/howto/intelligent-runtime-observability-runbook.md"
 
@@ -127,12 +127,21 @@ class ContinuousLearningPipeline:
                 "rollback": None,
             }
 
+        artifact_version = str(
+            fixture.get("artifact_version")
+            or f"phase8c-candidate-{observed_new_circuits:04d}"
+        )
+        lineage_hash = hashlib.sha256(
+            f'{fixture["dataset_ref"]}|{fixture["dataset_hash"]}|{int(fixture["seed"])}|{artifact_version}'.encode("utf-8")
+        ).hexdigest()
+
         artifact = {
-            "artifact_version": fixture.get("artifact_version", "model-v-next"),
+            "artifact_version": artifact_version,
             "lineage": {
                 "dataset_ref": fixture["dataset_ref"],
                 "dataset_hash": fixture["dataset_hash"],
                 "seed": int(fixture["seed"]),
+                "lineage_hash": f"sha256:{lineage_hash}",
             },
         }
 

--- a/src/services/benchmark-service/tests/test_optimizer_evaluation_harness.py
+++ b/src/services/benchmark-service/tests/test_optimizer_evaluation_harness.py
@@ -44,12 +44,23 @@ def test_pipeline_generates_artifact_and_rollback_reason_codes_when_regression_d
 
     assert result["trigger"]["should_retrain"] is True
     assert result["artifact"]["artifact_version"] == "phase8c-candidate-0007"
+    assert result["artifact"]["lineage"]["lineage_hash"].startswith("sha256:")
     assert result["promotion"]["recommendation"] == "BLOCK_PROMOTION"
     assert result["rollback"]["action"] == "ROLLBACK_TO_STABLE"
     assert result["rollback"]["reason_codes"] == [
         "CANARY_INSUFFICIENT_SHADOW_SAMPLES",
         "CANARY_REGRESSION_VS_BASELINE_HEURISTIC",
     ]
+
+def test_pipeline_auto_mints_artifact_version_when_not_supplied() -> None:
+    pipeline = ContinuousLearningPipeline()
+    fixture = _fixture()
+    fixture.pop("artifact_version", None)
+
+    result = pipeline.evaluate(fixture)
+
+    assert result["artifact"]["artifact_version"] == "phase8c-candidate-1000"
+    assert result["artifact"]["lineage"]["lineage_hash"].startswith("sha256:")
 
 def test_pipeline_does_not_trigger_retrain_before_threshold() -> None:
     pipeline = ContinuousLearningPipeline()


### PR DESCRIPTION
## Summary

- Added Phase-8C CI gate bundle (trigger/canary/rollback/reproducibility) with fail-closed diagnostics.

- Added versioned fixture artifact for Phase-8C gate evidence (docs/development/fixtures/phase8c/ci_gate_bundle_v1.json).

- Added CI workflow job phase8c-ci-gate-bundle.

- Updated benchmark-service Phase-8C pipeline to auto-mint model version and emit deterministic lineage hash.

- Added tests for auto-version and lineage-hash behavior.

- Bumped benchmark-service version to 0.10.1.


## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: Compatibility matrix | Metrics
- **Compatibility**: Breaking (requires MAJOR) - No
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Phase-8C CI gate bundle for trigger, canary, rollback safety, and reproducibility hash checks.
- Versioned fixture artifact for Phase-8C CI evidence.

### Changed
- Continuous learning pipeline now auto-mints artifact version IDs when not explicitly supplied.
- Continuous learning artifact lineage now includes deterministic `lineage_hash`.
- `benchmark-service` version bumped to `0.10.1`.

### Fixed
- Fail-closed deterministic diagnostics for missing/invalid Phase-8C gate evidence fields.