### PR TITLE
Implement full PDP enforcement as per documentation

### DIFF
--- a/src/services/system-api/src/system_api/grpc_impl.py
+++ b/src/services/system-api/src/system_api/grpc_impl.py
@@ -23,7 +23,7 @@ from .lifecycle import apply_signal
 from .scheduling import resolve_dag
 from .observability import log_request_end, log_request_start, new_request_context
 from .qfs_store import QFS_STORE
-from .security import enforce_authn, enforce_authz
+from .security import auth_context, enforce_authn, enforce_authz
 from .validation import (
     validate_device_id,
     validate_job_id,
@@ -101,6 +101,8 @@ class _JobRecord:
     batch_manifest_ref: str
     batch_id: str
     queue_delay_sec: float
+    owner_subject: str
+    owner_tenant: str
 
 
 @dataclass
@@ -546,7 +548,16 @@ class JobService:
         else:
             self._store_timeline(record)
 
-    def _build_job_record(self, request, *, job_id: str, created_at: Timestamp, trace_id: str | None) -> _JobRecord:
+    def _build_job_record(
+        self,
+        request,
+        *,
+        job_id: str,
+        created_at: Timestamp,
+        trace_id: str | None,
+        owner_subject: str,
+        owner_tenant: str,
+    ) -> _JobRecord:
         metadata = dict(request.metadata)
         created_at_dt = created_at.ToDatetime().replace(tzinfo=timezone.utc)
         attempt = 1
@@ -739,6 +750,8 @@ class JobService:
             batch_manifest_ref="",
             batch_id="",
             queue_delay_sec=0.0,
+            owner_subject=owner_subject,
+            owner_tenant=owner_tenant,
         )
         self._provision_temporary_artifacts(record)
         QFS_STORE.atomic_write_bytes(
@@ -893,6 +906,16 @@ class JobService:
         if not record.batch_id:
             self._assign_single_dispatch_delay(record)
 
+    def _enforce_job_access(self, *, context: grpc.ServicerContext, record: _JobRecord) -> None:
+        subject, roles, tenant = auth_context(context)
+        if "*" in roles or "admin" in roles:
+            return
+        if tenant != record.owner_tenant:
+            context.abort(
+                grpc.StatusCode.PERMISSION_DENIED,
+                "POLICY_DENY_TENANT_MISMATCH: cross-tenant access denied",
+            )
+
     def SubmitJob(self, request, context: grpc.ServicerContext):
         enforce_authn(context, method_name="JobService.SubmitJob")
         enforce_authz(context, required_permission="jobs:submit")
@@ -943,7 +966,15 @@ class JobService:
             rc.job_id = job_id
             now = _ts_now()
             trace_id = rc.trace_id or request.metadata.get("trace_id", "").strip() or None
-            record = self._build_job_record(request, job_id=job_id, created_at=now, trace_id=trace_id)
+            owner_subject, _, owner_tenant = auth_context(context)
+            record = self._build_job_record(
+                request,
+                job_id=job_id,
+                created_at=now,
+                trace_id=trace_id,
+                owner_subject=owner_subject,
+                owner_tenant=owner_tenant,
+            )
             self._jobs[job_id] = record
             self._assign_scheduler_slot(record)
             if idem_key:
@@ -985,6 +1016,7 @@ class JobService:
         if record is None:
             context.abort(grpc.StatusCode.NOT_FOUND, f"job_id not found: {request.job_id}")
         with self._lock:
+            self._enforce_job_access(context=context, record=record)
             self._advance_job(record)
             latest = record.updates[-1]
         created_at = record.created_at
@@ -1024,6 +1056,7 @@ class JobService:
             record = self._jobs.get(request.job_id)
             if record is None:
                 context.abort(grpc.StatusCode.NOT_FOUND, f"job_id not found: {request.job_id}")
+            self._enforce_job_access(context=context, record=record)
             self._advance_job(record)
             terminal_values = {getattr(self._types_pb, name) for name in TERMINAL_JOB_STATES}
             decision = apply_signal(
@@ -1058,6 +1091,7 @@ class JobService:
                 record = self._jobs.get(request.job_id)
                 if record is None:
                     context.abort(grpc.StatusCode.NOT_FOUND, f"job_id not found: {request.job_id}")
+                self._enforce_job_access(context=context, record=record)
                 self._advance_job(record)
                 selected_updates = list(record.updates)
                 done = selected_updates[-1].state in terminal_values
@@ -1091,6 +1125,7 @@ class JobService:
         with self._lock:
             record = self._jobs.get(request.job_id)
             if record is not None:
+                self._enforce_job_access(context=context, record=record)
                 self._advance_job(record)
 
         if record is None:
@@ -1152,6 +1187,7 @@ class JobService:
                     domain="eigen.api.v1.explain",
                     metadata={"job_id": request.job_id},
                 )
+            self._enforce_job_access(context=context, record=record)
             self._advance_job(record)
             rationale = dict(record.dispatch_rationale)
             attrs = dict(rationale["attributes"])

--- a/src/services/system-api/src/system_api/security.py
+++ b/src/services/system-api/src/system_api/security.py
@@ -145,10 +145,27 @@ def enforce_authz(context: grpc.ServicerContext, *, required_permission: str) ->
     scope, _, action = need.partition(":")
     wildcard = f"{scope}:*"
 
+    subject, _, tenant = auth_context(context)
+    if not subject.strip() or not tenant.strip():
+        log_authz_denied(
+            method=getattr(context, "_rpc_event_call_details", None).method if hasattr(context, "_rpc_event_call_details") else "unknown",
+            subject=subject or "unknown",
+            permission="POLICY_DENY_MISSING_AUTH_CONTEXT",
+        )
+        context.abort(
+            grpc.StatusCode.PERMISSION_DENIED,
+            "POLICY_DENY_MISSING_AUTH_CONTEXT: subject and tenant are required",
+        )
+
     if need in granted or wildcard in granted or "*" in granted:
         return
 
+    log_authz_denied(
+        method=getattr(context, "_rpc_event_call_details", None).method if hasattr(context, "_rpc_event_call_details") else "unknown",
+        subject=subject,
+        permission=f"POLICY_DENY_PERMISSION_REQUIRED:{need}",
+    )
     context.abort(
         grpc.StatusCode.PERMISSION_DENIED,
-        f"permission denied: requires {required_permission}",
+        f"POLICY_DENY_PERMISSION_REQUIRED: requires {required_permission}",
     )

--- a/src/services/system-api/tests/test_security_baseline.py
+++ b/src/services/system-api/tests/test_security_baseline.py
@@ -159,3 +159,56 @@ def test_metrics_include_authz_denied_counter(monkeypatch: pytest.MonkeyPatch) -
     finally:
         server.stop(grace=None)
         metrics_server.shutdown()
+
+def test_static_token_mode_fails_closed_on_missing_auth_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SYSTEM_API_AUTH_MODE", "static_token")
+    monkeypatch.setenv("SYSTEM_API_AUTH_TOKEN", "ctx-token")
+    monkeypatch.setenv("SYSTEM_API_AUTH_ROLES", "admin")
+    monkeypatch.setenv("SYSTEM_API_AUTH_SUBJECT", "")
+    monkeypatch.setenv("SYSTEM_API_AUTH_TENANT", "")
+
+    addr = f"127.0.0.1:{_free_port()}"
+    server = serve(bind=addr)
+    time.sleep(0.05)
+    try:
+        channel = grpc.insecure_channel(addr)
+        stub = dev_pb_grpc.DeviceServiceStub(channel)
+        with pytest.raises(grpc.RpcError) as exc:
+            stub.ListDevices(
+                dev_pb.ListDevicesRequest(),
+                metadata=(("authorization", "Bearer ctx-token"),),
+            )
+        assert exc.value.code() == grpc.StatusCode.PERMISSION_DENIED
+        assert "POLICY_DENY_MISSING_AUTH_CONTEXT" in exc.value.details()
+    finally:
+        server.stop(grace=None)
+
+
+def test_cross_tenant_access_denied(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SYSTEM_API_AUTH_MODE", "static_token")
+    monkeypatch.setenv("SYSTEM_API_AUTH_TOKEN", "tenant-token")
+    monkeypatch.setenv("SYSTEM_API_AUTH_ROLES", "user")
+    monkeypatch.setenv("SYSTEM_API_AUTH_SUBJECT", "alice")
+    monkeypatch.setenv("SYSTEM_API_AUTH_TENANT", "tenant-a")
+    addr = f"127.0.0.1:{_free_port()}"
+    server = serve(bind=addr)
+    time.sleep(0.05)
+    try:
+        channel = grpc.insecure_channel(addr)
+        job_stub = job_pb_grpc.JobServiceStub(channel)
+        md = (("authorization", "Bearer tenant-token"),)
+        submitted = job_stub.SubmitJob(
+            job_pb.SubmitJobRequest(
+                name="tenant-owned",
+                target="sim:local",
+                eigen_lang=types_pb.EigenLangSource(source=b"def main():\n    return 0", entrypoint="main"),
+            ),
+            metadata=md,
+        )
+        monkeypatch.setenv("SYSTEM_API_AUTH_TENANT", "tenant-b")
+        with pytest.raises(grpc.RpcError) as exc:
+            job_stub.GetJobStatus(job_pb.GetJobStatusRequest(job_id=submitted.job_id), metadata=md)
+        assert exc.value.code() == grpc.StatusCode.PERMISSION_DENIED
+        assert "POLICY_DENY_TENANT_MISMATCH" in exc.value.details()
+    finally:
+        server.stop(grace=None)


### PR DESCRIPTION
## Summary

- Implemented fail-closed PDP behavior in System API authz: if authorization context is incomplete (missing subject or tenant), requests are denied with a stable reason code POLICY_DENY_MISSING_AUTH_CONTEXT, and deny events are audited via log_authz_denied.

- Standardized permission-denied responses to policy reason-coded format (POLICY_DENY_PERMISSION_REQUIRED) and added explicit deny audit logging for insufficient permissions.

- Added tenant ownership to job records and enforced cross-tenant access denial on critical job query/control paths (GetJobStatus, CancelJob, StreamJobUpdates, GetJobResults, GetDispatchRationale) with stable deny reason code POLICY_DENY_TENANT_MISMATCH.

- Bound job ownership at submit-time from auth context (owner_subject, owner_tenant) and persisted it in the job record so downstream enforcement is deterministic.

- Added negative conformance tests for:

    - fail-closed behavior on missing auth context in static-token mode;

    - unauthorized cross-tenant job status access denial.

## Validation

- [ ] Tests added/updated
- [ ] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: CLI payloads | Plugin envelopes | Compatibility matrix | JobSpec | AQO | QFS | Metrics
- **Compatibility**: Breaking requires
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Fail-closed PDP deny path for missing authorization context (`subject`/`tenant`) with stable reason code.
- Negative conformance coverage for cross-tenant unauthorized access.

### Changed
- Permission deny responses now use standardized `POLICY_DENY_*` reason-coded messages.
- Job query/control paths now enforce tenant ownership for non-admin callers.

### Fixed
- Inconsistent authorization enforcement across critical job runtime edges.