### PR TITLE
Implement secret lifecycle management

### DIFF
--- a/src/services/driver-manager/README.md
+++ b/src/services/driver-manager/README.md
@@ -39,6 +39,27 @@ export DRIVER_MANAGER_SECRETS_JSON='{"ibm/runtime/token":"<your-token>"}'
 python -m driver_manager.main
 ```
 
+Lifecycle-aware secret envelope (Stage-9A):
+
+```json
+{
+  "ibm/runtime/token": {
+    "value": "<your-token>",
+    "state": "issued",
+    "issued_at": "2026-05-20T00:00:00Z",
+    "expires_at": "2026-06-20T00:00:00Z"
+  },
+  "aws/braket/credentials": {
+    "value": {"access_key_id": "<id>", "secret_access_key": "<secret>"},
+    "state": "rotated",
+    "issued_at": "2026-05-01T00:00:00Z",
+    "rotated_at": "2026-05-20T00:00:00Z"
+  }
+}
+```
+
+`state=revoked` or expired `expires_at` entries are denied during retrieval and emitted as audit events (`secret_lifecycle_event`).
+
 ## Tests
 
 ```bash

--- a/src/services/driver-manager/src/driver_manager/aws_braket_driver.py
+++ b/src/services/driver-manager/src/driver_manager/aws_braket_driver.py
@@ -11,6 +11,7 @@ import grpc
 
 from .base_driver import DeviceStatusInfo, DriverCapabilities, DriverHealth
 from .simulator_driver import DriverExecutionError
+from .secret_lifecycle import SecretLifecycleStore
 
 
 @dataclass(frozen=True)
@@ -147,13 +148,8 @@ class AwsBraketDriver:
 
         secret_ref = config.get("credentials_secret_ref", "").strip()
         if secret_ref:
-            secrets_blob = os.getenv("DRIVER_MANAGER_SECRETS_JSON", "{}")
-            try:
-                secrets = json.loads(secrets_blob)
-            except json.JSONDecodeError as exc:
-                self._init_error = "DRIVER_MANAGER_SECRETS_JSON must be valid JSON object"
-                raise ValueError(self._init_error) from exc
-            raw = secrets.get(secret_ref, {})
+            secrets = SecretLifecycleStore()
+            raw = secrets.get(secret_ref, actor=self.name, workload_id=config.get("workload_id", "driver-init"), consumer=self.name)
             if isinstance(raw, dict):
                 access_key_id = str(raw.get("access_key_id", "")).strip()
                 secret_access_key = str(raw.get("secret_access_key", "")).strip()

--- a/src/services/driver-manager/src/driver_manager/qiskit_runtime_driver.py
+++ b/src/services/driver-manager/src/driver_manager/qiskit_runtime_driver.py
@@ -11,6 +11,7 @@ import grpc
 
 from .base_driver import DeviceStatusInfo, DriverCapabilities, DriverHealth
 from .simulator_driver import DriverExecutionError
+from .secret_lifecycle import SecretLifecycleStore
 
 
 @dataclass(frozen=True)
@@ -155,13 +156,8 @@ class QiskitRuntimeDriver:
 
         token_secret_ref = config.get("token_secret_ref", "").strip()
         if token_secret_ref:
-            secrets_blob = os.getenv("DRIVER_MANAGER_SECRETS_JSON", "{}")
-            try:
-                secrets = json.loads(secrets_blob)
-            except json.JSONDecodeError as exc:
-                self._init_error = "DRIVER_MANAGER_SECRETS_JSON must be valid JSON object"
-                raise ValueError(self._init_error) from exc
-            token = str(secrets.get(token_secret_ref, "")).strip()
+            secrets = SecretLifecycleStore()
+            token = str(secrets.get(token_secret_ref, actor=self.name, workload_id=config.get("workload_id", "driver-init"), consumer=self.name)).strip()
             if token:
                 return _AuthConfig(source=f"secret_ref:{token_secret_ref}", token=token)
             self._init_error = f"missing token for secret ref '{token_secret_ref}'"

--- a/src/services/driver-manager/src/driver_manager/secret_lifecycle.py
+++ b/src/services/driver-manager/src/driver_manager/secret_lifecycle.py
@@ -1,0 +1,117 @@
+"""Secret lifecycle state, retrieval, and audit event wiring for driver-manager."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+import logging
+import os
+import threading
+from typing import Any
+
+
+_AUDIT_LOG = logging.getLogger("driver_manager.secret_audit")
+
+
+@dataclass(frozen=True)
+class SecretRecord:
+    value: Any
+    state: str
+    issued_at: datetime
+    rotated_at: datetime | None = None
+    revoked_at: datetime | None = None
+    expires_at: datetime | None = None
+
+
+class SecretLifecycleStore:
+    """In-memory lifecycle view over DRIVER_MANAGER_SECRETS_JSON with audit traces."""
+
+    _ACTIVE_STATES = {"issued", "rotated"}
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._records: dict[str, SecretRecord] = {}
+        self._load_from_env()
+
+    def _load_from_env(self) -> None:
+        raw = os.getenv("DRIVER_MANAGER_SECRETS_JSON", "{}")
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError("DRIVER_MANAGER_SECRETS_JSON must be valid JSON object") from exc
+        if not isinstance(data, dict):
+            raise ValueError("DRIVER_MANAGER_SECRETS_JSON must be valid JSON object")
+
+        now = _utcnow()
+        with self._lock:
+            self._records = {}
+            for ref, payload in data.items():
+                rec = self._normalize_record(payload=payload, now=now)
+                self._records[str(ref)] = rec
+
+    def _normalize_record(self, payload: Any, now: datetime) -> SecretRecord:
+        if isinstance(payload, dict) and "value" in payload:
+            state = str(payload.get("state", "issued")).strip().lower() or "issued"
+            expires_at = _parse_dt(payload.get("expires_at"))
+            return SecretRecord(
+                value=payload.get("value"),
+                state=state,
+                issued_at=_parse_dt(payload.get("issued_at")) or now,
+                rotated_at=_parse_dt(payload.get("rotated_at")),
+                revoked_at=_parse_dt(payload.get("revoked_at")),
+                expires_at=expires_at,
+            )
+        return SecretRecord(value=payload, state="issued", issued_at=now)
+
+    def get(self, secret_ref: str, *, actor: str, workload_id: str, consumer: str) -> Any:
+        now = _utcnow()
+        with self._lock:
+            record = self._records.get(secret_ref)
+
+        if record is None:
+            self._emit("lookup_denied", secret_ref, actor, workload_id, consumer, "not_found")
+            raise ValueError(f"missing secret for ref '{secret_ref}'")
+
+        if record.expires_at and now >= record.expires_at:
+            self._emit("expire", secret_ref, actor, workload_id, consumer, "expired")
+            raise ValueError(f"expired secret for ref '{secret_ref}'")
+
+        if record.state == "revoked":
+            self._emit("revoke", secret_ref, actor, workload_id, consumer, "revoked")
+            raise ValueError(f"revoked secret for ref '{secret_ref}'")
+
+        if record.state not in self._ACTIVE_STATES:
+            self._emit("lookup_denied", secret_ref, actor, workload_id, consumer, f"invalid_state:{record.state}")
+            raise ValueError(f"inactive secret for ref '{secret_ref}'")
+
+        action = "issue" if record.state == "issued" else "rotate"
+        self._emit(action, secret_ref, actor, workload_id, consumer, "ok")
+        return record.value
+
+    def _emit(self, event: str, secret_ref: str, actor: str, workload_id: str, consumer: str, outcome: str) -> None:
+        _AUDIT_LOG.info(
+            "secret_lifecycle_event",
+            extra={
+                "event": event,
+                "secret_ref": secret_ref,
+                "actor": actor,
+                "workload_id": workload_id,
+                "consumer": consumer,
+                "outcome": outcome,
+                "ts": _utcnow().isoformat(),
+            },
+        )
+
+
+def _parse_dt(raw: Any) -> datetime | None:
+    if raw in (None, ""):
+        return None
+    val = str(raw)
+    if val.endswith("Z"):
+        val = val[:-1] + "+00:00"
+    return datetime.fromisoformat(val).astimezone(timezone.utc)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)

--- a/src/services/driver-manager/tests/test_secret_lifecycle.py
+++ b/src/services/driver-manager/tests/test_secret_lifecycle.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from driver_manager.secret_lifecycle import SecretLifecycleStore
+
+
+def test_secret_lifecycle_issued_and_rotated(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "DRIVER_MANAGER_SECRETS_JSON",
+        '{"a":{"value":"x","state":"issued"},"b":{"value":"y","state":"rotated"}}',
+    )
+    store = SecretLifecycleStore()
+    assert store.get("a", actor="runtime", workload_id="job-1", consumer="qiskit") == "x"
+    assert store.get("b", actor="runtime", workload_id="job-1", consumer="aws") == "y"
+
+
+def test_secret_lifecycle_revoked_or_expired_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "DRIVER_MANAGER_SECRETS_JSON",
+        '{"rev":{"value":"x","state":"revoked"},"exp":{"value":"x","state":"issued","expires_at":"2000-01-01T00:00:00Z"}}',
+    )
+    store = SecretLifecycleStore()
+    with pytest.raises(ValueError, match="revoked secret"):
+        store.get("rev", actor="runtime", workload_id="job-1", consumer="aws")
+    with pytest.raises(ValueError, match="expired secret"):
+        store.get("exp", actor="runtime", workload_id="job-1", consumer="aws")


### PR DESCRIPTION
## Summary

- Implemented a full secret lifecycle subsystem for driver-manager with explicit lifecycle states and fail-closed retrieval behavior:

    - Supported states for retrieval decisions: issued, rotated, revoked, and expired (via expires_at).

    - Added structured event emission (secret_lifecycle_event) with actor/workload/consumer context for auditable traces.

- Wired both runtime driver auth paths to use lifecycle-aware retrieval for secret refs:

    - Qiskit Runtime token_secret_ref now goes through lifecycle enforcement.

    - AWS Braket credentials_secret_ref now goes through lifecycle enforcement.
    This blocks revoked/expired credentials during initialization as required.

- Added tests for lifecycle behavior (allow for issued/rotated and deny for revoked/expired).

- Updated driver-manager docs with the lifecycle-aware secret envelope format and behavior notes for revoked/expired secrets and audit events.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: Plugin envelopes | Compatibility matrix | Metrics
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Secret lifecycle store with `issued/rotated/revoked/expired` evaluation and structured audit events for secret retrieval decisions.
- Lifecycle-focused tests for allow/deny secret resolution paths.

### Changed
- Qiskit Runtime and AWS Braket drivers now resolve `*_secret_ref` credentials through lifecycle-aware policy checks.

### Fixed
- Revoked and expired secret refs are now deterministically denied during driver auth resolution.