### PR TITLE
Implement fair queueing primitives in QRTX core

### DIFF
--- a/src/rust/crates/resource-manager/src/lib.rs
+++ b/src/rust/crates/resource-manager/src/lib.rs
@@ -15,7 +15,7 @@ use std::collections::{BTreeMap, HashMap, VecDeque};
 ///
 /// Any breaking change to queue semantics, quota semantics,
 /// dispatch reason codes, or dispatch contracts must bump MAJOR.
-pub const SCHEDULER_DECISION_VERSION: &str = "2.1.0";
+pub const SCHEDULER_DECISION_VERSION: &str = "2.2.0";
 /// SemVer version for device score DTOs/contracts.
 pub const DEVICE_SCORE_VERSION: &str = "2.1.0";
 /// SemVer version for backend scoring contract artifacts (Phase-4 intelligent runtime).

--- a/src/rust/crates/resource-manager/tests/fixtures/scheduler_contracts/dispatch_reason_codes_v2_2_0.json
+++ b/src/rust/crates/resource-manager/tests/fixtures/scheduler_contracts/dispatch_reason_codes_v2_2_0.json
@@ -1,0 +1,7 @@
+[
+  "DeviceScore",
+  "DeviceScoreTieBreak",
+  "QueueEmpty",
+  "StarvationPrevention",
+  "WeightedFairness"
+]

--- a/src/rust/crates/resource-manager/tests/fixtures/scheduler_contracts/fair_queueing_admission_ordering_v1_0_0.json
+++ b/src/rust/crates/resource-manager/tests/fixtures/scheduler_contracts/fair_queueing_admission_ordering_v1_0_0.json
@@ -1,0 +1,64 @@
+{
+  "contract_version": "1.0.0",
+  "input": {
+    "seed": 424242,
+    "jobs": [
+      {
+        "job_id": "job-a1",
+        "tenant_id": "tenant-a",
+        "project_id": "project-a",
+        "priority": 5
+      },
+      {
+        "job_id": "job-b1",
+        "tenant_id": "tenant-b",
+        "project_id": "project-b",
+        "priority": 5
+      },
+      {
+        "job_id": "job-a2",
+        "tenant_id": "tenant-a",
+        "project_id": "project-a",
+        "priority": 5
+      },
+      {
+        "job_id": "job-c1",
+        "tenant_id": "tenant-c",
+        "project_id": "project-c",
+        "priority": 5
+      },
+      {
+        "job_id": "job-b2",
+        "tenant_id": "tenant-b",
+        "project_id": "project-b",
+        "priority": 5
+      },
+      {
+        "job_id": "job-a3",
+        "tenant_id": "tenant-a",
+        "project_id": "project-a",
+        "priority": 5
+      }
+    ]
+  },
+  "expected": {
+    "contract_version": "1.0.0",
+    "seed": 424242,
+    "dispatch_order": [
+      "job-a1",
+      "job-b1",
+      "job-c1",
+      "job-a2",
+      "job-b2",
+      "job-a3"
+    ],
+    "reason_codes": [
+      "WeightedFairness",
+      "WeightedFairness",
+      "WeightedFairness",
+      "WeightedFairness",
+      "WeightedFairness",
+      "WeightedFairness"
+    ]
+  }
+}

--- a/src/rust/crates/resource-manager/tests/fixtures/scheduler_contracts/scheduler_decision_v2_2_0.json
+++ b/src/rust/crates/resource-manager/tests/fixtures/scheduler_contracts/scheduler_decision_v2_2_0.json
@@ -1,0 +1,9 @@
+{
+  "version": "2.2.0",
+  "selected_job_id": "job-contract-001",
+  "selected_tenant_id": "tenant-a",
+  "selected_project_id": "project-a",
+  "selected_priority": 7,
+  "queue_depth_after": 0,
+  "reason_code": "WeightedFairness"
+}

--- a/src/rust/crates/resource-manager/tests/fixtures/scheduler_contracts/split_plan_manifest_v2_0_0.json
+++ b/src/rust/crates/resource-manager/tests/fixtures/scheduler_contracts/split_plan_manifest_v2_0_0.json
@@ -1,7 +1,7 @@
 {
   "version": "2.0.0",
   "parent_job_id": "job-parent-compat-01",
-  "scheduler_decision_version": "2.1.0",
+  "scheduler_decision_version": "2.2.0",
   "shard_plans": [
     {
       "version": "2.0.0",

--- a/src/rust/crates/resource-manager/tests/scheduler_contract_compatibility.rs
+++ b/src/rust/crates/resource-manager/tests/scheduler_contract_compatibility.rs
@@ -45,7 +45,7 @@ fn scheduler_decision_contract_matches_golden_fixture() {
         "reason_code": format!("{:?}", decision.reason_code),
     });
 
-    assert_eq!(snapshot, fixture("scheduler_decision_v2_1_0.json"));
+    assert_eq!(snapshot, fixture("scheduler_decision_v2_2_0.json"));
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn dispatch_reason_codes_match_golden_fixture() {
     ]);
 
     let expected: BTreeSet<String> =
-        serde_json::from_value(fixture("dispatch_reason_codes_v2_1_0.json"))
+        serde_json::from_value(fixture("dispatch_reason_codes_v2_2_0.json"))
             .expect("reason-code fixture must be an array of strings");
 
     assert_eq!(current, expected);
@@ -243,8 +243,40 @@ fn queue_delivery_previous_minor_baseline_remains_compatible() {
 }
 
 #[test]
+fn deterministic_fair_queueing_fixture_matches_golden_snapshot() {
+    let fixture: Value = fixture("fair_queueing_admission_ordering_v1_0_0.json");
+    let mut scheduler = Scheduler::new(AdmissionPolicy::default(), FairnessPolicy::default());
+
+    for job in fixture["input"]["jobs"].as_array().expect("jobs must be array") {
+        scheduler.submit(ScheduledJob {
+            job_id: job["job_id"].as_str().expect("job_id").to_string(),
+            tenant_id: job["tenant_id"].as_str().expect("tenant_id").to_string(),
+            project_id: job["project_id"].as_str().expect("project_id").to_string(),
+            priority: job["priority"].as_u64().expect("priority") as u8,
+        });
+    }
+
+    let mut dispatch_order = Vec::new();
+    let mut reason_codes = Vec::new();
+    while scheduler.queue_depth() > 0 {
+        let decision = scheduler.dispatch_next();
+        dispatch_order.push(decision.selected_job_id.expect("job id expected"));
+        reason_codes.push(format!("{:?}", decision.reason_code));
+    }
+
+    let snapshot = json!({
+        "contract_version": fixture["contract_version"],
+        "seed": fixture["input"]["seed"],
+        "dispatch_order": dispatch_order,
+        "reason_codes": reason_codes,
+    });
+
+    assert_eq!(snapshot, fixture["expected"]);
+}
+
+#[test]
 fn all_orchestration_contracts_keep_explicit_version_markers() {
-    assert_eq!(SCHEDULER_DECISION_VERSION, "2.1.0");
+    assert_eq!(SCHEDULER_DECISION_VERSION, "2.2.0");
     assert_eq!(DEVICE_SCORE_VERSION, "2.1.0");
     assert_eq!(BACKEND_SCORING_CONTRACT_VERSION, "1.0.0");
     assert_eq!(BACKEND_SCORING_PROFILE_SCHEMA_VERSION, "1.0.0");


### PR DESCRIPTION
## Summary

- Implemented the Phase-9C deterministic baseline lock by bumping SCHEDULER_DECISION_VERSION from 2.1.0 to 2.2.0 (MINOR, non-breaking), so contract artifacts explicitly reflect the new fairness-conformance lock.

- Updated scheduler contract compatibility tests to consume the new 2.2.0 golden artifacts for scheduler decisions and dispatch reason code set.

- Added a new deterministic fair-queueing fixture lock test (deterministic_fair_queueing_fixture_matches_golden_snapshot) that replays a fixed workload snapshot (with fixed seed metadata), then asserts exact admission/dispatch order and reason codes.

- Added/updated golden fixtures to freeze Stage-C conformance behavior:

    - new scheduler decision fixture scheduler_decision_v2_2_0.json;

    - new dispatch reason-code fixture dispatch_reason_codes_v2_2_0.json;

    - updated split-plan manifest linkage to the new scheduler decision contract version.

## Validation

- [x] Tests added/updated
- [ ] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: Compatibility matrix | JobSpec | AQO | QFS | Metrics
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Deterministic fair-queueing golden fixture for fixed workload snapshots and seed metadata, with strict dispatch-order and reason-code assertions.

### Changed
- Scheduler decision contract version bumped to `2.2.0`.
- Scheduler contract fixture set updated to `2.2.0` baseline.
- Split-plan manifest fixture now references scheduler decision `2.2.0`.

### Fixed
- Conformance coverage gap for plugins-disabled deterministic fair queueing admission ordering.