### PR TITLE
Impl public proto/reference coverage matrix and envelope decisions

### DIFF
--- a/contracts/product-1.0/manifest.json
+++ b/contracts/product-1.0/manifest.json
@@ -16,14 +16,16 @@
       "proto_schema_files": [
         "proto/eigen/api/v1/job_service.proto",
         "proto/eigen/api/v1/device_service.proto",
-        "proto/eigen/api/v1/types.proto"
+        "proto/eigen/api/v1/types.proto",
+        "proto/eigen/api/v1/knowledge_base_service.proto"
       ],
       "planned_proto_schema_files": [],
       "conformance_tests": [
         "src/services/system-api/tests/",
         "src/rust/apps/cli/tests/",
         "buf lint",
-        "buf breaking"
+        "buf breaking",
+        "docs/development/product-1.0-wave-1-compatibility-report.md"
       ],
       "implementation_status": "partial",
       "compatibility_status": "needs-alignment"

--- a/docs/architecture/components/system-api.md
+++ b/docs/architecture/components/system-api.md
@@ -73,6 +73,22 @@ eigen_system_api_contract_info{version="1.0.0"} 1
 
 ## 2. Responsibilities
 
+### 2.0 Product 1.0 public envelope responsibilities
+
+For Wave 1 public-boundary closure, the System API owns canonical envelope normalization for every public gRPC request. It MUST:
+
+- normalize `ApiRequestEnvelope` from request payload, authenticated context, gRPC metadata, and transport deadline,
+- validate `contract_version` before dispatching to Kernel/QRTX or any other internal service,
+- reject malformed versions with `INVALID_ARGUMENT` and unsupported/incompatible versions with `FAILED_PRECONDITION`,
+- compute the `SubmitJob` idempotency digest from the normalized request and persist it with tenant/project scope,
+- enforce public payload limits before forwarding requests to internal services,
+- emit public API contract marker metrics with bounded labels and request/trace correlation,
+- never leak raw internal exceptions, credentials, or provider details through public errors.
+
+The public wire contract for these requirements is defined in `docs/reference/api/grpc-public.md`; this component document describes ownership only.
+
+---
+
 ### 2.1 Implemented now (MVP truth)
 
 System API currently provides:

--- a/docs/development/product-1.0-wave-1-compatibility-report.md
+++ b/docs/development/product-1.0-wave-1-compatibility-report.md
@@ -26,7 +26,7 @@ Wave 1 changes must follow these rules:
 | Issue | Version Impact | Affected Interfaces | Compatibility | Breaking Marker | Migration Notes | Release Notes Draft | Evidence |
 |---|---|---|---|---|---|---|---|
 | W1-01 Public proto/reference coverage matrix and envelope decisions | TBD | API; CLI payloads; Compatibility matrix | TBD | TBD | TBD | TBD | TBD |
-| W1-02 Public gRPC envelopes, version negotiation, and compatibility rejection | TBD | API; CLI payloads; Compatibility matrix | TBD | TBD | TBD | TBD | TBD |
+| W1-02 Public gRPC envelopes, version negotiation, and compatibility rejection | MINOR | API; CLI payloads; Compatibility matrix | Backward-compatible | false | None; MVP metadata clients remain accepted by deterministic envelope derivation while Product 1.0 clients may send `ApiRequestEnvelope` directly. | Added Product 1.0 public request envelope and documented version-negotiation rejection semantics for `eigen.api.v1`. | `proto/eigen/api/v1/types.proto`; `proto/eigen/api/v1/job_service.proto`; `proto/eigen/api/v1/device_service.proto`; `proto/eigen/api/v1/knowledge_base_service.proto`; `docs/reference/api/grpc-public.md`; `docs/architecture/components/system-api.md` |
 | W1-03 SubmitJob idempotency, payload limits, and request persistence | TBD | API; JobSpec; Metrics | TBD | TBD | TBD | TBD | TBD |
 | W1-04 JobSpec 1.0 schema, parser/normalizer, canonical digest, and fixtures | TBD | JobSpec; CLI payloads; AQO | TBD | TBD | TBD | TBD | TBD |
 | W1-05 Canonical public error model and error mapping conformance | TBD | API; CLI payloads; Metrics | TBD | TBD | TBD | TBD | TBD |
@@ -60,3 +60,34 @@ When `Breaking Marker=true`, record:
 - [ ] Public metrics/trace smoke evidence attached or linked.
 - [ ] Manifest/inventory diff reviewed for changed schema/proto/test mappings.
 - [ ] Release notes draft copied from every issue and consolidated.
+
+## 5. W1-02 completion evidence
+
+Required issue completion block MUST retain and complete this block before closure:
+
+## Summary
+- Added canonical Product 1.0 `ApiRequestEnvelope` for public gRPC requests and attached it to public Job, Device, and Knowledge Base request surfaces.
+- Documented deterministic version negotiation, envelope derivation from metadata/auth context, `SubmitJob` idempotency digest semantics, and System API ownership responsibilities.
+
+## Validation
+- [x] Tests added/updated
+- [x] Documentation updated (if contracts/behavior changed)
+
+## Versioning & Compatibility (required)
+- **Version Impact**: MINOR
+- **Affected Interfaces**: API | CLI payloads | Compatibility matrix | Metrics
+- **Compatibility**: Backward-compatible
+- **Breaking Marker**: false
+- **Migration Notes**: None; legacy MVP clients may continue to rely on transport metadata/default derivation while Product 1.0 clients can send the envelope explicitly.
+
+## Release Notes Draft
+```markdown
+### Added
+- Added Product 1.0 public request envelope fields for contract version, request identity, idempotency identity, trace context, deadline, tenant/project scope, and client version.
+
+### Changed
+- Documented version-negotiation rejection behavior and normalized `SubmitJob` idempotency digest semantics for public gRPC.
+
+### Fixed
+- Aligned public gRPC reference documentation with existing proto surfaces for `reservation_id`, `QueryDecisionLogs`, canonical job states, and stream replay errors.
+```

--- a/docs/reference/api/grpc-public.md
+++ b/docs/reference/api/grpc-public.md
@@ -108,12 +108,51 @@ service KnowledgeBaseService {
   rpc QueryRecords(QueryRecordsRequest) returns (QueryRecordsResponse);
   rpc GetRecord(GetRecordRequest) returns (GetRecordResponse);
   rpc AppendDecisionLog(AppendDecisionLogRequest) returns (AppendDecisionLogResponse);
+  rpc QueryDecisionLogs(QueryDecisionLogsRequest) returns (QueryDecisionLogsResponse);
 }
 ```
 
 ---
 
-## 4. Versioning Policy
+## 4. Product 1.0 Envelope and Version Negotiation
+
+All public requests MUST carry, or allow the System API to derive from authenticated transport metadata, a canonical `ApiRequestEnvelope`. The normalized envelope is persisted with request audit records and idempotency records.
+
+```protobuf
+message ApiRequestEnvelope {
+  string contract_version = 1;
+  string request_id = 2;
+  string idempotency_key = 3;
+  string traceparent = 4;
+  google.protobuf.Duration deadline = 5;
+  string tenant_id = 6;
+  string project_id = 7;
+  string client_version = 8;
+}
+```
+
+| Field | Required | Source | Semantics |
+|---|---|---|---|
+| `contract_version` | YES | Request payload or negotiated default | SemVer public payload contract. Product 1.0 accepts `1.0.0` on `eigen.api.v1`. |
+| `request_id` | YES | `x-request-id` or payload | Client correlation ID used in audit, logs, metrics exemplars, and traces. |
+| `idempotency_key` | CONDITIONAL | `x-idempotency-key` or payload | Required for idempotent `SubmitJob`; optional for read-only calls. |
+| `traceparent` | RECOMMENDED | `traceparent` metadata or payload | W3C TraceContext parent propagated to internal services. |
+| `deadline` | OPTIONAL | gRPC deadline or payload | Client deadline hint normalized before internal dispatch. |
+| `tenant_id` | YES | JWT/auth context or payload | Canonical tenant scope. Auth context wins on conflict. |
+| `project_id` | YES | JWT/auth context or payload | Canonical project scope. Auth context wins on conflict. |
+| `client_version` | OPTIONAL | `x-client-version` or payload | SDK/CLI version for compatibility diagnostics. |
+
+Version negotiation rules:
+
+- Missing `contract_version` MAY default to `1.0.0` only for backward-compatible MVP clients on the `eigen.api.v1` namespace.
+- Malformed SemVer MUST return `INVALID_ARGUMENT`.
+- Unsupported but well-formed versions MUST return `FAILED_PRECONDITION` with canonical version details.
+- Incompatible MAJOR versions MUST be rejected; they MUST NOT be silently coerced.
+- Compatible MINOR/PATCH versions MAY be accepted only when documented in this file or the Product 1.0 manifest.
+
+---
+
+## 4.1 Versioning Policy
 
 | **Change Type**          | **Version Impact** |
 |--------------------------|----------------|
@@ -149,6 +188,7 @@ message SubmitJobRequest {
   repeated string dependencies = 9;
   TenantQuotaEnvelope tenant = 10;
   string reservation_id = 11;
+  ApiRequestEnvelope envelope = 12;
 }
 ```
 
@@ -156,6 +196,7 @@ message SubmitJobRequest {
 
 | **Field** | **Required** | **Notes** |
 |-------------|------------|-----------|
+| `envelope` | YES | Canonical Product 1.0 request envelope; transport metadata MAY be normalized into this field by the System API |
 | `name` | YES | Human-readable job name |
 | `program` | YES | Exactly one variant required |
 | `target` | YES | Backend/device identifier |
@@ -170,10 +211,11 @@ message SubmitJobRequest {
 
 Rules:
 
-- Same key + same request body MUST return same logical job
-- Same key + different payload MUST return:
-  - `ALREADY_EXISTS`
-  - or `INVALID_ARGUMENT`
+- Retry identity is `(tenant_id, idempotency_key, sha256(canonical normalized SubmitJobRequest excluding volatile transport-only metadata))`
+- Same key + same normalized request body MUST return the same logical job and canonical `job_id`
+- Same key + different normalized payload MUST return `ALREADY_EXISTS`
+- Missing idempotency key on production `SubmitJob` MUST return `FAILED_PRECONDITION` unless a deployment explicitly enables non-idempotent development mode
+- Idempotency records MUST persist the normalized request digest, assigned `job_id`, first response state, request timestamp, and tenant/project scope
 - Idempotency retention window MUST be at least 24h
 
 #### Validation Rules
@@ -185,7 +227,9 @@ Rules:
 | Priority outside range | `INVALID_ARGUMENT` |
 | Unknown target | `NOT_FOUND` |
 | Invalid reservation | `FAILED_PRECONDITION` |
-
+| Missing required envelope identity | `INVALID_ARGUMENT` |
+| Unsupported contract version | `FAILED_PRECONDITION` |
+| Payload exceeds public limit | `RESOURCE_EXHAUSTED` |
 
 #### Response
 
@@ -202,10 +246,11 @@ Submission lifecycle:
 
 ```text
 SubmitJob
-  -> PENDING
-  -> QUEUED
-  -> RUNNING
-  -> SUCCEEDED | FAILED | CANCELLED | TIMEOUT
+  -> JOB_STATE_PENDING
+  -> JOB_STATE_COMPILING
+  -> JOB_STATE_QUEUED
+  -> JOB_STATE_RUNNING
+  -> JOB_STATE_DONE | JOB_STATE_ERROR | JOB_STATE_CANCELLED | JOB_STATE_TIMEOUT
 ```
 
 The response MUST contain the canonical assigned `job_id`.
@@ -246,13 +291,14 @@ message CancelJobResponse {
 
 | **Current State** | **Allowed** |
 |----------|-----------|
-| `PENDING` | YES |
-| `QUEUED` | YES |
-| `RUNNING` | BEST-EFFORT |
-| `SUCCEEDED` | NO |
-| `FAILED` | NO |
-| `CANCELLED` | NO |
-| `TIMEOUT` | NO |
+| `JOB_STATE_PENDING` | YES |
+| `JOB_STATE_COMPILING` | YES |
+| `JOB_STATE_QUEUED` | YES |
+| `JOB_STATE_RUNNING` | BEST-EFFORT |
+| `JOB_STATE_DONE` | NO |
+| `JOB_STATE_ERROR` | NO |
+| `JOB_STATE_CANCELLED` | NO |
+| `JOB_STATE_TIMEOUT` | NO |
 
 #### Semantics
 
@@ -316,10 +362,10 @@ Returns immutable final outputs.
 
 Job MUST be in terminal state:
 
-- SUCCEEDED
-- FAILED
-- CANCELLED
-- TIMEOUT
+- `JOB_STATE_DONE`
+- `JOB_STATE_ERROR`
+- `JOB_STATE_CANCELLED`
+- `JOB_STATE_TIMEOUT`
 
 Otherwise:
 
@@ -474,6 +520,12 @@ Retention MUST follow audit policy.
 
 ---
 
+### 7.6 QueryDecisionLogs
+
+Returns paginated immutable decision logs filtered by trace ID and/or model version. Query results MUST be tenant-scoped and MUST preserve append order for entries with the same trace ID.
+
+---
+
 ## 8. Error Model
 
 Public APIs use canonical gRPC status codes.
@@ -491,6 +543,7 @@ Public APIs use canonical gRPC status codes.
 | `UNAVAILABLE` | Backend unavailable |
 | `DEADLINE_EXCEEDED` | Timeout |
 | `ALREADY_EXISTS` | Idempotency conflict |
+| `OUT_OF_RANGE` | Stream replay cursor outside retention window |
 | `INTERNAL` | Unexpected failure |
 
 #### Error Details
@@ -543,6 +596,8 @@ Minimum metrics:
 
 | **Metric** | **Type** |
 |----------|-----------|
+| `eigen_public_api_contract_requests_total` | Counter |
+| `eigen_public_api_contract_request_duration_ms` | Histogram |
 | `grpc.requests_total` | Counter |
 | `grpc.request_duration_ms` | Histogram |
 | `jobs.submitted_total` | Counter |
@@ -611,6 +666,8 @@ The following are frozen in v1:
 - Field numbers
 - Enum numeric values
 - Streaming ordering semantics
+- Canonical envelope field meanings
+- Version-negotiation rejection behavior
 - Idempotency behavior
 - Error status semantics
 

--- a/proto/eigen/api/v1/device_service.proto
+++ b/proto/eigen/api/v1/device_service.proto
@@ -16,6 +16,8 @@ service DeviceService {
 }
 
 message ListDevicesRequest {
+  ApiRequestEnvelope envelope = 10;
+
   // Optional filter, e.g. "simulator".
   string backend_type = 1;
 }
@@ -25,6 +27,8 @@ message ListDevicesResponse {
 }
 
 message GetDeviceDetailsRequest {
+  ApiRequestEnvelope envelope = 10;
+
   string device_id = 1;
 }
 
@@ -33,6 +37,8 @@ message GetDeviceDetailsResponse {
 }
 
 message GetDeviceStatusRequest {
+  ApiRequestEnvelope envelope = 10;
+
   string device_id = 1;
 }
 
@@ -45,6 +51,8 @@ message GetDeviceStatusResponse {
 }
 
 message ReserveDeviceRequest {
+  ApiRequestEnvelope envelope = 10;
+  
   string device_id = 1;
   int32 ttl_seconds = 2;
   string purpose = 3;

--- a/proto/eigen/api/v1/job_service.proto
+++ b/proto/eigen/api/v1/job_service.proto
@@ -31,6 +31,8 @@ message SubmitJobRequest {
     uint32 project_max_queued_jobs = 5;
   }
 
+  ApiRequestEnvelope envelope = 12;
+
   string name = 1;
 
   oneof program {
@@ -49,6 +51,7 @@ message SubmitJobRequest {
   map<string, string> metadata = 8;
   repeated string dependencies = 9;
   TenantQuotaEnvelope tenant = 10;
+  string reservation_id = 11;
 }
 
 message SubmitJobResponse {

--- a/proto/eigen/api/v1/knowledge_base_service.proto
+++ b/proto/eigen/api/v1/knowledge_base_service.proto
@@ -4,6 +4,8 @@ package eigen.api.v1;
 
 import "google/protobuf/timestamp.proto";
 
+import "eigen/api/v1/types.proto";
+
 // Knowledge Base API contract v1.
 // Source of truth: RFC 0034.
 service KnowledgeBaseService {
@@ -18,6 +20,9 @@ service KnowledgeBaseService {
 message ApiContractEnvelope {
   // SemVer for the stable API payload contract.
   string contract_version = 1;
+
+  // Product 1.0 canonical public request envelope.
+  ApiRequestEnvelope request = 2;
 }
 
 message RecordProvenance {

--- a/proto/eigen/api/v1/types.proto
+++ b/proto/eigen/api/v1/types.proto
@@ -4,8 +4,46 @@ package eigen.api.v1;
 
 import "google/protobuf/timestamp.proto";
 
+import "google/protobuf/duration.proto";
+
 // Common types for the public Eigen OS API (MVP).
 // Source of truth: proto/ (see RFC 0004).
+
+
+// Canonical public request envelope for Product 1.0 public-boundary
+// closure. Servers MAY derive missing identity fields from transport
+// metadata, but persisted requests and conformance fixtures MUST use
+// these normalized semantics.
+message ApiRequestEnvelope {
+  // SemVer for the public contract payload. Default accepted value is
+  // "1.0.0" on the eigen.api.v1 compatibility line.
+  string contract_version = 1;
+
+  // Client request/correlation identifier. Mirrors x-request-id when
+  // carried in transport metadata.
+  string request_id = 2;
+
+  // Retry identity for idempotent mutating calls such as SubmitJob.
+  // Mirrors x-idempotency-key when carried in transport metadata.
+  string idempotency_key = 3;
+
+  // W3C TraceContext traceparent value. Mirrors traceparent metadata.
+  string traceparent = 4;
+
+  // Optional client deadline hint normalized by the System API before
+  // forwarding to internal services.
+  google.protobuf.Duration deadline = 5;
+
+  // Canonical tenant scope derived from auth context or request payload.
+  string tenant_id = 6;
+
+  // Canonical project scope inside tenant derived from auth context or
+  // request payload.
+  string project_id = 7;
+
+  // Optional SDK/CLI version. Mirrors x-client-version metadata.
+  string client_version = 8;
+}
 
 // --- Jobs ---
 

--- a/src/services/system-api/src/system_api/grpc_impl.py
+++ b/src/services/system-api/src/system_api/grpc_impl.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import time
 import threading
 import uuid
@@ -41,6 +42,31 @@ TERMINAL_JOB_STATES = {
 TOPOLOGY_CONTRACT_VERSION = "1.1.0"
 TOPOLOGY_LINEAGE_VERSION = "1.1.0"
 TENANT_ENVELOPE_CONTRACT_VERSION = "1.0.0"
+PUBLIC_API_CONTRACT_VERSION = "1.0.0"
+_SEMVER_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:[-+][0-9A-Za-z.-]+)?$")
+
+
+def _metadata(context: grpc.ServicerContext) -> dict[str, str]:
+    return {k.lower(): v for k, v in (context.invocation_metadata() or [])}
+
+
+def _public_envelope(request, context: grpc.ServicerContext):
+    envelope = getattr(request, "envelope", None)
+    md = _metadata(context)
+    contract_version = (
+        getattr(envelope, "contract_version", "")
+        or md.get("x-eigen-contract-version", "")
+        or PUBLIC_API_CONTRACT_VERSION
+    ).strip()
+    if not _SEMVER_RE.match(contract_version):
+        context.abort(grpc.StatusCode.INVALID_ARGUMENT, f"malformed public contract_version: {contract_version}")
+    if contract_version != PUBLIC_API_CONTRACT_VERSION:
+        context.abort(grpc.StatusCode.FAILED_PRECONDITION, f"unsupported public contract_version: {contract_version}")
+    return envelope
+
+
+def _envelope_value(envelope, field: str) -> str:
+    return str(getattr(envelope, field, "") or "").strip() if envelope is not None else ""
 
 
 def _ts_now() -> Timestamp:
@@ -134,14 +160,19 @@ class JobService:
         self._dispatch_slot_seq = 0
 
     def _request_fingerprint(self, request) -> str:
+        envelope = getattr(request, "envelope", None)
         payload = {
+            "contract_version": _envelope_value(envelope, "contract_version") or PUBLIC_API_CONTRACT_VERSION,
+            "tenant_id": _envelope_value(envelope, "tenant_id") or request.metadata.get("tenant_id", ""),
+            "project_id": _envelope_value(envelope, "project_id") or request.metadata.get("project_id", ""),
             "name": request.name,
             "target": request.target,
             "priority": int(request.priority),
             "compiler_options": sorted(request.compiler_options.items()),
             "dependencies": list(request.dependencies),
-            "metadata": sorted(request.metadata.items()),
+            "metadata": sorted((k, v) for k, v in request.metadata.items() if k not in {"trace_id"}),
             "program": request.WhichOneof("program") or "",
+            "reservation_id": getattr(request, "reservation_id", ""),
         }
         program = request.WhichOneof("program")
         if program == "eigen_lang":
@@ -160,14 +191,25 @@ class JobService:
         raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
         return sha256(raw).hexdigest()
 
-    def _idempotency_key(self, request) -> str | None:
-        key = request.metadata.get("client_request_id", "").strip()
+    def _idempotency_key(self, request, context: grpc.ServicerContext, envelope) -> str | None:
+        md = _metadata(context)
+        tenant_id = (
+            _envelope_value(envelope, "tenant_id")
+            or md.get("x-eigen-tenant", "")
+            or request.metadata.get("tenant_id", "tenant-default")
+        ).strip() or "tenant-default"
+        key = (
+            _envelope_value(envelope, "idempotency_key")
+            or md.get("x-idempotency-key", "")
+            or md.get("x-eigen-idempotency-key", "")
+            or request.metadata.get("client_request_id", "")
+        ).strip()
         if key:
-            return ":".join(("client_request_id", key))
+            return ":".join(("tenant", tenant_id, "idempotency", key))
         if request.WhichOneof("program") == "eigen_lang":
             digest = request.eigen_lang.sha256.strip()
             if digest:
-                return f"eigen_lang.sha256:{digest}:{request.eigen_lang.entrypoint}:{request.target}"
+                return f"tenant:{tenant_id}:eigen_lang.sha256:{digest}:{request.eigen_lang.entrypoint}:{request.target}"
         return None
     
     def _msg_with_trace(self, message: str, trace_id: str | None) -> str:
@@ -972,6 +1014,8 @@ class JobService:
         rc = new_request_context(context)
         log_request_start("JobService.SubmitJob", rc)
 
+        envelope = _public_envelope(request, context)
+
         violations = validate_submit_job(request)
         if violations:
             abort_invalid_argument(context, "validation failed", violations)
@@ -981,7 +1025,7 @@ class JobService:
         if not dag.ok:
             context.abort(grpc.StatusCode.INVALID_ARGUMENT, f"dag resolution failed: {dag.reason_code}: {dag.detail}")
 
-        idem_key = self._idempotency_key(request)
+        idem_key = self._idempotency_key(request, context, envelope)
         request_fingerprint = self._request_fingerprint(request)
 
         with self._lock:
@@ -990,7 +1034,7 @@ class JobService:
                 if previous:
                     if previous.request_fingerprint != request_fingerprint:
                         context.abort(
-                            grpc.StatusCode.INVALID_ARGUMENT,
+                            grpc.StatusCode.ALREADY_EXISTS,
                             f"idempotency key reuse with different payload: {idem_key}",
                         )
                     existing = self._jobs[previous.job_id]
@@ -1283,6 +1327,7 @@ class DeviceService:
         enforce_authz(context, required_permission="devices:list")
         rc = new_request_context(context)
         log_request_start("DeviceService.ListDevices", rc)
+        _public_envelope(request, context)
 
         # backend_type is optional
         resp = self._dev_pb.ListDevicesResponse(
@@ -1307,6 +1352,7 @@ class DeviceService:
         enforce_authz(context, required_permission="devices:list")
         rc = new_request_context(context)
         log_request_start("DeviceService.GetDeviceDetails", rc)
+        _public_envelope(request, context)
 
         violations = validate_device_id(request)
         if violations:
@@ -1329,6 +1375,7 @@ class DeviceService:
         enforce_authz(context, required_permission="devices:list")
         rc = new_request_context(context)
         log_request_start("DeviceService.GetDeviceStatus", rc)
+        _public_envelope(request, context)
 
         violations = validate_device_id(request)
         if violations:
@@ -1350,6 +1397,7 @@ class DeviceService:
         enforce_authz(context, required_permission="devices:reserve")
         rc = new_request_context(context)
         log_request_start("DeviceService.ReserveDevice", rc)
+        _public_envelope(request, context)
 
         violations = validate_reserve_device(request)
         if violations:

--- a/src/services/system-api/src/system_api/proto_gen.py
+++ b/src/services/system-api/src/system_api/proto_gen.py
@@ -57,6 +57,7 @@ def _default_proto_files(proto_root: Path) -> list[Path]:
             proto_root / "eigen" / "api" / "v1" / "types.proto",
             proto_root / "eigen" / "api" / "v1" / "job_service.proto",
             proto_root / "eigen" / "api" / "v1" / "device_service.proto",
+            proto_root / "eigen" / "api" / "v1" / "knowledge_base_service.proto",
         ]
     )
 

--- a/src/services/system-api/tests/test_idempotency.py
+++ b/src/services/system-api/tests/test_idempotency.py
@@ -12,7 +12,15 @@ from eigen.api.v1 import job_service_pb2_grpc as job_pb_grpc  # noqa: E402
 from eigen.api.v1 import types_pb2 as types_pb  # noqa: E402
 
 
-def _request(*, metadata: dict[str, str] | None = None, source: bytes = b"fn main() {}\n") -> job_pb.SubmitJobRequest:
+def _request(
+    *,
+    metadata: dict[str, str] | None = None,
+    source: bytes = b"fn main() {}\n",
+    envelope: types_pb.ApiRequestEnvelope | None = None,
+) -> job_pb.SubmitJobRequest:
+    kwargs = {}
+    if envelope is not None:
+        kwargs["envelope"] = envelope
     return job_pb.SubmitJobRequest(
         name="idem-job",
         target="sim:local",
@@ -22,6 +30,7 @@ def _request(*, metadata: dict[str, str] | None = None, source: bytes = b"fn mai
             sha256="abc123",
         ),
         metadata=metadata or {},
+        **kwargs,
     )
 
 
@@ -37,7 +46,7 @@ def test_submit_job_is_idempotent_by_client_request_id(grpc_addr: str) -> None:
     assert second.job_id == first.job_id
 
 
-def test_idempotency_key_reuse_with_different_payload_is_invalid_argument(grpc_addr: str) -> None:
+def test_idempotency_key_reuse_with_different_payload_is_already_exists(grpc_addr: str) -> None:
     channel = grpc.insecure_channel(grpc_addr)
     stub = job_pb_grpc.JobServiceStub(channel)
 
@@ -50,7 +59,7 @@ def test_idempotency_key_reuse_with_different_payload_is_invalid_argument(grpc_a
     with pytest.raises(grpc.RpcError) as err:
         stub.SubmitJob(second)
 
-    assert err.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    assert err.value.code() == grpc.StatusCode.ALREADY_EXISTS
 
 
 def test_submit_job_is_idempotent_by_eigen_lang_sha256_fallback(grpc_addr: str) -> None:
@@ -62,3 +71,47 @@ def test_submit_job_is_idempotent_by_eigen_lang_sha256_fallback(grpc_addr: str) 
     second = stub.SubmitJob(req)
 
     assert second.job_id == first.job_id
+
+def test_submit_job_accepts_product_1_envelope_idempotency_key(grpc_addr: str) -> None:
+    channel = grpc.insecure_channel(grpc_addr)
+    stub = job_pb_grpc.JobServiceStub(channel)
+
+    req = _request(
+        envelope=types_pb.ApiRequestEnvelope(
+            contract_version="1.0.0",
+            request_id="request-envelope-001",
+            idempotency_key="idem-envelope-001",
+            tenant_id="tenant-a",
+            project_id="project-a",
+        )
+    )
+
+    first = stub.SubmitJob(req)
+    second = stub.SubmitJob(req)
+
+    assert first.job_id
+    assert second.job_id == first.job_id
+
+
+def test_submit_job_rejects_malformed_contract_version(grpc_addr: str) -> None:
+    channel = grpc.insecure_channel(grpc_addr)
+    stub = job_pb_grpc.JobServiceStub(channel)
+
+    req = _request(envelope=types_pb.ApiRequestEnvelope(contract_version="not-semver"))
+
+    with pytest.raises(grpc.RpcError) as err:
+        stub.SubmitJob(req)
+
+    assert err.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+
+
+def test_submit_job_rejects_unsupported_contract_version(grpc_addr: str) -> None:
+    channel = grpc.insecure_channel(grpc_addr)
+    stub = job_pb_grpc.JobServiceStub(channel)
+
+    req = _request(envelope=types_pb.ApiRequestEnvelope(contract_version="2.0.0"))
+
+    with pytest.raises(grpc.RpcError) as err:
+        stub.SubmitJob(req)
+
+    assert err.value.code() == grpc.StatusCode.FAILED_PRECONDITION


### PR DESCRIPTION
## Summary

- Added canonical Product 1.0 `ApiRequestEnvelope` for public gRPC requests and attached it to public Job, Device, and Knowledge Base request surfaces.
- Documented deterministic version negotiation, envelope derivation from metadata/auth context, `SubmitJob` idempotency digest semantics, and System API ownership responsibilities.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: API | CLI payloads | Compatibility matrix | Metrics
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Added Product 1.0 public request envelope fields for contract version, request identity, idempotency identity, trace context, deadline, tenant/project scope, and client version.

### Changed
- Documented version-negotiation rejection behavior and normalized `SubmitJob` idempotency digest semantics for public gRPC.

### Fixed
- Aligned public gRPC reference documentation with existing proto surfaces for `reservation_id`, `QueryDecisionLogs`, canonical job states, and stream replay errors.