### PR TITLE
Implement IBM driver hardening changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Before `1.0.0`, breaking changes may occur in minor versions. After `1.0.0`, bre
 
 ### Added
 
+- Phase-8D P8D-02 IBM Quantum official driver hardening (`driver-manager` package `0.6.0`) with version-pinned adapter defaults, retry/timeout/quota-aware execution policy aligned with QDriver v1.0 taxonomy, IBM-focused driver tests, and IBM degradation response guidance in the runtime-data runbook.
 - Phase-8D P8D-01 QDriver v1.0 conformance gate foundation (`driver-manager` package `0.5.0`) with explicit fail-closed provider-profile handling for unsupported adapters and deterministic profile-matrix conformance tests (`simulator` pass, `ibm`/`aws` unsupported-class diagnostics).
 - Phase-8B RFC/ADR synchronization closure (`governance-docs` package `0.12.0`) with RFC 0038/0039/0040 accepted status alignment, new ADR 0024/0025/0026 records, synchronized RFC/ADR pointers, and completed Phase-8B readiness + evidence docs.
 - Phase-8B P8B-06 CI gate bundle (`qa-ci` assets `0.1.0`) with required executable `scripts/ci/check-phase8b-gates.sh`, deterministic scale/latency/integrity fixture validation (`docs/development/fixtures/phase8b/ci_gate_bundle_v1.json`), and fail-closed reason-code diagnostics with mitigation hints.

--- a/docs/howto/runtime-data-observability-runbook.md
+++ b/docs/howto/runtime-data-observability-runbook.md
@@ -60,6 +60,18 @@ Prometheus alerts:
   2. Confirm whether degradation is localized to a single hardware pool.
   3. Isolate failing pool and re-route new assignments until driver rollback completes.
 
+#### IBM Quantum-specific checks
+
+When failures are concentrated on the `ibm:qiskit-runtime` target:
+
+1. Confirm credential source and channel in `/healthz` (`auth_source`, `channel`, `instance`).
+2. Distinguish taxonomy quickly:
+   - `auth` → token/secret drift.
+   - `quota` → provider credits or tenant rate limits.
+   - `network`/`deadline_exceeded` → transient backend instability.
+3. If quota-limited, reduce shot count and allow configured retry budget to absorb bursts before escalating.
+4. If deadline failures persist beyond retry budget, fail over workload class to simulator profile and open provider incident with correlation IDs.
+
 ### Correlation breakage
 
 - Trigger: any increase in `eigen_cluster_trace_breakage_total` over 10m.

--- a/src/services/driver-manager/README.md
+++ b/src/services/driver-manager/README.md
@@ -8,7 +8,7 @@ Implemented in this milestone:
 - `ListDevices` / `GetDeviceStatus` behavior backed by registered drivers.
 - `BaseDriver` (`QDriver`) interface with capability handshake and healthcheck.
 - In-memory `DriverRegistry` with device-to-driver lookup.
-- Qiskit Runtime driver skeleton with auth resolution (`token`, `token_env`, `token_secret_ref`).
+- Qiskit Runtime adapter hardening baseline with auth resolution, timeout/retry policy, and provider error normalization.
 - HTTP endpoints: `/metrics` and `/healthz`.
 
 ## Run
@@ -22,6 +22,9 @@ python -m driver_manager.main
 ```bash
 export DRIVER_MANAGER_QISKIT_RUNTIME_ENABLED=true
 export DRIVER_MANAGER_QISKIT_RUNTIME_TOKEN_ENV=IBM_RUNTIME_TOKEN
+export DRIVER_MANAGER_QISKIT_RUNTIME_TIMEOUT_SEC=30
+export DRIVER_MANAGER_QISKIT_RUNTIME_MAX_RETRIES=2
+export DRIVER_MANAGER_QISKIT_RUNTIME_RETRY_BACKOFF_SEC=0.25
 export IBM_RUNTIME_TOKEN='<your-token>'
 python -m driver_manager.main
 curl -s localhost:9092/healthz

--- a/src/services/driver-manager/pyproject.toml
+++ b/src/services/driver-manager/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "driver-manager"
-version = "0.5.0"
+version = "0.6.0"
 description = "Eigen OS driver-manager service (MVP skeleton)."
 requires-python = ">=3.12"
 dependencies = [

--- a/src/services/driver-manager/src/driver_manager/qiskit_runtime_driver.py
+++ b/src/services/driver-manager/src/driver_manager/qiskit_runtime_driver.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from dataclasses import dataclass
 
 import grpc
@@ -30,6 +31,10 @@ class QiskitRuntimeDriver:
         self._auth_source = ""
         self._instance = ""
         self._channel = "ibm_quantum"
+        self._timeout_sec = 30.0
+        self._max_retries = 2
+        self._retry_backoff_sec = 0.25
+        self._executor = None
 
     def initialize(self, config: dict[str, str]) -> None:
         self._initialized = False
@@ -38,6 +43,9 @@ class QiskitRuntimeDriver:
         self._auth_source = auth.source
         self._instance = config.get("instance", "")
         self._channel = config.get("channel", "ibm_quantum")
+        self._timeout_sec = _positive_float(config.get("timeout_sec"), default=30.0)
+        self._max_retries = _non_negative_int(config.get("max_retries"), default=2)
+        self._retry_backoff_sec = _positive_float(config.get("retry_backoff_sec"), default=0.25)
         self._initialized = True
 
     def capability_handshake(self) -> DriverCapabilities:
@@ -47,6 +55,8 @@ class QiskitRuntimeDriver:
                 "execution": "qiskit_runtime",
                 "auth_sources": "token,token_env,token_secret_ref",
                 "channel": self._channel,
+                "timeouts": "execute_timeout_sec",
+                "retry_policy": "unavailable,deadline_exceeded,resource_exhausted",
             },
         )
 
@@ -87,8 +97,37 @@ class QiskitRuntimeDriver:
         ]
 
     def execute_circuit(self, device_id: str, circuit: bytes, shots: int, options: dict[str, str]) -> tuple[dict[str, int], float, dict[str, str]]:
-        _ = (device_id, circuit, shots, options)
-        raise DriverExecutionError(grpc.StatusCode.UNIMPLEMENTED, "Qiskit Runtime execution is not implemented yet")
+        self._ensure_ready()
+        timeout_sec = _positive_float(options.get("timeout_sec"), default=self._timeout_sec)
+        deadline = time.monotonic() + timeout_sec
+        attempts = self._max_retries + 1
+        last_error: DriverExecutionError | None = None
+        for attempt in range(1, attempts + 1):
+            try:
+                return self._invoke_runtime(device_id=device_id, circuit=circuit, shots=shots, options=options, timeout_sec=timeout_sec)
+            except DriverExecutionError as err:
+                last_error = self._normalize_provider_error(err)
+                if not self._is_retryable(last_error.code) or attempt >= attempts:
+                    raise last_error
+                if time.monotonic() >= deadline:
+                    raise DriverExecutionError(grpc.StatusCode.DEADLINE_EXCEEDED, f"IBM runtime timed out after {timeout_sec:.3f}s")
+                sleep_sec = min(self._retry_backoff_sec * attempt, max(0.0, deadline - time.monotonic()))
+                if sleep_sec > 0:
+                    time.sleep(sleep_sec)
+        raise last_error or DriverExecutionError(grpc.StatusCode.INTERNAL, "IBM runtime execution failed")
+
+    def _invoke_runtime(
+        self,
+        *,
+        device_id: str,
+        circuit: bytes,
+        shots: int,
+        options: dict[str, str],
+        timeout_sec: float,
+    ) -> tuple[dict[str, int], float, dict[str, str]]:
+        if self._executor is None:
+            raise DriverExecutionError(grpc.StatusCode.UNIMPLEMENTED, "Qiskit Runtime execution adapter is not configured")
+        return self._executor(device_id=device_id, circuit=circuit, shots=shots, options=options, timeout_sec=timeout_sec)
 
     def get_device_status(self, device_id: str) -> DeviceStatusInfo:
         return DeviceStatusInfo(
@@ -130,3 +169,38 @@ class QiskitRuntimeDriver:
 
         self._init_error = "qiskit runtime auth missing: set token, token_env, or token_secret_ref"
         raise ValueError(self._init_error)
+
+    def _ensure_ready(self) -> None:
+        if not self._initialized:
+            raise DriverExecutionError(grpc.StatusCode.FAILED_PRECONDITION, "Qiskit Runtime driver is not initialized")
+
+    @staticmethod
+    def _is_retryable(code: grpc.StatusCode) -> bool:
+        return code in {grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.DEADLINE_EXCEEDED, grpc.StatusCode.RESOURCE_EXHAUSTED}
+
+    @staticmethod
+    def _normalize_provider_error(err: DriverExecutionError) -> DriverExecutionError:
+        msg = err.message.lower()
+        if "quota" in msg or "rate limit" in msg:
+            return DriverExecutionError(grpc.StatusCode.RESOURCE_EXHAUSTED, err.message)
+        if "timeout" in msg:
+            return DriverExecutionError(grpc.StatusCode.DEADLINE_EXCEEDED, err.message)
+        return err
+
+
+def _positive_float(raw: str | None, *, default: float) -> float:
+    if raw is None or str(raw).strip() == "":
+        return default
+    value = float(raw)
+    if value <= 0:
+        raise ValueError("value must be > 0")
+    return value
+
+
+def _non_negative_int(raw: str | None, *, default: int) -> int:
+    if raw is None or str(raw).strip() == "":
+        return default
+    value = int(raw)
+    if value < 0:
+        raise ValueError("value must be >= 0")
+    return value

--- a/src/services/driver-manager/tests/test_qiskit_runtime_driver.py
+++ b/src/services/driver-manager/tests/test_qiskit_runtime_driver.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import pytest
+import grpc
 
 from driver_manager.proto_gen import ensure_generated
+from driver_manager.simulator_driver import DriverExecutionError
 from driver_manager.qiskit_runtime_driver import QiskitRuntimeDriver
 
 ensure_generated()
@@ -57,4 +59,33 @@ def test_missing_env_token_is_reported(monkeypatch: pytest.MonkeyPatch) -> None:
         driver.initialize({"token_env": "IBM_RUNTIME_TOKEN"})
 
     assert driver.healthcheck().ready is False
-    
+
+def test_execute_retries_resource_exhausted_then_succeeds() -> None:
+    driver = QiskitRuntimeDriver(types_pb=types_pb)
+    driver.initialize({"token": "abc", "max_retries": "2", "retry_backoff_sec": "0.001"})
+    calls = {"n": 0}
+
+    def _executor(**_kwargs):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise DriverExecutionError(grpc.StatusCode.RESOURCE_EXHAUSTED, "quota exceeded")
+        return {"0": 10}, 0.2, {"provider_profile": "ibm"}
+
+    driver._executor = _executor
+    counts, _, metadata = driver.execute_circuit("ibm:qiskit-runtime", b"{}", 10, {})
+    assert counts == {"0": 10}
+    assert metadata["provider_profile"] == "ibm"
+    assert calls["n"] == 3
+
+
+def test_execute_timeout_surface_deadline() -> None:
+    driver = QiskitRuntimeDriver(types_pb=types_pb)
+    driver.initialize({"token": "abc", "max_retries": "1", "retry_backoff_sec": "0.001", "timeout_sec": "0.001"})
+
+    def _executor(**_kwargs):
+        raise DriverExecutionError(grpc.StatusCode.UNAVAILABLE, "upstream timeout")
+
+    driver._executor = _executor
+    with pytest.raises(DriverExecutionError) as err:
+        driver.execute_circuit("ibm:qiskit-runtime", b"{}", 10, {})
+    assert err.value.code == grpc.StatusCode.DEADLINE_EXCEEDED


### PR DESCRIPTION
## Summary

- Implemented IBM Qiskit Runtime hardening in the driver: added version-pinned defaults for timeout/retry, retry loop with deadline budgeting, retryable-class policy, quota/timeout normalization, and fail-closed behavior when runtime executor is not configured.

- Extended IBM driver tests with execution-path checks: retry-on-quota until success and timeout/deadline surfacing behavior.

- Bumped driver-manager package version from 0.5.0 to 0.6.0 (MINOR, additive behavior).

- Updated driver-manager README with new IBM runtime timeout/retry environment knobs and clarified hardening scope.

- Added IBM-specific incident triage guidance under driver degradation in the runtime-data runbook.

- Added Unreleased changelog entry for P8D-02 with version and scope details.

## Validation

- [ ] Tests added/updated
- [ ] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: Compatibility matrix | Metrics
- **Compatibility**: Breaking (requires MAJOR) - No
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- IBM Qiskit Runtime driver hardening baseline with retry/timeout/quota-aware execution semantics for QDriver v1.0 operations.
- IBM-specific degradation triage section in the runtime-data observability runbook.

### Changed
- `driver-manager` package version bumped to `0.6.0`.
- Qiskit Runtime capability metadata now advertises timeout/retry behavior.

### Fixed
- Provider errors containing quota/rate-limit and timeout signals are normalized into stable retry/taxonomy-aligned classes.