### PR TITLE
Implement canary rollout with auto-rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Before `1.0.0`, breaking changes may occur in minor versions. After `1.0.0`, bre
 
 ### Added
 
+- Phase-9B P9B-06 canary rollout + auto-rollback safety pack (`benchmark-service` package `0.11.0`) with deterministic canary cohort/window policy fields, auditable stable canary reason codes, and automatic rollback envelopes that pin stable target model version and 15-minute restore SLO metadata.
 - Phase-8D P8D-06 developer surfaces skeleton pack (`governance-docs` package `0.13.0`) with non-GA bootstrap artifacts for web dashboard, VS Code, and Jupyter surfaces, simulator walkthrough docs, and explicit System API parity alignment constraints.
 - Phase-8D P8D-07 operator rollback governance pack (`driver-manager` package `0.8.0`) with official-provider runbooks for outage/degradation/auth/quota incidents, deterministic rollback controls (adapter pin/quarantine/matrix demotion), and fixture-tested rollback-safety rehearsal checks for simulator/IBM/AWS.
 - Phase-8D P8D-02 IBM Quantum official driver hardening (`driver-manager` package `0.6.0`) with version-pinned adapter defaults, retry/timeout/quota-aware execution policy aligned with QDriver v1.0 taxonomy, IBM-focused driver tests, and IBM degradation response guidance in the runtime-data runbook.

--- a/docs/development/phase-9b/p9b-06-canary-rollout-auto-rollback-on-regression.md
+++ b/docs/development/phase-9b/p9b-06-canary-rollout-auto-rollback-on-regression.md
@@ -1,0 +1,24 @@
+# P9B-06 — Canary Rollout + Auto-Rollback on Regression
+
+## Implemented contract updates
+
+- `optimizer_evaluation` contract advanced to `1.5.0`.
+- Continuous learning pipeline policy advanced to `1.4.0`.
+- Canary policy now carries deterministic cohort and window fields:
+  - `canary.cohort.dimension`
+  - `canary.cohort.value`
+  - `canary.evaluation_window_minutes`
+- Canary outcomes are auditable with stable reason codes:
+  - `CANARY_PROMOTION_APPROVED`
+  - `CANARY_REGRESSION_VS_BASELINE_HEURISTIC`
+  - `CANARY_INSUFFICIENT_SHADOW_SAMPLES`
+- Auto-rollback now includes deterministic operational targets:
+  - rollback `target_model_version`
+  - rollback SLO (`slo_minutes=15`)
+  - runbook reference for execution evidence.
+
+## CI and release expectations
+
+- Canary/rollback contract fields are fixture-covered by benchmark-service unit tests.
+- Phase-9B gates must fail closed when canary reason codes indicate regression or insufficient evidence.
+- Release evidence must include one rollback drill proving recovery within the SLO window.

--- a/src/services/benchmark-service/pyproject.toml
+++ b/src/services/benchmark-service/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "benchmark-service"
-version = "0.10.1"
+version = "0.11.0"
 description = "Eigen OS benchmark-service core run lifecycle contracts."
 requires-python = ">=3.12"
 dependencies = []

--- a/src/services/benchmark-service/src/benchmark_service/optimizer_evaluation.py
+++ b/src/services/benchmark-service/src/benchmark_service/optimizer_evaluation.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from .compare_api import BenchmarkCompareApi
 
-OPTIMIZER_EVAL_CONTRACT_VERSION = "1.4.0"
+OPTIMIZER_EVAL_CONTRACT_VERSION = "1.5.0"
 OPTIMIZER_BASELINE_VERSION = "1.0.0"
 
 
@@ -143,9 +143,12 @@ class OptimizerEvaluationHarness:
             "offline_bundle": offline,
         }
 
-LEARNING_PIPELINE_POLICY_VERSION = "1.3.0"
+LEARNING_PIPELINE_POLICY_VERSION = "1.4.0"
 DEFAULT_TRIGGER_CIRCUITS = 1000
-ROLLBACK_RUNBOOK_REF = "docs/howto/intelligent-runtime-observability-runbook.md"
+ROLLBACK_RUNBOOK_REF = "docs/howto/intelligent-runtime-observability-runbook.md#rollback-decision-trace"
+DEFAULT_CANARY_EVALUATION_WINDOW_MINUTES = 30
+DEFAULT_CANARY_COHORT = "backend_class"
+AUTO_ROLLBACK_SLO_MINUTES = 15
 
 
 class ContinuousLearningPipeline:
@@ -235,6 +238,16 @@ class ContinuousLearningPipeline:
             "eval_report": f"sha256:{self._sha256_digest({'artifact_version': artifact_version, 'kind': 'eval_report'})}",
         }
 
+        canary_policy = fixture.get("canary_policy", {})
+        cohort_dimension = str(canary_policy.get("cohort_dimension", DEFAULT_CANARY_COHORT))
+        cohort_value = str(
+            canary_policy.get("cohort_value")
+            or fixture.get("cohort_filters", {}).get(cohort_dimension, "default")
+        )
+        evaluation_window_minutes = int(
+            canary_policy.get("evaluation_window_minutes", DEFAULT_CANARY_EVALUATION_WINDOW_MINUTES)
+        )
+
         artifact = {
             "artifact_version": artifact_version,
             "registry_entry_id": f"model-{artifact_version}",
@@ -259,20 +272,20 @@ class ContinuousLearningPipeline:
         }
 
         promotion = self._harness.evaluate_shadow(fixture)
+        canary_decision = "PROMOTE" if promotion["recommendation"] == "PROMOTE" else "ROLLBACK"
+        canary_reason_codes = [f"CANARY_{reason}" for reason in promotion["gate_reasons"]]
+        if canary_decision == "PROMOTE":
+            canary_reason_codes = ["CANARY_PROMOTION_APPROVED"]
 
         rollback = None
-        if promotion["recommendation"] != "PROMOTE":
-            rollback_reasons = [
-                f"CANARY_{reason}"
-                for reason in promotion["gate_reasons"]
-                if reason in {"REGRESSION_VS_BASELINE_HEURISTIC", "INSUFFICIENT_SHADOW_SAMPLES"}
-            ]
-            if rollback_reasons:
-                rollback = {
-                    "action": "ROLLBACK_TO_STABLE",
-                    "reason_codes": sorted(rollback_reasons),
-                    "runbook_ref": ROLLBACK_RUNBOOK_REF,
-                }
+        if canary_decision == "ROLLBACK":
+            rollback = {
+                "action": "ROLLBACK_TO_STABLE",
+                "reason_codes": sorted(canary_reason_codes),
+                "runbook_ref": ROLLBACK_RUNBOOK_REF,
+                "target_model_version": str(fixture.get("stable_model_version", "phase8c-stable-previous")),
+                "slo_minutes": AUTO_ROLLBACK_SLO_MINUTES,
+            }
 
         audit_events.append(
             {
@@ -304,6 +317,16 @@ class ContinuousLearningPipeline:
             "audit_events": audit_events,
             "artifact": artifact,
             "promotion": promotion,
+            "canary": {
+                "cohort": {
+                    "dimension": cohort_dimension,
+                    "value": cohort_value,
+                },
+                "evaluation_window_minutes": evaluation_window_minutes,
+                "decision": canary_decision,
+                "reason_codes": sorted(canary_reason_codes),
+                "auto_rollback_slo_minutes": AUTO_ROLLBACK_SLO_MINUTES,
+            },
             "rollback": rollback,
         }
 

--- a/src/services/benchmark-service/tests/fixtures/optimizer_evaluation/offline_online_fixture.json
+++ b/src/services/benchmark-service/tests/fixtures/optimizer_evaluation/offline_online_fixture.json
@@ -41,7 +41,7 @@
   "candidate_snapshot": {
     "run_id": "candidate-frozen-001",
     "metrics": [
-       {
+      {
         "name": "latency_ms",
         "mean": 103.0,
         "stddev": 2.0,
@@ -71,5 +71,11 @@
     "new_circuit_threshold": 1000
   },
   "observed_new_circuits": 1000,
-  "artifact_version": "phase8c-candidate-0007"
+  "artifact_version": "phase8c-candidate-0007",
+  "canary_policy": {
+    "cohort_dimension": "backend_class",
+    "cohort_value": "simulator",
+    "evaluation_window_minutes": 45
+  },
+  "stable_model_version": "phase8c-stable-0006"
 }

--- a/src/services/benchmark-service/tests/test_optimizer_evaluation_harness.py
+++ b/src/services/benchmark-service/tests/test_optimizer_evaluation_harness.py
@@ -24,7 +24,7 @@ def test_offline_harness_is_reproducible_for_frozen_fixture() -> None:
 
     assert first == second
     assert first["comparison"]["summary"]["has_regression"] is True
-    assert first["contract_version"] == "1.4.0"
+    assert first["contract_version"] == "1.5.0"
     assert first["quality_signal"]["schema_version"] == "1.0.0"
     assert first["quality_signal"]["swap_count"] == 2
     assert "confidence" in first["quality_signal"]
@@ -56,6 +56,12 @@ def test_pipeline_generates_artifact_and_rollback_reason_codes_when_regression_d
     assert result["rollback"]["action"] == "ROLLBACK_TO_STABLE"
     assert result["audit_events"][0]["event_type"] == "RETRAIN_TRIGGER_EVALUATED"
     assert result["audit_events"][1]["linked_model_version"] == "phase8c-candidate-0007"
+    assert result["canary"]["cohort"]["dimension"] == "backend_class"
+    assert result["canary"]["cohort"]["value"] == "simulator"
+    assert result["canary"]["evaluation_window_minutes"] == 45
+    assert result["canary"]["decision"] == "ROLLBACK"
+    assert result["rollback"]["target_model_version"] == "phase8c-stable-0006"
+    assert result["rollback"]["slo_minutes"] == 15
     assert result["rollback"]["reason_codes"] == [
         "CANARY_INSUFFICIENT_SHADOW_SAMPLES",
         "CANARY_REGRESSION_VS_BASELINE_HEURISTIC",


### PR DESCRIPTION
## Summary

- Implemented P9B-06 canary rollout + auto-rollback in the continuous learning pipeline with deterministic canary policy fields (cohort.dimension, cohort.value, evaluation_window_minutes), explicit canary decision (PROMOTE/ROLLBACK), stable reason codes, and auto-rollback SLO metadata (15 minutes) plus rollback target model version.

- Upgraded contract/policy versions for this additive behavior:

    - OPTIMIZER_EVAL_CONTRACT_VERSION: 1.4.0 → 1.5.0

    - LEARNING_PIPELINE_POLICY_VERSION: 1.3.0 → 1.4.0

    - benchmark-service package: 0.10.1 → 0.11.0.

- Extended test fixture and unit tests to validate the new canary/rollback contract fields and reason-code behavior.

- Added dedicated Phase-9B implementation doc for P9B-06 and added release note entry in CHANGELOG.md.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: Compatibility matrix | Metrics
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Phase-9B P9B-06 canary rollout/auto-rollback safety envelope in benchmark-service with deterministic canary cohort/window policy, auditable reason codes, and rollback target+SLO metadata.

### Changed
- optimizer_evaluation contract bumped to 1.5.0 and continuous-learning policy bumped to 1.4.0.
- benchmark-service package version bumped to 0.11.0.

### Fixed
- Deterministic rollback decision payload now always carries stable reason-code taxonomy and explicit rollback execution metadata.