### PR TITLE
Impl public gRPC envelopes, version negotiation, and compatibility re…

### DIFF
--- a/docs/architecture/components/system-api.md
+++ b/docs/architecture/components/system-api.md
@@ -79,7 +79,8 @@ For Wave 1 public-boundary closure, the System API owns canonical envelope norma
 
 - normalize `ApiRequestEnvelope` from request payload, authenticated context, gRPC metadata, and transport deadline,
 - validate `contract_version` before dispatching to Kernel/QRTX or any other internal service,
-- reject malformed versions with `INVALID_ARGUMENT` and unsupported/incompatible versions with `FAILED_PRECONDITION`,
+- reject malformed versions with `INVALID_ARGUMENT` plus `PUBLIC_CONTRACT_VERSION_MALFORMED` details and unsupported/incompatible versions with `FAILED_PRECONDITION` plus `PUBLIC_CONTRACT_VERSION_UNSUPPORTED` details,
+- derive deterministic defaults for missing MVP-client envelope fields (`contract_version=1.0.0`, stable `req_<sha256-prefix>` request IDs, `tenant-default`, and `project-default`) before audit, idempotency, or internal forwarding,
 - compute the `SubmitJob` idempotency digest from the normalized request and persist it with tenant/project scope,
 - enforce public payload limits before forwarding requests to internal services,
 - emit public API contract marker metrics with bounded labels and request/trace correlation,

--- a/docs/development/product-1.0-wave-1-compatibility-report.md
+++ b/docs/development/product-1.0-wave-1-compatibility-report.md
@@ -26,7 +26,7 @@ Wave 1 changes must follow these rules:
 | Issue | Version Impact | Affected Interfaces | Compatibility | Breaking Marker | Migration Notes | Release Notes Draft | Evidence |
 |---|---|---|---|---|---|---|---|
 | W1-01 Public proto/reference coverage matrix and envelope decisions | TBD | API; CLI payloads; Compatibility matrix | TBD | TBD | TBD | TBD | TBD |
-| W1-02 Public gRPC envelopes, version negotiation, and compatibility rejection | MINOR | API; CLI payloads; Compatibility matrix | Backward-compatible | false | None; MVP metadata clients remain accepted by deterministic envelope derivation while Product 1.0 clients may send `ApiRequestEnvelope` directly. | Added Product 1.0 public request envelope and documented version-negotiation rejection semantics for `eigen.api.v1`. | `proto/eigen/api/v1/types.proto`; `proto/eigen/api/v1/job_service.proto`; `proto/eigen/api/v1/device_service.proto`; `proto/eigen/api/v1/knowledge_base_service.proto`; `docs/reference/api/grpc-public.md`; `docs/architecture/components/system-api.md` |
+| W1-02 Public gRPC envelopes, version negotiation, and compatibility rejection | MINOR | API; CLI payloads; Compatibility matrix | Backward-compatible | false | None; MVP metadata clients remain accepted by deterministic envelope derivation while Product 1.0 clients may send `ApiRequestEnvelope` directly. | Added Product 1.0 public request envelope and runtime version-negotiation rejection semantics for `eigen.api.v1`. | `proto/eigen/api/v1/types.proto`; `proto/eigen/api/v1/job_service.proto`; `proto/eigen/api/v1/device_service.proto`; `proto/eigen/api/v1/knowledge_base_service.proto`; `src/services/system-api/src/system_api/grpc_impl.py`; `src/services/system-api/tests/test_public_envelope_versioning.py`; `docs/reference/api/grpc-public.md`; `docs/architecture/components/system-api.md` |
 | W1-03 SubmitJob idempotency, payload limits, and request persistence | TBD | API; JobSpec; Metrics | TBD | TBD | TBD | TBD | TBD |
 | W1-04 JobSpec 1.0 schema, parser/normalizer, canonical digest, and fixtures | TBD | JobSpec; CLI payloads; AQO | TBD | TBD | TBD | TBD | TBD |
 | W1-05 Canonical public error model and error mapping conformance | TBD | API; CLI payloads; Metrics | TBD | TBD | TBD | TBD | TBD |
@@ -67,7 +67,7 @@ Required issue completion block MUST retain and complete this block before closu
 
 ## Summary
 - Added canonical Product 1.0 `ApiRequestEnvelope` for public gRPC requests and attached it to public Job, Device, and Knowledge Base request surfaces.
-- Documented deterministic version negotiation, envelope derivation from metadata/auth context, `SubmitJob` idempotency digest semantics, and System API ownership responsibilities.
+- Implemented and documented deterministic version negotiation, envelope derivation from metadata/auth context, structured compatibility rejection details, `SubmitJob` idempotency digest semantics, and System API ownership responsibilities.
 
 ## Validation
 - [x] Tests added/updated
@@ -83,11 +83,11 @@ Required issue completion block MUST retain and complete this block before closu
 ## Release Notes Draft
 ```markdown
 ### Added
-- Added Product 1.0 public request envelope fields for contract version, request identity, idempotency identity, trace context, deadline, tenant/project scope, and client version.
+- Added Product 1.0 public request envelope fields for contract version, request identity, idempotency identity, trace context, deadline, tenant/project scope, and client version, including read-side JobService requests.
 
 ### Changed
-- Documented version-negotiation rejection behavior and normalized `SubmitJob` idempotency digest semantics for public gRPC.
+- Implemented and documented version-negotiation rejection behavior and normalized `SubmitJob` idempotency digest semantics for public gRPC.
 
 ### Fixed
-- Aligned public gRPC reference documentation with existing proto surfaces for `reservation_id`, `QueryDecisionLogs`, canonical job states, and stream replay errors.
+- Aligned public gRPC reference documentation with proto and System API runtime behavior for request envelopes, `reservation_id`, `QueryDecisionLogs`, canonical job states, and stream replay errors.
 ```

--- a/docs/reference/api/grpc-public.md
+++ b/docs/reference/api/grpc-public.md
@@ -134,19 +134,20 @@ message ApiRequestEnvelope {
 | Field | Required | Source | Semantics |
 |---|---|---|---|
 | `contract_version` | YES | Request payload or negotiated default | SemVer public payload contract. Product 1.0 accepts `1.0.0` on `eigen.api.v1`. |
-| `request_id` | YES | `x-request-id` or payload | Client correlation ID used in audit, logs, metrics exemplars, and traces. |
+| `request_id` | YES | `x-request-id`, payload, or deterministic server derivation | Client correlation ID used in audit, logs, metrics exemplars, and traces. If omitted by an MVP client, the System API derives `req_<sha256-prefix>` from the deterministic serialized request bytes before audit/logging. |
 | `idempotency_key` | CONDITIONAL | `x-idempotency-key` or payload | Required for idempotent `SubmitJob`; optional for read-only calls. |
 | `traceparent` | RECOMMENDED | `traceparent` metadata or payload | W3C TraceContext parent propagated to internal services. |
 | `deadline` | OPTIONAL | gRPC deadline or payload | Client deadline hint normalized before internal dispatch. |
-| `tenant_id` | YES | JWT/auth context or payload | Canonical tenant scope. Auth context wins on conflict. |
-| `project_id` | YES | JWT/auth context or payload | Canonical project scope. Auth context wins on conflict. |
+| `tenant_id` | YES | JWT/auth context, metadata, payload, or deterministic local-dev default | Canonical tenant scope. Auth context wins on conflict; local/dev allow-all mode defaults to `tenant-default` when no tenant is supplied. |
+| `project_id` | YES | JWT/auth context, metadata, payload, or deterministic local-dev default | Canonical project scope. Auth context wins on conflict; local/dev allow-all mode defaults to `project-default` when no project is supplied. |
 | `client_version` | OPTIONAL | `x-client-version` or payload | SDK/CLI version for compatibility diagnostics. |
 
 Version negotiation rules:
 
 - Missing `contract_version` MAY default to `1.0.0` only for backward-compatible MVP clients on the `eigen.api.v1` namespace.
-- Malformed SemVer MUST return `INVALID_ARGUMENT`.
-- Unsupported but well-formed versions MUST return `FAILED_PRECONDITION` with canonical version details.
+- Missing `request_id`, `tenant_id`, or `project_id` is normalized deterministically before dispatch using the sources above; the normalized envelope is the value used for audit, logs, metrics, idempotency scope, and internal forwarding.
+- Malformed SemVer MUST return `INVALID_ARGUMENT` with `google.rpc.ErrorInfo.reason = PUBLIC_CONTRACT_VERSION_MALFORMED`.
+- Unsupported but well-formed versions MUST return `FAILED_PRECONDITION` with `google.rpc.ErrorInfo.reason = PUBLIC_CONTRACT_VERSION_UNSUPPORTED` and the supported version in details metadata.
 - Incompatible MAJOR versions MUST be rejected; they MUST NOT be silently coerced.
 - Compatible MINOR/PATCH versions MAY be accepted only when documented in this file or the Product 1.0 manifest.
 
@@ -196,7 +197,7 @@ message SubmitJobRequest {
 
 | **Field** | **Required** | **Notes** |
 |-------------|------------|-----------|
-| `envelope` | YES | Canonical Product 1.0 request envelope; transport metadata MAY be normalized into this field by the System API |
+| `envelope` | NORMALIZED YES | Canonical Product 1.0 request envelope; transport metadata and deterministic defaults MAY be normalized into this field by the System API for MVP clients |
 | `name` | YES | Human-readable job name |
 | `program` | YES | Exactly one variant required |
 | `target` | YES | Backend/device identifier |
@@ -227,7 +228,6 @@ Rules:
 | Priority outside range | `INVALID_ARGUMENT` |
 | Unknown target | `NOT_FOUND` |
 | Invalid reservation | `FAILED_PRECONDITION` |
-| Missing required envelope identity | `INVALID_ARGUMENT` |
 | Unsupported contract version | `FAILED_PRECONDITION` |
 | Payload exceeds public limit | `RESOURCE_EXHAUSTED` |
 
@@ -261,6 +261,15 @@ The response MUST contain the canonical assigned `job_id`.
 
 Returns current job state.
 
+#### Request
+
+```protobuf
+message GetJobStatusRequest {
+  string job_id = 1;
+  ApiRequestEnvelope envelope = 10;
+}
+```
+
 #### Guarantees
 
 - Read-after-write consistency for same client session
@@ -276,6 +285,7 @@ Returns current job state.
 ```protobuf
 message CancelJobRequest {
   string job_id = 1;
+  ApiRequestEnvelope envelope = 10;
 }
 ```
 
@@ -315,8 +325,8 @@ message CancelJobResponse {
 ```protobuf
 message StreamJobUpdatesRequest {
   string job_id = 1;
-
   uint64 last_event_seq = 2;
+  ApiRequestEnvelope envelope = 10;
 }
 ```
 
@@ -358,6 +368,15 @@ If replay window expired:
 
 Returns immutable final outputs.
 
+#### Request
+
+```protobuf
+message GetJobResultsRequest {
+  string job_id = 1;
+  ApiRequestEnvelope envelope = 10;
+}
+```
+
 #### Preconditions
 
 Job MUST be in terminal state:
@@ -380,6 +399,15 @@ MUST be returned.
 ### 5.6 GetDispatchRationale
 
 Returns scheduler explanation for backend selection.
+
+#### Request
+
+```protobuf
+message GetDispatchRationaleRequest {
+  string job_id = 1;
+  ApiRequestEnvelope envelope = 10;
+}
+```
 
 #### Semantics
 

--- a/proto/eigen/api/v1/job_service.proto
+++ b/proto/eigen/api/v1/job_service.proto
@@ -60,6 +60,8 @@ message SubmitJobResponse {
 }
 
 message GetJobStatusRequest {
+  ApiRequestEnvelope envelope = 10;
+
   string job_id = 1;
 }
 
@@ -68,6 +70,8 @@ message GetJobStatusResponse {
 }
 
 message CancelJobRequest {
+  ApiRequestEnvelope envelope = 10;
+
   string job_id = 1;
 }
 
@@ -77,6 +81,8 @@ message CancelJobResponse {
 }
 
 message StreamJobUpdatesRequest {
+  ApiRequestEnvelope envelope = 10;
+
   string job_id = 1;
 
   // Best-effort resume point (MVP): server MAY start from the next event.
@@ -88,6 +94,8 @@ message StreamJobUpdatesResponse {
 }
 
 message GetJobResultsRequest {
+  ApiRequestEnvelope envelope = 10;
+
   string job_id = 1;
 }
 
@@ -108,6 +116,8 @@ message GetJobResultsResponse {
 }
 
 message GetDispatchRationaleRequest {
+  ApiRequestEnvelope envelope = 10;
+  
   string job_id = 1;
 }
 

--- a/src/services/system-api/src/system_api/grpc_impl.py
+++ b/src/services/system-api/src/system_api/grpc_impl.py
@@ -50,19 +50,90 @@ def _metadata(context: grpc.ServicerContext) -> dict[str, str]:
     return {k.lower(): v for k, v in (context.invocation_metadata() or [])}
 
 
-def _public_envelope(request, context: grpc.ServicerContext):
+@dataclass(frozen=True)
+class NormalizedPublicEnvelope:
+    contract_version: str
+    request_id: str
+    idempotency_key: str
+    traceparent: str
+    tenant_id: str
+    project_id: str
+    client_version: str
+
+
+def _stable_request_id(request) -> str:
+    raw = request.SerializeToString(deterministic=True)
+    return f"req_{sha256(raw).hexdigest()[:24]}"
+
+
+def _public_envelope(request, context: grpc.ServicerContext) -> NormalizedPublicEnvelope:
+
     envelope = getattr(request, "envelope", None)
     md = _metadata(context)
+    _subject, _roles, auth_tenant = auth_context(context)
     contract_version = (
         getattr(envelope, "contract_version", "")
         or md.get("x-eigen-contract-version", "")
         or PUBLIC_API_CONTRACT_VERSION
     ).strip()
     if not _SEMVER_RE.match(contract_version):
-        context.abort(grpc.StatusCode.INVALID_ARGUMENT, f"malformed public contract_version: {contract_version}")
+        abort_with_error_info(
+            context,
+            grpc_code=grpc.StatusCode.INVALID_ARGUMENT,
+            message=f"malformed public contract_version: {contract_version}",
+            reason="PUBLIC_CONTRACT_VERSION_MALFORMED",
+            domain="eigen.api.v1",
+            metadata={"contract_version": contract_version},
+        )
     if contract_version != PUBLIC_API_CONTRACT_VERSION:
-        context.abort(grpc.StatusCode.FAILED_PRECONDITION, f"unsupported public contract_version: {contract_version}")
-    return envelope
+        abort_with_error_info(
+            context,
+            grpc_code=grpc.StatusCode.FAILED_PRECONDITION,
+            message=f"unsupported public contract_version: {contract_version}",
+            reason="PUBLIC_CONTRACT_VERSION_UNSUPPORTED",
+            domain="eigen.api.v1",
+            metadata={
+                "contract_version": contract_version,
+                "supported_contract_version": PUBLIC_API_CONTRACT_VERSION,
+            },
+        )
+
+    request_id = (
+        getattr(envelope, "request_id", "")
+        or md.get("x-request-id", "")
+        or _stable_request_id(request)
+    ).strip()
+    tenant_id = (
+        auth_tenant
+        or getattr(envelope, "tenant_id", "")
+        or md.get("x-eigen-tenant", "")
+        or "tenant-default"
+    ).strip()
+    project_id = (
+        getattr(envelope, "project_id", "")
+        or md.get("x-eigen-project", "")
+        or md.get("x-project-id", "")
+        or "project-default"
+    ).strip()
+    return NormalizedPublicEnvelope(
+        contract_version=contract_version,
+        request_id=request_id,
+        idempotency_key=(
+            getattr(envelope, "idempotency_key", "")
+            or md.get("x-idempotency-key", "")
+            or md.get("x-eigen-idempotency-key", "")
+        ).strip(),
+        traceparent=(getattr(envelope, "traceparent", "") or md.get("traceparent", "")).strip(),
+        tenant_id=tenant_id or "tenant-default",
+        project_id=project_id or "project-default",
+        client_version=(getattr(envelope, "client_version", "") or md.get("x-client-version", "")).strip(),
+    )
+
+
+def _apply_public_envelope_context(rc, envelope: NormalizedPublicEnvelope) -> None:
+    rc.request_id = envelope.request_id
+    if envelope.traceparent and not rc.traceparent:
+        rc.traceparent = envelope.traceparent
 
 
 def _envelope_value(envelope, field: str) -> str:
@@ -159,12 +230,13 @@ class JobService:
         self._starvation_threshold_sec = max(float(os.getenv("EIGEN_SCHED_STARVATION_SEC", "2.0")), 0.0)
         self._dispatch_slot_seq = 0
 
-    def _request_fingerprint(self, request) -> str:
-        envelope = getattr(request, "envelope", None)
+    def _request_fingerprint(
+        self, request, envelope: NormalizedPublicEnvelope
+    ) -> str:
         payload = {
-            "contract_version": _envelope_value(envelope, "contract_version") or PUBLIC_API_CONTRACT_VERSION,
-            "tenant_id": _envelope_value(envelope, "tenant_id") or request.metadata.get("tenant_id", ""),
-            "project_id": _envelope_value(envelope, "project_id") or request.metadata.get("project_id", ""),
+            "contract_version": envelope.contract_version,
+            "tenant_id": envelope.tenant_id,
+            "project_id": envelope.project_id,
             "name": request.name,
             "target": request.target,
             "priority": int(request.priority),
@@ -191,18 +263,17 @@ class JobService:
         raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
         return sha256(raw).hexdigest()
 
-    def _idempotency_key(self, request, context: grpc.ServicerContext, envelope) -> str | None:
-        md = _metadata(context)
+    def _idempotency_key(
+        self,
+        request,
+        _context: grpc.ServicerContext,
+        envelope: NormalizedPublicEnvelope,
+    ) -> str | None:
         tenant_id = (
-            _envelope_value(envelope, "tenant_id")
-            or md.get("x-eigen-tenant", "")
-            or request.metadata.get("tenant_id", "tenant-default")
+            envelope.tenant_id or request.metadata.get("tenant_id", "tenant-default")
         ).strip() or "tenant-default"
         key = (
-            _envelope_value(envelope, "idempotency_key")
-            or md.get("x-idempotency-key", "")
-            or md.get("x-eigen-idempotency-key", "")
-            or request.metadata.get("client_request_id", "")
+            envelope.idempotency_key or request.metadata.get("client_request_id", "")
         ).strip()
         if key:
             return ":".join(("tenant", tenant_id, "idempotency", key))
@@ -603,11 +674,17 @@ class JobService:
         trace_id: str | None,
         owner_subject: str,
         owner_tenant: str,
+        owner_project: str,
     ) -> _JobRecord:
         metadata = dict(request.metadata)
         tenant_envelope = request.tenant
         tenant_id = (tenant_envelope.tenant_id or metadata.get("tenant_id") or owner_tenant or "tenant-default").strip() or "tenant-default"
-        project_id = (tenant_envelope.project_id or metadata.get("project_id") or "project-default").strip() or "project-default"
+        project_id = (
+            tenant_envelope.project_id
+            or metadata.get("project_id")
+            or owner_project
+            or "project-default"
+        ).strip() or "project-default"
         tenant_quota_limit = int(tenant_envelope.tenant_max_queued_jobs or os.getenv("EIGEN_SCHED_TENANT_QUOTA_MAX_QUEUED", "16"))
         project_quota_limit = int(tenant_envelope.project_max_queued_jobs or os.getenv("EIGEN_SCHED_PROJECT_QUOTA_MAX_QUEUED", "8"))
         created_at_dt = created_at.ToDatetime().replace(tzinfo=timezone.utc)
@@ -1015,6 +1092,7 @@ class JobService:
         log_request_start("JobService.SubmitJob", rc)
 
         envelope = _public_envelope(request, context)
+        _apply_public_envelope_context(rc, envelope)
 
         violations = validate_submit_job(request)
         if violations:
@@ -1026,7 +1104,7 @@ class JobService:
             context.abort(grpc.StatusCode.INVALID_ARGUMENT, f"dag resolution failed: {dag.reason_code}: {dag.detail}")
 
         idem_key = self._idempotency_key(request, context, envelope)
-        request_fingerprint = self._request_fingerprint(request)
+        request_fingerprint = self._request_fingerprint(request, envelope)
 
         with self._lock:
             if idem_key:
@@ -1060,14 +1138,15 @@ class JobService:
             rc.job_id = job_id
             now = _ts_now()
             trace_id = rc.trace_id or request.metadata.get("trace_id", "").strip() or None
-            owner_subject, _, owner_tenant = auth_context(context)
+            owner_subject, _, _owner_tenant = auth_context(context)
             record = self._build_job_record(
                 request,
                 job_id=job_id,
                 created_at=now,
                 trace_id=trace_id,
                 owner_subject=owner_subject,
-                owner_tenant=owner_tenant,
+                owner_tenant=envelope.tenant_id,
+                owner_project=envelope.project_id,
             )
             self._jobs[job_id] = record
             self._assign_scheduler_slot(record)
@@ -1099,6 +1178,8 @@ class JobService:
         rc = new_request_context(context)
         rc.job_id = request.job_id
         log_request_start("JobService.GetJobStatus", rc)
+        envelope = _public_envelope(request, context)
+        _apply_public_envelope_context(rc, envelope)
 
         violations = validate_job_id(request)
         if violations:
@@ -1140,6 +1221,8 @@ class JobService:
         rc = new_request_context(context)
         rc.job_id = request.job_id
         log_request_start("JobService.CancelJob", rc)
+        envelope = _public_envelope(request, context)
+        _apply_public_envelope_context(rc, envelope)
 
         violations = validate_job_id(request)
         if violations:
@@ -1173,6 +1256,8 @@ class JobService:
         rc = new_request_context(context)
         rc.job_id = request.job_id
         log_request_start("JobService.StreamJobUpdates", rc)
+        envelope = _public_envelope(request, context)
+        _apply_public_envelope_context(rc, envelope)
 
         violations = validate_job_id(request)
         if violations:
@@ -1211,6 +1296,8 @@ class JobService:
         rc = new_request_context(context)
         rc.job_id = request.job_id
         log_request_start("JobService.GetJobResults", rc)
+        envelope = _public_envelope(request, context)
+        _apply_public_envelope_context(rc, envelope)
 
         violations = validate_job_id(request)
         if violations:
@@ -1258,6 +1345,8 @@ class JobService:
         rc = new_request_context(context)
         rc.job_id = request.job_id
         log_request_start("JobService.GetDispatchRationale", rc)
+        envelope = _public_envelope(request, context)
+        _apply_public_envelope_context(rc, envelope)
 
         violations = validate_job_id(request)
         if violations:
@@ -1327,7 +1416,8 @@ class DeviceService:
         enforce_authz(context, required_permission="devices:list")
         rc = new_request_context(context)
         log_request_start("DeviceService.ListDevices", rc)
-        _public_envelope(request, context)
+        envelope = _public_envelope(request, context)
+        _apply_public_envelope_context(rc, envelope)
 
         # backend_type is optional
         resp = self._dev_pb.ListDevicesResponse(
@@ -1352,7 +1442,8 @@ class DeviceService:
         enforce_authz(context, required_permission="devices:list")
         rc = new_request_context(context)
         log_request_start("DeviceService.GetDeviceDetails", rc)
-        _public_envelope(request, context)
+        envelope = _public_envelope(request, context)
+        _apply_public_envelope_context(rc, envelope)
 
         violations = validate_device_id(request)
         if violations:
@@ -1375,7 +1466,8 @@ class DeviceService:
         enforce_authz(context, required_permission="devices:list")
         rc = new_request_context(context)
         log_request_start("DeviceService.GetDeviceStatus", rc)
-        _public_envelope(request, context)
+        envelope = _public_envelope(request, context)
+        _apply_public_envelope_context(rc, envelope)
 
         violations = validate_device_id(request)
         if violations:
@@ -1397,7 +1489,8 @@ class DeviceService:
         enforce_authz(context, required_permission="devices:reserve")
         rc = new_request_context(context)
         log_request_start("DeviceService.ReserveDevice", rc)
-        _public_envelope(request, context)
+        envelope = _public_envelope(request, context)
+        _apply_public_envelope_context(rc, envelope)
 
         violations = validate_reserve_device(request)
         if violations:

--- a/src/services/system-api/tests/test_public_envelope_versioning.py
+++ b/src/services/system-api/tests/test_public_envelope_versioning.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import grpc
+import pytest
+from google.rpc import error_details_pb2
+from grpc_status import rpc_status
+
+from system_api.proto_gen import ensure_generated
+
+ensure_generated()
+
+from eigen.api.v1 import device_service_pb2 as dev_pb  # noqa: E402
+from eigen.api.v1 import device_service_pb2_grpc as dev_pb_grpc  # noqa: E402
+from eigen.api.v1 import job_service_pb2 as job_pb  # noqa: E402
+from eigen.api.v1 import job_service_pb2_grpc as job_pb_grpc  # noqa: E402
+from eigen.api.v1 import types_pb2 as types_pb  # noqa: E402
+
+
+def _submit_request(envelope: types_pb.ApiRequestEnvelope | None = None) -> job_pb.SubmitJobRequest:
+    kwargs = {}
+    if envelope is not None:
+        kwargs["envelope"] = envelope
+    return job_pb.SubmitJobRequest(
+        name="versioned-envelope-job",
+        target="sim:local",
+        eigen_lang=types_pb.EigenLangSource(source=b"fn main() {}\n", entrypoint="main", sha256="env-v1"),
+        **kwargs,
+    )
+
+
+def _error_info(err: grpc.RpcError) -> error_details_pb2.ErrorInfo:
+    status = rpc_status.from_call(err)
+    assert status is not None
+    info = error_details_pb2.ErrorInfo()
+    assert status.details
+    assert status.details[0].Unpack(info)
+    return info
+
+
+def test_missing_contract_version_defaults_to_product_1(grpc_addr: str) -> None:
+    channel = grpc.insecure_channel(grpc_addr)
+    job_stub = job_pb_grpc.JobServiceStub(channel)
+    dev_stub = dev_pb_grpc.DeviceServiceStub(channel)
+
+    submitted = job_stub.SubmitJob(_submit_request())
+    assert submitted.job_id
+
+    status = job_stub.GetJobStatus(job_pb.GetJobStatusRequest(job_id=submitted.job_id))
+    assert status.status.job_id == submitted.job_id
+
+    devices = dev_stub.ListDevices(dev_pb.ListDevicesRequest())
+    assert [device.device_id for device in devices.devices] == ["sim:local"]
+
+
+@pytest.mark.parametrize(
+    "rpc_request, code, reason",
+    [
+        (
+            job_pb.GetJobStatusRequest(
+                job_id="job_missing",
+                envelope=types_pb.ApiRequestEnvelope(contract_version="not-semver"),
+            ),
+            grpc.StatusCode.INVALID_ARGUMENT,
+            "PUBLIC_CONTRACT_VERSION_MALFORMED",
+        ),
+        (
+            job_pb.GetJobStatusRequest(
+                job_id="job_missing",
+                envelope=types_pb.ApiRequestEnvelope(contract_version="2.0.0"),
+            ),
+            grpc.StatusCode.FAILED_PRECONDITION,
+            "PUBLIC_CONTRACT_VERSION_UNSUPPORTED",
+        ),
+        (
+            job_pb.GetJobStatusRequest(
+                job_id="job_missing",
+                envelope=types_pb.ApiRequestEnvelope(contract_version="1.1.0"),
+            ),
+            grpc.StatusCode.FAILED_PRECONDITION,
+            "PUBLIC_CONTRACT_VERSION_UNSUPPORTED",
+        ),
+    ],
+)
+def test_job_read_requests_reject_malformed_future_and_unsupported_versions(
+    grpc_addr: str,
+    rpc_request: job_pb.GetJobStatusRequest,
+    code: grpc.StatusCode,
+    reason: str,
+) -> None:
+    channel = grpc.insecure_channel(grpc_addr)
+    stub = job_pb_grpc.JobServiceStub(channel)
+
+    with pytest.raises(grpc.RpcError) as err:
+        stub.GetJobStatus(rpc_request)
+
+    assert err.value.code() == code
+    assert _error_info(err.value).reason == reason
+
+
+def test_metadata_contract_version_is_validated_before_device_dispatch(grpc_addr: str) -> None:
+    channel = grpc.insecure_channel(grpc_addr)
+    stub = dev_pb_grpc.DeviceServiceStub(channel)
+
+    with pytest.raises(grpc.RpcError) as err:
+        stub.ListDevices(
+            dev_pb.ListDevicesRequest(),
+            metadata=(("x-eigen-contract-version", "9.0.0"),),
+        )
+
+    assert err.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+    info = _error_info(err.value)
+    assert info.reason == "PUBLIC_CONTRACT_VERSION_UNSUPPORTED"
+    assert info.metadata["supported_contract_version"] == "1.0.0"
+    


### PR DESCRIPTION
## Summary

- Added ApiRequestEnvelope to read-side JobService request protos so status, cancel, stream, results, and dispatch-rationale calls participate in the Product 1.0 public envelope contract.

- Implemented System API public envelope normalization with deterministic request IDs, tenant/project defaults, metadata-derived fields, and structured canonical rejections for malformed or unsupported contract versions.

- Wired normalized envelopes into SubmitJob idempotency scoping/fingerprints and into JobService/DeviceService runtime request handling before dispatch.

- Added conformance tests covering deterministic defaulting, malformed versions, future/unsupported versions, and metadata-driven compatibility rejection.

- Updated public gRPC reference, System API architecture responsibilities, and Wave 1 compatibility/completion evidence for W1-02.
 

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: API | Compatibility matrix | Metrics
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None