### PR TITLE
Core Tenant Envelope + Baseline Quotas Contract

### DIFF
--- a/docs/development/phase-9c/phase-9c-core-tenant-envelope-baseline-quotas.md
+++ b/docs/development/phase-9c/phase-9c-core-tenant-envelope-baseline-quotas.md
@@ -1,0 +1,42 @@
+# P9C-01 — Core Tenant Envelope + Baseline Quotas Contract
+
+## Contract version
+
+- Tenant envelope contract: `1.0.0`.
+- Public gRPC `SubmitJobRequest` now includes `tenant` envelope (`SubmitJobRequest.TenantQuotaEnvelope`).
+
+## Canonical fields
+
+- `tenant.contract_version` — SemVer marker for envelope contract.
+- `tenant.tenant_id` — canonical tenant id.
+- `tenant.project_id` — canonical project id.
+- `tenant.tenant_max_queued_jobs` — baseline tenant queued-job quota.
+- `tenant.project_max_queued_jobs` — baseline project queued-job quota.
+
+## Deterministic defaults
+
+When tenant metadata is missing:
+
+- `tenant_id` defaults to authenticated tenant from auth context, otherwise `tenant-default`.
+- `project_id` defaults to `project-default`.
+- `tenant_max_queued_jobs` defaults to `EIGEN_SCHED_TENANT_QUOTA_MAX_QUEUED` or `16`.
+- `project_max_queued_jobs` defaults to `EIGEN_SCHED_PROJECT_QUOTA_MAX_QUEUED` or `8`.
+
+## Kernel-path quota reason codes
+
+Scheduler path emits deterministic quota reason codes:
+
+- `TARGET_QUOTA_DELAY`
+- `TENANT_BASELINE_QUOTA_DELAY`
+- `PROJECT_BASELINE_QUOTA_DELAY`
+
+Additional deterministic attributes:
+
+- `tenant_quota_state`
+- `project_quota_state`
+
+## Migration notes
+
+- This is a backward-compatible additive change.
+- Existing clients without `tenant` envelope remain valid and receive deterministic defaults.
+- No wire-level field removals or renames.

--- a/proto/eigen/api/v1/job_service.proto
+++ b/proto/eigen/api/v1/job_service.proto
@@ -18,6 +18,19 @@ service JobService {
 }
 
 message SubmitJobRequest {
+  message TenantQuotaEnvelope {
+    // Contract SemVer for tenant envelope.
+    string contract_version = 1;
+    // Canonical tenant scope. If omitted server defaults to "tenant-default".
+    string tenant_id = 2;
+    // Canonical project scope inside tenant. If omitted server defaults to "project-default".
+    string project_id = 3;
+    // Baseline per-tenant concurrent queued jobs (0 => server default policy).
+    uint32 tenant_max_queued_jobs = 4;
+    // Baseline per-project concurrent queued jobs (0 => server default policy).
+    uint32 project_max_queued_jobs = 5;
+  }
+
   string name = 1;
 
   oneof program {
@@ -35,6 +48,7 @@ message SubmitJobRequest {
   map<string, string> compiler_options = 7;
   map<string, string> metadata = 8;
   repeated string dependencies = 9;
+  TenantQuotaEnvelope tenant = 10;
 }
 
 message SubmitJobResponse {

--- a/src/services/system-api/src/system_api/grpc_impl.py
+++ b/src/services/system-api/src/system_api/grpc_impl.py
@@ -40,6 +40,7 @@ TERMINAL_JOB_STATES = {
 
 TOPOLOGY_CONTRACT_VERSION = "1.1.0"
 TOPOLOGY_LINEAGE_VERSION = "1.1.0"
+TENANT_ENVELOPE_CONTRACT_VERSION = "1.0.0"
 
 
 def _ts_now() -> Timestamp:
@@ -103,6 +104,9 @@ class _JobRecord:
     queue_delay_sec: float
     owner_subject: str
     owner_tenant: str
+    owner_project: str
+    tenant_quota_limit: int
+    project_quota_limit: int
 
 
 @dataclass
@@ -559,6 +563,11 @@ class JobService:
         owner_tenant: str,
     ) -> _JobRecord:
         metadata = dict(request.metadata)
+        tenant_envelope = request.tenant
+        tenant_id = (tenant_envelope.tenant_id or metadata.get("tenant_id") or owner_tenant or "tenant-default").strip() or "tenant-default"
+        project_id = (tenant_envelope.project_id or metadata.get("project_id") or "project-default").strip() or "project-default"
+        tenant_quota_limit = int(tenant_envelope.tenant_max_queued_jobs or os.getenv("EIGEN_SCHED_TENANT_QUOTA_MAX_QUEUED", "16"))
+        project_quota_limit = int(tenant_envelope.project_max_queued_jobs or os.getenv("EIGEN_SCHED_PROJECT_QUOTA_MAX_QUEUED", "8"))
         created_at_dt = created_at.ToDatetime().replace(tzinfo=timezone.utc)
         attempt = 1
         try:
@@ -599,7 +608,7 @@ class JobService:
             run_duration_sec = default_runtime_sec
 
         results_metadata = {
-            "version": "0.2",
+            "version": "0.3",
             "backend": request.target or "sim:local",
             "qfs_compiled_aqo": f"qfs://jobs/{job_id}/compiled/circuit.aqo.json",
             "qfs_results_parquet": f"qfs://jobs/{job_id}/results.parquet",
@@ -616,6 +625,11 @@ class JobService:
             "topology_partition_id": topology["partition_id"],
             "topology_attempt": topology["attempt"],
             "topology_envelope_ref": f"qfs://jobs/{job_id}/topology/envelope.json",
+            "tenant_envelope_contract_version": TENANT_ENVELOPE_CONTRACT_VERSION,
+            "tenant_id": tenant_id,
+            "project_id": project_id,
+            "tenant_max_queued_jobs": str(max(tenant_quota_limit, 1)),
+            "project_max_queued_jobs": str(max(project_quota_limit, 1)),
         }
         noise_score = metadata.get("noise_score", "").strip()
         noise_threshold = metadata.get("noise_threshold", "").strip() or "0.03"
@@ -628,7 +642,7 @@ class JobService:
         if topology_telemetry:
             topology_fallback_reason = "NO_FALLBACK"
         dispatch_rationale = {
-           "version": "2.3.0",
+           "version": "2.4.0",
             "policy_version": metadata.get("dispatch_policy_version", "2.2.0"),
             "reason_codes": ["WEIGHTED_FAIRNESS", "DEVICE_SCORE", "PRIORITY_QUOTA", "SINGLE_DISPATCH"],
             "selected_backend": request.target or "sim:local",
@@ -647,6 +661,11 @@ class JobService:
                 "noise_hook_status": "present" if noise_score else "fallback",
                 "noise_score": noise_score or "unavailable",
                 "noise_threshold": noise_threshold,
+                "tenant_envelope_contract_version": TENANT_ENVELOPE_CONTRACT_VERSION,
+                "tenant_id": tenant_id,
+                "project_id": project_id,
+                "tenant_quota_limit": str(max(tenant_quota_limit, 1)),
+                "project_quota_limit": str(max(project_quota_limit, 1)),
             },
             "lineage": [
                 {
@@ -751,7 +770,10 @@ class JobService:
             batch_id="",
             queue_delay_sec=0.0,
             owner_subject=owner_subject,
-            owner_tenant=owner_tenant,
+            owner_tenant=tenant_id,
+            owner_project=project_id,
+            tenant_quota_limit=max(tenant_quota_limit, 1),
+            project_quota_limit=max(project_quota_limit, 1),
         )
         self._provision_temporary_artifacts(record)
         QFS_STORE.atomic_write_bytes(
@@ -893,6 +915,30 @@ class JobService:
         else:
             record.dispatch_rationale["attributes"]["quota_state"] = "eligible"
             record.dispatch_rationale["attributes"]["quota_penalty_slots"] = "0"
+            queued_for_tenant = sum(
+            1
+            for rec in self._jobs.values()
+            if rec.job_id != record.job_id and rec.owner_tenant == record.owner_tenant and rec.updates and rec.updates[-1].stage == "QUEUED"
+        )
+        if queued_for_tenant >= record.tenant_quota_limit:
+            record.dispatch_rationale["reason_codes"].append("TENANT_BASELINE_QUOTA_DELAY")
+            record.dispatch_rationale["attributes"]["tenant_quota_state"] = "throttled"
+        else:
+            record.dispatch_rationale["attributes"]["tenant_quota_state"] = "eligible"
+        queued_for_project = sum(
+            1
+            for rec in self._jobs.values()
+            if rec.job_id != record.job_id
+            and rec.owner_tenant == record.owner_tenant
+            and rec.owner_project == record.owner_project
+            and rec.updates
+            and rec.updates[-1].stage == "QUEUED"
+        )
+        if queued_for_project >= record.project_quota_limit:
+            record.dispatch_rationale["reason_codes"].append("PROJECT_BASELINE_QUOTA_DELAY")
+            record.dispatch_rationale["attributes"]["project_quota_state"] = "throttled"
+        else:
+            record.dispatch_rationale["attributes"]["project_quota_state"] = "eligible"
         if age_sec >= self._starvation_threshold_sec:
             record.queue_delay_sec = 0.0
             record.dispatch_rationale["reason_codes"].append("STARVATION_PROTECTION")


### PR DESCRIPTION
## Summary

- Added a versioned tenant envelope to public job submission contract: SubmitJobRequest.TenantQuotaEnvelope with canonical tenant_id, project_id, and baseline tenant/project quota fields. This is additive on the wire (tenant = 10).

- Implemented deterministic tenant/project default resolution in the kernel submission path (auth-tenant fallback, hard defaults, env-driven quota defaults), and propagated this envelope into runtime metadata and dispatch attributes. Also bumped internal envelope markers (results_metadata.version to 0.3, dispatch rationale version to 2.4.0).

- Extended scheduler quota evaluation with deterministic tenant/project quota checks and stable reason codes: TENANT_BASELINE_QUOTA_DELAY and PROJECT_BASELINE_QUOTA_DELAY, plus tenant_quota_state / project_quota_state attributes. Existing target-level quota behavior remains intact.

- Added Phase-9C implementation note with contract version, canonical fields, deterministic defaults, reason codes, and migration guidance (backward-compatible additive change).

## Validation

- [ ] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: CLI payloads | Plugin envelopes | Compatibility matrix | JobSpec | AQO | QFS | Metrics 
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Added `SubmitJobRequest.TenantQuotaEnvelope` with canonical tenant/project fields and baseline quota fields.
- Added deterministic scheduler reason codes for tenant/project baseline quota pressure.

### Changed
- Submission runtime now resolves deterministic tenant/project defaults when envelope fields are omitted.
- Dispatch rationale contract marker advanced to `2.4.0`; runtime metadata marker advanced to `0.3`.

### Fixed
- Ensured quota evaluation includes tenant/project baseline checks in kernel scheduling path with stable attributes/reason codes.