### PR TITLE
Finalize QDriver API v1.0 and Conformance Kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Before `1.0.0`, breaking changes may occur in minor versions. After `1.0.0`, bre
 
 ### Added
 
+- Phase-8D P8D-01 QDriver v1.0 conformance gate foundation (`driver-manager` package `0.5.0`) with explicit fail-closed provider-profile handling for unsupported adapters and deterministic profile-matrix conformance tests (`simulator` pass, `ibm`/`aws` unsupported-class diagnostics).
 - Phase-8B RFC/ADR synchronization closure (`governance-docs` package `0.12.0`) with RFC 0038/0039/0040 accepted status alignment, new ADR 0024/0025/0026 records, synchronized RFC/ADR pointers, and completed Phase-8B readiness + evidence docs.
 - Phase-8B P8B-06 CI gate bundle (`qa-ci` assets `0.1.0`) with required executable `scripts/ci/check-phase8b-gates.sh`, deterministic scale/latency/integrity fixture validation (`docs/development/fixtures/phase8b/ci_gate_bundle_v1.json`), and fail-closed reason-code diagnostics with mitigation hints.
 - Phase-8B P8B-05 observability join model + runtime/data alert pack (`runtime-observability` assets `0.4.0`) with lifecycle span correlation requirements (`queue -> schedule -> dispatch -> execute -> persist -> checkpoint`), deterministic queue/compiler/driver regression alerts, and runbook-linked actionable diagnostics for CI/ops workflows.

--- a/src/services/driver-manager/pyproject.toml
+++ b/src/services/driver-manager/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "driver-manager"
-version = "0.4.0"
+version = "0.5.0"
 description = "Eigen OS driver-manager service (MVP skeleton)."
 requires-python = ">=3.12"
 dependencies = [

--- a/src/services/driver-manager/src/driver_manager/simulator_driver.py
+++ b/src/services/driver-manager/src/driver_manager/simulator_driver.py
@@ -82,6 +82,7 @@ class SimulatorDriver:
         _ = device_id
         start = time.perf_counter()
 
+        self._validate_provider_profile(options)
         self._simulate_error(options)
         payload = self._parse_payload(circuit)
         qubits = self._parse_qubits(payload)
@@ -96,6 +97,7 @@ class SimulatorDriver:
 
         elapsed = time.perf_counter() - start
         metadata = {
+            "provider_profile": options.get("provider_profile", "simulator"),
             "driver": self.name,
             "aqo_version": str(payload.get("version", "")),
             "qubits": str(qubits),
@@ -116,6 +118,11 @@ class SimulatorDriver:
     def calibrate_device(self, device_id: str, options: dict[str, str]) -> str:
         _ = (options,)
         return f"calib://simulator/{device_id}"
+
+    def _validate_provider_profile(self, options: dict[str, str]) -> None:
+        profile = options.get("provider_profile", "simulator").strip().lower()
+        if profile != "simulator":
+            raise DriverExecutionError(grpc.StatusCode.UNIMPLEMENTED, f"Unsupported provider_profile: {profile}")
 
     def _simulate_error(self, options: dict[str, str]) -> None:
         signal = options.get("simulate_error", "").upper()

--- a/src/services/driver-manager/tests/test_qdriver_v1_conformance.py
+++ b/src/services/driver-manager/tests/test_qdriver_v1_conformance.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+
+import grpc
+import pytest
+
+from driver_manager.simulator_driver import DriverExecutionError, SimulatorDriver
+
+
+class _FakeDevice:
+    def __init__(self, device_id: str) -> None:
+        self.device_id = device_id
+
+
+@pytest.fixture()
+def simulator_driver() -> SimulatorDriver:
+    from eigen_internal.v1 import types_pb2 as types_pb
+
+    drv = SimulatorDriver(types_pb=types_pb)
+    drv.initialize(config={})
+    return drv
+
+
+def _aqo(ops: list[dict], qubits: int = 2) -> bytes:
+    return json.dumps({"version": "1.0.0", "qubits": qubits, "operations": ops}).encode("utf-8")
+
+
+@pytest.mark.parametrize(
+    ("profile", "enabled", "expected"),
+    [
+        ("simulator", True, "pass"),
+        ("ibm", False, "unsupported"),
+        ("aws", False, "unsupported"),
+    ],
+)
+def test_qdriver_v1_profile_matrix_fail_closed(
+    simulator_driver: SimulatorDriver,
+    profile: str,
+    enabled: bool,
+    expected: str,
+) -> None:
+    if not enabled:
+        with pytest.raises(DriverExecutionError) as err:
+            simulator_driver.execute_circuit(
+                device_id="sim:local",
+                circuit=_aqo([{"op": "MEASURE", "q": [0], "c": [0]}], qubits=1),
+                shots=8,
+                options={"provider_profile": profile},
+            )
+        assert err.value.status_code == grpc.StatusCode.UNIMPLEMENTED
+        assert f"Unsupported provider_profile: {profile}" == err.value.message
+        return
+
+    counts, _, metadata = simulator_driver.execute_circuit(
+        device_id="sim:local",
+        circuit=_aqo([{"op": "MEASURE", "q": [0], "c": [0]}], qubits=1),
+        shots=8,
+        options={"provider_profile": profile, "seed": "11"},
+    )
+    assert sum(counts.values()) == 8
+    assert metadata["provider_profile"] == "simulator"
+    assert expected == "pass"
+    


### PR DESCRIPTION
## Summary

- Added a Phase-8D QDriver v1.0 conformance baseline for provider-profile behavior with deterministic matrix assertions.

- Enforced fail-closed profile handling in simulator execution (provider_profile != simulator => UNIMPLEMENTED).

- Exposed active provider_profile in execution metadata for diagnostics.

- Bumped driver-manager package version to 0.5.0 and updated changelog.


## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: Compatibility matrix | Metrics
- **Compatibility**: Breaking (requires MAJOR) - No
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft
### Added
- QDriver v1.0 provider-profile conformance baseline tests (simulator pass, ibm/aws fail-closed unsupported).

### Changed
- Simulator driver now validates `provider_profile` fail-closed and emits `provider_profile` in execution metadata.
- `driver-manager` package version bumped to `0.5.0`.

### Fixed
- Deterministic unsupported-profile diagnostics for non-simulator provider profiles.