### PR TITLE
Implement issue P8D-05 for API compatibility

### DIFF
--- a/scripts/ci/contract-version-manifest.json
+++ b/scripts/ci/contract-version-manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": "1.5.0",
+  "manifest_version": "1.6.0",
   "artifacts": [
     {
       "path": "proto/eigen/api/v1/device_service.proto",
@@ -64,6 +64,10 @@
     {
       "path": "src/services/system-api/tests/fixtures/contracts/knowledge_base_v1/decision_log_lineage_contract_v1_1_0.json",
       "sha256": "9be0f3b2b20aa71f3f42cfb8d3774c54bb1348b92a5b55c5de18a987b09d18be"
+    },
+    {
+      "path": "src/services/system-api/tests/fixtures/contracts/system_api_rest_v1/parity_matrix_v1_0_0.json",
+      "sha256": "e680c037e80e85a958ea8fbd6c932a629d29ee1854836360c353480cd74a17e6"
     }
   ]
 }

--- a/src/services/system-api/pyproject.toml
+++ b/src/services/system-api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "system-api"
-version = "0.6.0"
+version = "0.7.0"
 description = "Eigen OS system-api (MVP gRPC skeleton)."
 requires-python = ">=3.12"
 dependencies = [

--- a/src/services/system-api/tests/fixtures/contracts/system_api_rest_v1/parity_matrix_v1_0_0.json
+++ b/src/services/system-api/tests/fixtures/contracts/system_api_rest_v1/parity_matrix_v1_0_0.json
@@ -1,0 +1,31 @@
+{
+  "artifact_version": "1.0.0",
+  "updated_at": "2026-05-19",
+  "release_artifacts": {
+    "compatibility_report": "docs/development/phase-8d/phase-8d-compatibility-report.md",
+    "exit_evidence": "docs/development/phase-8d/phase-8d-exit-evidence-bundle.md"
+  },
+  "rest_parity": {
+    "version": "1.0.0",
+    "paths": ["submit", "watch", "results", "cancel"],
+    "required_terminal_states": ["DONE", "ERROR", "CANCELLED", "TIMEOUT"],
+    "watch_monotonic_event_seq": true
+  },
+  "providers": [
+    {
+      "provider": "sim:local",
+      "capabilities": {"submit": true, "watch": true, "results": true, "cancel": true},
+      "status": "ga"
+    },
+    {
+      "provider": "ibm:runtime",
+      "capabilities": {"submit": true, "watch": true, "results": true, "cancel": true},
+      "status": "preview"
+    },
+    {
+      "provider": "aws:braket",
+      "capabilities": {"submit": true, "watch": true, "results": true, "cancel": true},
+      "status": "preview"
+    }
+  ]
+}

--- a/src/services/system-api/tests/test_rest_parity_and_compatibility_matrix.py
+++ b/src/services/system-api/tests/test_rest_parity_and_compatibility_matrix.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import grpc
+
+from system_api.proto_gen import ensure_generated
+
+ensure_generated()
+
+from eigen.api.v1 import job_service_pb2 as job_pb  # noqa: E402
+from eigen.api.v1 import job_service_pb2_grpc as job_pb_grpc  # noqa: E402
+from eigen.api.v1 import types_pb2 as types_pb  # noqa: E402
+
+FIXTURE = (
+    Path(__file__).resolve().parent
+    / "fixtures"
+    / "contracts"
+    / "system_api_rest_v1"
+    / "parity_matrix_v1_0_0.json"
+)
+
+
+def _submit(stub: job_pb_grpc.JobServiceStub, *, target: str = "sim:local") -> str:
+    req = job_pb.SubmitJobRequest(
+        name="phase8d-rest-parity",
+        target=target,
+        eigen_lang=types_pb.EigenLangSource(source=b"fn main() {}\n", entrypoint="main"),
+    )
+    return stub.SubmitJob(req).job_id
+
+
+def _as_rest_status(status) -> dict[str, object]:
+    return {
+        "job_id": status.job_id,
+        "state": types_pb.JobState.Name(status.state).replace("JOB_STATE_", ""),
+        "message": status.message,
+    }
+
+
+def _as_rest_results(results) -> dict[str, object]:
+    return {
+        "job_id": results.job_id,
+        "state": types_pb.JobState.Name(results.state).replace("JOB_STATE_", ""),
+        "counts": dict(results.counts),
+        "metadata": dict(results.metadata),
+    }
+
+
+def test_phase8d_rest_parity_and_compatibility_matrix_fixture(grpc_addr: str) -> None:
+    matrix = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    assert matrix["artifact_version"] == "1.0.0"
+    assert matrix["rest_parity"]["paths"] == ["submit", "watch", "results", "cancel"]
+
+    channel = grpc.insecure_channel(grpc_addr)
+    stub = job_pb_grpc.JobServiceStub(channel)
+
+    # submit + watch + results parity
+    job_id = _submit(stub)
+    updates = [item.update for item in stub.StreamJobUpdates(job_pb.StreamJobUpdatesRequest(job_id=job_id))]
+    seqs = [int(u.event_seq) for u in updates]
+    assert seqs == sorted(seqs)
+    assert len(set(seqs)) == len(seqs)
+
+    status = stub.GetJobStatus(job_pb.GetJobStatusRequest(job_id=job_id)).status
+    rest_status = _as_rest_status(status)
+    assert rest_status["state"] in matrix["rest_parity"]["required_terminal_states"]
+
+    results = stub.GetJobResults(job_pb.GetJobResultsRequest(job_id=job_id))
+    rest_results = _as_rest_results(results)
+    assert rest_results["state"] == "DONE"
+    assert rest_results["counts"]
+
+    # cancel parity
+    cancellable_job_id = _submit(stub, target="emu:real-hifi")
+    cancel = stub.CancelJob(job_pb.CancelJobRequest(job_id=cancellable_job_id))
+    assert cancel.accepted is True
+    cancel_status = stub.GetJobStatus(job_pb.GetJobStatusRequest(job_id=cancellable_job_id)).status
+    rest_cancel = _as_rest_status(cancel_status)
+    assert rest_cancel["state"] == "CANCELLED"
+    


### PR DESCRIPTION
## Summary

- Added a Phase-8D versioned compatibility matrix artifact for System API REST parity (submit/watch/results/cancel) and provider capability publication.

- Added a new parity test that validates submit/watch/results/cancel behavior against the versioned fixture.

- Wired the new artifact into contract drift governance (check-contract-drift.py manifest) so undocumented contract drift fails CI.

- Bumped system-api version to 0.7.0 for a backward-compatible addition.

## Validation

- [x] Tests added/updated
- [ ] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: Compatibility matrix | Metrics 
- **Compatibility**: Breaking (requires MAJOR) - no
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Added `system_api_rest_v1/parity_matrix_v1_0_0.json` as a versioned compatibility matrix artifact for submit/watch/results/cancel REST parity.
- Added `test_rest_parity_and_compatibility_matrix.py` to enforce parity and compatibility fixture coverage.

### Changed
- Updated `scripts/ci/contract-version-manifest.json` to include the new contract artifact and bumped manifest version to `1.6.0`.
- Bumped `system-api` package version to `0.7.0`.

### Fixed
- None.