### PR TITLE
Canonical public error model and error mapping conformance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Before `1.0.0`, breaking changes may occur in minor versions. After `1.0.0`, bre
 
 ### Added
 
+- Product 1.0 Wave-1 W1-05 public error conformance (`system-api` package `1.0.0-major-marker`) with canonical `google.rpc.Status` construction, `EIGEN_PUBLIC_*` reason codes, retryability metadata, and conformance coverage for validation, auth, idempotency conflict, version mismatch, payload limit, deadline, cancellation, unavailable, and internal failure shapes.
 - Phase-9B P9B-06 canary rollout + auto-rollback safety pack (`benchmark-service` package `0.11.0`) with deterministic canary cohort/window policy fields, auditable stable canary reason codes, and automatic rollback envelopes that pin stable target model version and 15-minute restore SLO metadata.
 - Phase-8D P8D-06 developer surfaces skeleton pack (`governance-docs` package `0.13.0`) with non-GA bootstrap artifacts for web dashboard, VS Code, and Jupyter surfaces, simulator walkthrough docs, and explicit System API parity alignment constraints.
 - Phase-8D P8D-07 operator rollback governance pack (`driver-manager` package `0.8.0`) with official-provider runbooks for outage/degradation/auth/quota incidents, deterministic rollback controls (adapter pin/quarantine/matrix demotion), and fixture-tested rollback-safety rehearsal checks for simulator/IBM/AWS.
@@ -226,6 +227,8 @@ Before `1.0.0`, breaking changes may occur in minor versions. After `1.0.0`, bre
 
 ### Changed
 
+- **MAJOR marker:** Public error reason codes for contract-version failures now use the `EIGEN_PUBLIC_*` namespace (`EIGEN_PUBLIC_CONTRACT_VERSION_MALFORMED`, `EIGEN_PUBLIC_CONTRACT_VERSION_UNSUPPORTED`), validation errors expose `ErrorInfo` before `BadRequest`, and public payload-limit failures map to `RESOURCE_EXHAUSTED` with `EIGEN_PUBLIC_PAYLOAD_LIMIT_EXCEEDED` plus `BadRequest`/`QuotaFailure` details.
+- **Migration notes:** SDKs and clients that previously matched `PUBLIC_CONTRACT_VERSION_*` or expected `BadRequest` as the first detail must switch to reading `google.rpc.ErrorInfo` from detail index 0 and use `ErrorInfo.reason` + `ErrorInfo.metadata.retryable`; clients that treated payload-limit validation as `INVALID_ARGUMENT` must handle `RESOURCE_EXHAUSTED` and surface the included field violations/quota detail.
 - Phase-1 is marked complete in roadmap and development planning docs with explicit closure date (**2026-04-27**).
 - Product/service package versions advanced from `0.2.0` to `0.3.0` for Phase-2 release closure.
 

--- a/docs/architecture/contract-map.md
+++ b/docs/architecture/contract-map.md
@@ -634,12 +634,14 @@ Canonical statuses:
 - `ABORTED`
 - `CANCELLED`
 
-Structured details (where applicable):
+Structured details at public boundaries must be encoded as deterministic `google.rpc.Status` details with `google.rpc.ErrorInfo` first. `ErrorInfo.reason` carries the stable `EIGEN_PUBLIC_*` or normalized `EIGEN_BACKEND_*` reason code, and `ErrorInfo.metadata.retryable` carries the public retryability decision. Additional detail types are attached according to the scenario:
 
-- `google.rpc.BadRequest`
-- `google.rpc.ErrorInfo`
-- `google.rpc.ResourceInfo`
-- `google.rpc.RetryInfo`
+- `google.rpc.BadRequest` for validation and payload shape failures
+- `google.rpc.QuotaFailure` for payload/quota limits
+- `google.rpc.PreconditionFailure` for lifecycle, version, and idempotency conflicts
+- `google.rpc.ResourceInfo` for missing or inaccessible resources
+- `google.rpc.RetryInfo` for retryable transient failures
+- `google.rpc.RequestInfo` for cancellation/internal correlation when available
 
 Backend/provider failures must be normalized before reaching public contracts.
 

--- a/docs/reference/api/grpc-public.md
+++ b/docs/reference/api/grpc-public.md
@@ -146,8 +146,8 @@ Version negotiation rules:
 
 - Missing `contract_version` MAY default to `1.0.0` only for backward-compatible MVP clients on the `eigen.api.v1` namespace.
 - Missing `request_id`, `tenant_id`, or `project_id` is normalized deterministically before dispatch using the sources above; the normalized envelope is the value used for audit, logs, metrics, idempotency scope, and internal forwarding.
-- Malformed SemVer MUST return `INVALID_ARGUMENT` with `google.rpc.ErrorInfo.reason = PUBLIC_CONTRACT_VERSION_MALFORMED`.
-- Unsupported but well-formed versions MUST return `FAILED_PRECONDITION` with `google.rpc.ErrorInfo.reason = PUBLIC_CONTRACT_VERSION_UNSUPPORTED` and the supported version in details metadata.
+- Malformed SemVer MUST return `INVALID_ARGUMENT` with `google.rpc.ErrorInfo.reason = EIGEN_PUBLIC_CONTRACT_VERSION_MALFORMED`.
+- Unsupported but well-formed versions MUST return `FAILED_PRECONDITION` with `google.rpc.ErrorInfo.reason = EIGEN_PUBLIC_CONTRACT_VERSION_UNSUPPORTED` and the supported version in details metadata.
 - Incompatible MAJOR versions MUST be rejected; they MUST NOT be silently coerced.
 - Compatible MINOR/PATCH versions MAY be accepted only when documented in this file or the Product 1.0 manifest.
 
@@ -230,7 +230,7 @@ Rules:
 | Unknown target | `NOT_FOUND` |
 | Invalid reservation | `FAILED_PRECONDITION` |
 | Unsupported contract version | `FAILED_PRECONDITION` |
-| Payload exceeds public limit | `INVALID_ARGUMENT` with field violations at the System API boundary; deployments MAY map ingress byte-quota failures to `RESOURCE_EXHAUSTED` before deserialization |
+| Payload exceeds public limit | `RESOURCE_EXHAUSTED` with `EIGEN_PUBLIC_PAYLOAD_LIMIT_EXCEEDED`, `BadRequest`, and `QuotaFailure` details |
 
 #### Response
 
@@ -557,32 +557,35 @@ Returns paginated immutable decision logs filtered by trace ID and/or model vers
 
 ## 8. Error Model
 
-Public APIs use canonical gRPC status codes.
+Public APIs use the canonical public error model in `docs/reference/error-model.md` and the mapping matrix in `docs/reference/error-mapping.md`. Every public failure MUST be represented as `google.rpc.Status` with a deterministic gRPC status code, stable `google.rpc.ErrorInfo.reason`, retryability metadata, and structured details appropriate for the failure shape. Public responses MUST NOT leak raw internal exceptions, stack traces, provider-private payloads, credentials, filesystem paths, or unnormalized backend errors.
 
 #### Allowed Status Codes
 
-| **Code** | **Meaning** |
-|----------|-----------|
-| `INVALID_ARGUMENT` | Validation failure |
-| `UNAUTHENTICATED` | Missing/invalid auth |
-| `PERMISSION_DENIED` | Insufficient scope |
-| `NOT_FOUND` | Missing resource |
-| `FAILED_PRECONDITION` | Invalid state transition |
-| `RESOURCE_EXHAUSTED` | Quota exceeded |
-| `UNAVAILABLE` | Backend unavailable |
-| `DEADLINE_EXCEEDED` | Timeout |
-| `FAILED_PRECONDITION` | Invalid state transition or idempotency conflict |
-| `OUT_OF_RANGE` | Stream replay cursor outside retention window |
-| `INTERNAL` | Unexpected failure |
+| **Code** | **Meaning** | **Canonical public reason examples** | **Retryability** |
+|----------|-----------|-----------|-----------|
+| `INVALID_ARGUMENT` | Validation failure | `EIGEN_PUBLIC_VALIDATION_FAILED`, `EIGEN_PUBLIC_CONTRACT_VERSION_MALFORMED` | No |
+| `UNAUTHENTICATED` | Missing/invalid auth | `EIGEN_PUBLIC_UNAUTHENTICATED` | After re-authentication |
+| `PERMISSION_DENIED` | Insufficient scope | `EIGEN_PUBLIC_PERMISSION_DENIED` | No |
+| `NOT_FOUND` | Missing resource | `EIGEN_PUBLIC_JOB_NOT_FOUND` | No unless documented eventual consistency applies |
+| `FAILED_PRECONDITION` | Invalid state transition, version mismatch, or idempotency conflict | `EIGEN_PUBLIC_RESULTS_NOT_READY`, `EIGEN_PUBLIC_CONTRACT_VERSION_UNSUPPORTED`, `EIGEN_PUBLIC_IDEMPOTENCY_CONFLICT` | Conditional |
+| `RESOURCE_EXHAUSTED` | Payload/quota/capacity limit exceeded | `EIGEN_PUBLIC_PAYLOAD_LIMIT_EXCEEDED` | Retry only after reducing payload or waiting for quota/capacity recovery |
+| `UNAVAILABLE` | Backend/service temporarily unavailable | `EIGEN_PUBLIC_UNAVAILABLE`, `EIGEN_BACKEND_UNAVAILABLE` | Yes with backoff |
+| `DEADLINE_EXCEEDED` | Deadline budget exceeded | `EIGEN_PUBLIC_DEADLINE_EXCEEDED` | Conditional on idempotency |
+| `ABORTED` | Coordination/idempotent conflict that can be retried | `EIGEN_PUBLIC_CONFLICT_ABORTED` | Yes with backoff/jitter |
+| `CANCELLED` | Caller/runtime cancellation | `EIGEN_PUBLIC_CANCELLED` | Caller-defined |
+| `OUT_OF_RANGE` | Stream replay cursor outside retention window | `EIGEN_PUBLIC_STREAM_CURSOR_OUT_OF_RANGE` | No without a new cursor |
+| `INTERNAL` | Unexpected failure | `EIGEN_PUBLIC_INTERNAL` | Conditional, bounded retry only |
 
 #### Error Details
 
-Structured protobuf error details SHOULD be attached:
+Structured protobuf error details are mandatory at the public boundary where supported. Detail ordering MUST be deterministic with `google.rpc.ErrorInfo` first so SDKs can extract `reason` and `metadata.retryable` uniformly. Scenario-specific details then follow:
 
-- field violations
-- quota failures
-- retry hints
-- resource metadata
+- validation: `BadRequest` field violations,
+- payload/quota limits: `BadRequest` plus `QuotaFailure`,
+- retryable transient failures: `RetryInfo`,
+- missing resources: `ResourceInfo`,
+- lifecycle/idempotency/version conflicts: `PreconditionFailure`,
+- cancellation/internal correlation: `RequestInfo` when a request identifier is available.
 
 ---
 

--- a/docs/reference/error-mapping.md
+++ b/docs/reference/error-mapping.md
@@ -421,11 +421,12 @@ Retryability:
 | Invalid JobSpec | Compiler/parser | `INVALID_ARGUMENT` | RPC failure or async `ERROR` | No |
 | Invalid AQO schema | Compiler/runtime | `INVALID_ARGUMENT` | RPC failure | No |
 | Invalid artifact checksum | Artifact layer | `INVALID_ARGUMENT` | RPC failure | No |
+| Payload exceeds public API limit | API gateway | `RESOURCE_EXHAUSTED` + `EIGEN_PUBLIC_PAYLOAD_LIMIT_EXCEEDED` | RPC failure | No until caller reduces payload |
 | Unknown job_id | Kernel/QFS | `NOT_FOUND` | RPC failure | Conditional |
 | Unknown shard | Distributed runtime | `NOT_FOUND` | RPC failure | No |
 | Unknown reservation | Reservation manager | `NOT_FOUND` | RPC failure | No |
 | Duplicate artifact upload | Artifact store | `ALREADY_EXISTS` | RPC failure | No |
-| Duplicate idempotency key with different normalized payload | API gateway | `FAILED_PRECONDITION` | RPC failure | No |
+| Duplicate idempotency key with different normalized payload | API gateway | `FAILED_PRECONDITION` + `EIGEN_PUBLIC_IDEMPOTENCY_CONFLICT` | RPC failure | No |
 | Results requested before completion | Runtime lifecycle | `FAILED_PRECONDITION` | RPC failure | Yes |
 | Merge before quorum satisfied | Runtime merge layer | `FAILED_PRECONDITION` | RPC failure | Yes |
 | Reservation expired | Device runtime | `FAILED_PRECONDITION` | RPC failure | Conditional |
@@ -440,11 +441,12 @@ Retryability:
 | Lease conflict | Cluster runtime | `ABORTED` | RPC failure | Yes |
 | Worker unavailable | Cluster runtime | `UNAVAILABLE` | RPC failure | Yes |
 | Cluster partition | Distributed runtime | `UNAVAILABLE` | RPC failure | Yes |
-| Deadline exceeded | Any service | `DEADLINE_EXCEEDED` | RPC failure | Conditional |
-| Invalid authentication | Auth layer | `UNAUTHENTICATED` | RPC failure | Yes |
-| Permission denied | Authorization layer | `PERMISSION_DENIED` | RPC failure | No |
-| Runtime invariant violation | Any service | `INTERNAL` | RPC failure | Conditional |
-| Explicit cancellation | Caller/runtime | `CANCELLED` | RPC failure | Caller-defined |
+| Deadline exceeded | Any service | `DEADLINE_EXCEEDED` + `EIGEN_PUBLIC_DEADLINE_EXCEEDED` | RPC failure | Conditional |
+| Invalid authentication | Auth layer | `UNAUTHENTICATED` + `EIGEN_PUBLIC_UNAUTHENTICATED` | RPC failure | Yes, after re-authentication |
+| Permission denied | Authorization layer | `PERMISSION_DENIED` + `EIGEN_PUBLIC_PERMISSION_DENIED` | RPC failure | No |
+| Runtime invariant violation | Any service | `INTERNAL` + `EIGEN_PUBLIC_INTERNAL` | RPC failure | Conditional |
+| Explicit cancellation | Caller/runtime | `CANCELLED` + `EIGEN_PUBLIC_CANCELLED` | RPC failure | Caller-defined |
+
 
 ---
 

--- a/docs/reference/error-model.md
+++ b/docs/reference/error-model.md
@@ -517,7 +517,28 @@ Examples:
 
 ---
 
-### 3.7 Localization Safety
+### 3.7 Public Boundary Conformance
+
+Public API implementations MUST normalize every public error into a deterministic `google.rpc.Status` before returning it to SDKs, CLI tools, or external callers. The public boundary contract is:
+
+| **Failure class** | **Status** | **Reason** | **Retryable metadata** | **Required detail shape** |
+|---|---|---|---|---|
+| Validation failure | `INVALID_ARGUMENT` | `EIGEN_PUBLIC_VALIDATION_FAILED` | `false` | `ErrorInfo`, `BadRequest` |
+| Authentication failure | `UNAUTHENTICATED` | `EIGEN_PUBLIC_UNAUTHENTICATED` | `true` after re-authentication | `ErrorInfo` |
+| Authorization denial | `PERMISSION_DENIED` | `EIGEN_PUBLIC_PERMISSION_DENIED` | `false` | `ErrorInfo` |
+| Idempotency payload conflict | `FAILED_PRECONDITION` | `EIGEN_PUBLIC_IDEMPOTENCY_CONFLICT` | `false` | `ErrorInfo`, `PreconditionFailure` |
+| Public contract version mismatch | `FAILED_PRECONDITION` | `EIGEN_PUBLIC_CONTRACT_VERSION_UNSUPPORTED` | `false` | `ErrorInfo`, optional `PreconditionFailure` |
+| Payload limit exceeded | `RESOURCE_EXHAUSTED` | `EIGEN_PUBLIC_PAYLOAD_LIMIT_EXCEEDED` | `false` | `ErrorInfo`, `BadRequest`, `QuotaFailure` |
+| Deadline exceeded | `DEADLINE_EXCEEDED` | `EIGEN_PUBLIC_DEADLINE_EXCEEDED` | conditional | `ErrorInfo`, optional `RetryInfo` |
+| Cancellation | `CANCELLED` | `EIGEN_PUBLIC_CANCELLED` | caller-defined | `ErrorInfo`, optional `RequestInfo` |
+| Temporary unavailable | `UNAVAILABLE` | `EIGEN_PUBLIC_UNAVAILABLE` or normalized `EIGEN_BACKEND_UNAVAILABLE` | `true` | `ErrorInfo`, `RetryInfo` |
+| Unexpected internal failure | `INTERNAL` | `EIGEN_PUBLIC_INTERNAL` | conditional | `ErrorInfo`, optional `RequestInfo`; `DebugInfo` only for trusted/internal callers |
+
+`google.rpc.ErrorInfo` MUST be the first detail entry for public errors. Its metadata MUST include `retryable` with a string value of `true` or `false`. Implementations MAY add bounded, non-sensitive correlation metadata, but MUST NOT expose raw internal exceptions, provider-private payloads, secrets, filesystem paths, or stack traces to public callers.
+
+---
+
+### 3.8 Localization Safety
 
 User-facing messages MAY include: `google.rpc.LocalizedMessage`
 

--- a/src/services/system-api/src/system_api/errors.py
+++ b/src/services/system-api/src/system_api/errors.py
@@ -33,31 +33,134 @@ def _grpc_code_int(code: grpc.StatusCode) -> int:
     return int(code.value[0])
 
 
+@dataclass(frozen=True)
+class PublicErrorSpec:
+    """Canonical public error contract emitted at the API boundary."""
+
+    grpc_code: grpc.StatusCode
+    message: str
+    reason: str
+    retryable: bool
+    domain: str = "eigen.api.v1"
+    metadata: dict[str, str] | None = None
+    violations: Sequence[FieldViolation] = ()
+    retry_delay_seconds: int | None = None
+    resource_type: str = ""
+    resource_name: str = ""
+    precondition_type: str = ""
+    precondition_subject: str = ""
+    quota_subject: str = ""
+    request_id: str = ""
+    detail: str = ""
+
+
+def build_public_status(spec: PublicErrorSpec) -> status_pb2.Status:
+    """Build deterministic google.rpc.Status details for public errors.
+
+    Detail order is intentionally stable: ErrorInfo is always first so SDKs can
+    extract reason/retryability uniformly, followed by scenario-specific detail
+    messages required by docs/reference/error-model.md.
+    """
+
+    metadata = dict(spec.metadata or {})
+    metadata["retryable"] = "true" if spec.retryable else "false"
+    st = status_pb2.Status(code=_grpc_code_int(spec.grpc_code), message=spec.message)
+    st.details.add().Pack(
+        error_details_pb2.ErrorInfo(
+            reason=spec.reason,
+            domain=spec.domain,
+            metadata={k: str(metadata[k]) for k in sorted(metadata)},
+        )
+    )
+    if spec.violations:
+        st.details.add().Pack(
+            error_details_pb2.BadRequest(
+                field_violations=[
+                    error_details_pb2.BadRequest.FieldViolation(field=v.field, description=v.description)
+                    for v in spec.violations
+                ]
+            )
+        )
+    if spec.retry_delay_seconds is not None:
+        retry = error_details_pb2.RetryInfo()
+        retry.retry_delay.seconds = int(spec.retry_delay_seconds)
+        st.details.add().Pack(retry)
+    if spec.resource_type or spec.resource_name:
+        st.details.add().Pack(
+            error_details_pb2.ResourceInfo(
+                resource_type=spec.resource_type,
+                resource_name=spec.resource_name,
+                description=spec.detail,
+            )
+        )
+    if spec.precondition_type or spec.precondition_subject:
+        violation = error_details_pb2.PreconditionFailure.Violation(
+            type=spec.precondition_type or spec.reason,
+            subject=spec.precondition_subject,
+            description=spec.detail or spec.message,
+        )
+        st.details.add().Pack(error_details_pb2.PreconditionFailure(violations=[violation]))
+    if spec.quota_subject:
+        violation = error_details_pb2.QuotaFailure.Violation(
+            subject=spec.quota_subject,
+            description=spec.detail or spec.message,
+        )
+        st.details.add().Pack(error_details_pb2.QuotaFailure(violations=[violation]))
+    if spec.request_id:
+        st.details.add().Pack(error_details_pb2.RequestInfo(request_id=spec.request_id))
+    return st
+
+
+def abort_public(context: grpc.ServicerContext, spec: PublicErrorSpec) -> None:
+    """Abort RPC with canonical public google.rpc.Status details."""
+
+    context.abort_with_status(rpc_status.to_status(build_public_status(spec)))
+
+
+def abort_validation(
+    context: grpc.ServicerContext,
+    message: str,
+    violations: Sequence[FieldViolation],
+) -> None:
+    abort_public(
+        context,
+        PublicErrorSpec(
+            grpc_code=grpc.StatusCode.INVALID_ARGUMENT,
+            message=message,
+            reason=reason,
+            retryable=False,
+            metadata=metadata,
+            violations=violations,
+        ),
+    )
+
+def abort_payload_limit(
+    context: grpc.ServicerContext,
+    message: str,
+    violations: Sequence[FieldViolation],
+) -> None:
+    abort_public(
+        context,
+        PublicErrorSpec(
+            grpc_code=grpc.StatusCode.RESOURCE_EXHAUSTED,
+            message=message,
+            reason="EIGEN_PUBLIC_PAYLOAD_LIMIT_EXCEEDED",
+            retryable=False,
+            metadata={"limit_class": "payload"},
+            violations=violations,
+            quota_subject="request.payload",
+            detail="Reduce request payload size and retry with a smaller request.",
+        ),
+    )
+
 def abort_invalid_argument(
     context: grpc.ServicerContext,
     message: str,
     violations: Sequence[FieldViolation],
 ) -> None:
-    """Abort the current RPC with INVALID_ARGUMENT + BadRequest details."""
+    """Abort the current RPC with INVALID_ARGUMENT + canonical public details."""
 
-    bad_request = error_details_pb2.BadRequest(
-        field_violations=[
-            error_details_pb2.BadRequest.FieldViolation(
-                field=v.field,
-                description=v.description,
-            )
-            for v in violations
-        ]
-    )
-
-    st = status_pb2.Status(
-        code=_grpc_code_int(grpc.StatusCode.INVALID_ARGUMENT),
-        message=message,
-    )
-    st.details.add().Pack(bad_request)
-
-    context.abort_with_status(rpc_status.to_status(st))
-
+    abort_validation(context, message, violations)
 
 def abort_with_error_info(
     context: grpc.ServicerContext,
@@ -68,19 +171,26 @@ def abort_with_error_info(
     domain: str,
     metadata: dict[str, str] | None = None,
 ) -> None:
-    """Abort RPC with google.rpc.ErrorInfo details for stable machine parsing."""
-    info = error_details_pb2.ErrorInfo(
-        reason=reason,
-        domain=domain,
-        metadata=metadata or {},
-    )
-    st = status_pb2.Status(
-        code=_grpc_code_int(grpc_code),
-        message=message,
-    )
-    st.details.add().Pack(info)
-    context.abort_with_status(rpc_status.to_status(st))
+    """Abort RPC with canonical public ErrorInfo details for stable parsing."""
 
+    abort_public(
+        context,
+        PublicErrorSpec(
+            grpc_code=grpc_code,
+            message=message,
+            reason=reason,
+            domain=domain,
+            retryable=grpc_code in {
+                grpc.StatusCode.UNAVAILABLE,
+                grpc.StatusCode.RESOURCE_EXHAUSTED,
+                grpc.StatusCode.ABORTED,
+            },
+            metadata=metadata,
+            retry_delay_seconds=1
+            if grpc_code in {grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.RESOURCE_EXHAUSTED, grpc.StatusCode.ABORTED}
+            else None,
+        ),
+    )
 
 def required_string(value: str, field: str) -> Iterable[FieldViolation]:
     if not value:

--- a/src/services/system-api/src/system_api/grpc_impl.py
+++ b/src/services/system-api/src/system_api/grpc_impl.py
@@ -20,7 +20,7 @@ from google.protobuf.timestamp_pb2 import Timestamp
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from .errors import abort_invalid_argument, abort_with_error_info
+from .errors import FieldViolation, PublicErrorSpec, abort_invalid_argument, abort_payload_limit, abort_public, abort_with_error_info
 from .lifecycle import apply_signal
 from .scheduling import resolve_dag
 from .observability import (
@@ -87,7 +87,7 @@ def _public_envelope(request, context: grpc.ServicerContext) -> NormalizedPublic
             context,
             grpc_code=grpc.StatusCode.INVALID_ARGUMENT,
             message=f"malformed public contract_version: {contract_version}",
-            reason="PUBLIC_CONTRACT_VERSION_MALFORMED",
+            reason="EIGEN_PUBLIC_CONTRACT_VERSION_MALFORMED",
             domain="eigen.api.v1",
             metadata={"contract_version": contract_version},
         )
@@ -96,7 +96,7 @@ def _public_envelope(request, context: grpc.ServicerContext) -> NormalizedPublic
             context,
             grpc_code=grpc.StatusCode.FAILED_PRECONDITION,
             message=f"unsupported public contract_version: {contract_version}",
-            reason="PUBLIC_CONTRACT_VERSION_UNSUPPORTED",
+            reason="EIGEN_PUBLIC_CONTRACT_VERSION_UNSUPPORTED",
             domain="eigen.api.v1",
             metadata={
                 "contract_version": contract_version,
@@ -133,6 +133,21 @@ def _public_envelope(request, context: grpc.ServicerContext) -> NormalizedPublic
         tenant_id=tenant_id or "tenant-default",
         project_id=project_id or "project-default",
         client_version=(getattr(envelope, "client_version", "") or md.get("x-client-version", "")).strip(),
+    )
+
+
+def _abort_job_not_found(context: grpc.ServicerContext, job_id: str) -> None:
+    abort_public(
+        context,
+        PublicErrorSpec(
+            grpc_code=grpc.StatusCode.NOT_FOUND,
+            message=f"job_id not found: {job_id}",
+            reason="EIGEN_PUBLIC_JOB_NOT_FOUND",
+            retryable=False,
+            resource_type="eigen.api.v1.Job",
+            resource_name=job_id,
+            detail="No job exists for the supplied job_id.",
+        ),
     )
 
 
@@ -1181,9 +1196,18 @@ class JobService:
         if "*" in roles or "admin" in roles:
             return
         if tenant != record.owner_tenant:
-            context.abort(
-                grpc.StatusCode.PERMISSION_DENIED,
-                "POLICY_DENY_TENANT_MISMATCH: cross-tenant access denied",
+            abort_public(
+                context,
+                PublicErrorSpec(
+                    grpc_code=grpc.StatusCode.PERMISSION_DENIED,
+                    message="cross-tenant access denied",
+                    reason="EIGEN_PUBLIC_PERMISSION_DENIED",
+                    retryable=False,
+                    metadata={"policy": "POLICY_DENY_TENANT_MISMATCH"},
+                    precondition_type="AUTHORIZATION_POLICY",
+                    precondition_subject=record.job_id,
+                    detail="Caller tenant does not match the job owner tenant.",
+                ),
             )
 
     def SubmitJob(self, request, context: grpc.ServicerContext):
@@ -1199,12 +1223,28 @@ class JobService:
         if violations:
             if any("exceeds max allowed size" in violation.description for violation in violations):
                 record_submit_job_outcome("limit")
+                abort_payload_limit(context, "payload limit exceeded", violations)
             abort_invalid_argument(context, "validation failed", violations)
 
         dag_nodes = sorted({request.name, *list(request.dependencies)})
         dag = resolve_dag(dag_nodes, {request.name: list(request.dependencies)})
         if not dag.ok:
-            context.abort(grpc.StatusCode.INVALID_ARGUMENT, f"dag resolution failed: {dag.reason_code}: {dag.detail}")
+            abort_public(
+                context,
+                PublicErrorSpec(
+                    grpc_code=grpc.StatusCode.INVALID_ARGUMENT,
+                    message="dag resolution failed",
+                    reason="EIGEN_PUBLIC_VALIDATION_FAILED",
+                    retryable=False,
+                    metadata={"reason_code": dag.reason_code},
+                    violations=[
+                        FieldViolation(
+                            field="dependencies",
+                            description=f"{dag.reason_code}: {dag.detail}",
+                        )
+                    ],
+                ),
+            )
 
         idem_key = self._idempotency_key(request, context, envelope)
         request_fingerprint = self._request_fingerprint(request, envelope)
@@ -1215,9 +1255,18 @@ class JobService:
                 if previous:
                     if previous.request_fingerprint != request_fingerprint:
                         record_submit_job_outcome("conflict")
-                        context.abort(
-                            grpc.StatusCode.FAILED_PRECONDITION,
-                            f"idempotency key reuse with different normalized payload: {idem_key}",
+                        abort_public(
+                            context,
+                            PublicErrorSpec(
+                                grpc_code=grpc.StatusCode.FAILED_PRECONDITION,
+                                message="idempotency key reuse with different normalized payload",
+                                reason="EIGEN_PUBLIC_IDEMPOTENCY_CONFLICT",
+                                retryable=False,
+                                metadata={"idempotency_scope": "tenant"},
+                                precondition_type="IDEMPOTENCY_CONFLICT",
+                                precondition_subject=idem_key,
+                                detail="Reuse the key only with the same normalized request payload or choose a new key.",
+                            ),
                         )
                     existing = self._jobs.get(previous.job_id)
                     if existing is None:
@@ -1315,7 +1364,7 @@ class JobService:
             record = self._jobs.get(request.job_id)
 
         if record is None:
-            context.abort(grpc.StatusCode.NOT_FOUND, f"job_id not found: {request.job_id}")
+            _abort_job_not_found(context, request.job_id)
         with self._lock:
             self._enforce_job_access(context=context, record=record)
             self._advance_job(record)
@@ -1358,7 +1407,7 @@ class JobService:
         with self._lock:
             record = self._jobs.get(request.job_id)
             if record is None:
-                context.abort(grpc.StatusCode.NOT_FOUND, f"job_id not found: {request.job_id}")
+                _abort_job_not_found(context, request.job_id)
             self._enforce_job_access(context=context, record=record)
             self._advance_job(record)
             terminal_values = {getattr(self._types_pb, name) for name in TERMINAL_JOB_STATES}
@@ -1395,7 +1444,7 @@ class JobService:
             with self._lock:
                 record = self._jobs.get(request.job_id)
                 if record is None:
-                    context.abort(grpc.StatusCode.NOT_FOUND, f"job_id not found: {request.job_id}")
+                    _abort_job_not_found(context, request.job_id)
                 self._enforce_job_access(context=context, record=record)
                 self._advance_job(record)
                 selected_updates = list(record.updates)
@@ -1436,16 +1485,26 @@ class JobService:
                 self._advance_job(record)
 
         if record is None:
-            context.abort(grpc.StatusCode.NOT_FOUND, f"job_id not found: {request.job_id}")
+            _abort_job_not_found(context, request.job_id)
         current_state = record.updates[-1].state
         if current_state in {
             self._types_pb.JOB_STATE_PENDING,
             self._types_pb.JOB_STATE_COMPILING,
             self._types_pb.JOB_STATE_RUNNING,
         }:
-            context.abort(
-                grpc.StatusCode.FAILED_PRECONDITION,
-                f"results are not ready yet for job_id={request.job_id}; current_state={self._types_pb.JobState.Name(current_state)}",
+            abort_public(
+                context,
+                PublicErrorSpec(
+                    grpc_code=grpc.StatusCode.FAILED_PRECONDITION,
+                    message="results are not ready yet",
+                    reason="EIGEN_PUBLIC_RESULTS_NOT_READY",
+                    retryable=True,
+                    metadata={"current_state": self._types_pb.JobState.Name(current_state)},
+                    retry_delay_seconds=1,
+                    precondition_type="JOB_LIFECYCLE",
+                    precondition_subject=request.job_id,
+                    detail="Poll GetJobStatus until the job reaches a terminal state before reading results.",
+                ),
             )
 
         resp = self._job_pb.GetJobResultsResponse(
@@ -1480,7 +1539,7 @@ class JobService:
                 context,
                 grpc_code=grpc.StatusCode.INVALID_ARGUMENT,
                 message="validation failed",
-                reason="EXPLAIN_INVALID_REQUEST",
+                reason="EIGEN_PUBLIC_EXPLAIN_INVALID_REQUEST",
                 domain="eigen.api.v1.explain",
                 metadata={"field": ",".join(v.field for v in violations)},
             )
@@ -1492,7 +1551,7 @@ class JobService:
                     context,
                     grpc_code=grpc.StatusCode.NOT_FOUND,
                     message=f"job_id not found: {request.job_id}",
-                    reason="EXPLAIN_DECISION_NOT_FOUND",
+                    reason="EIGEN_PUBLIC_EXPLAIN_DECISION_NOT_FOUND",
                     domain="eigen.api.v1.explain",
                     metadata={"job_id": request.job_id},
                 )

--- a/src/services/system-api/src/system_api/security.py
+++ b/src/services/system-api/src/system_api/security.py
@@ -10,6 +10,8 @@ import os
 from dataclasses import dataclass
 
 import grpc
+
+from .errors import PublicErrorSpec, abort_public
 from .observability import log_authz_denied
 
 _AUTH_ALLOW_ALL = "allow_all"
@@ -84,18 +86,28 @@ def enforce_authn(context: grpc.ServicerContext, *, method_name: str) -> None:
     authorization = md.get("authorization", "")
     expected = f"Bearer {cfg.static_token}"
     if authorization != expected:
-        context.abort(
-            grpc.StatusCode.UNAUTHENTICATED,
-            f"authentication required for {method_name}; configure SYSTEM_API_AUTH_MODE=allow_all for local dev",
+        abort_public(
+            context,
+            PublicErrorSpec(
+                grpc_code=grpc.StatusCode.UNAUTHENTICATED,
+                message=f"authentication required for {method_name}",
+                reason="EIGEN_PUBLIC_UNAUTHENTICATED",
+                retryable=True,
+                metadata={"auth_mode": cfg.auth_mode},
+                detail="Authenticate with a valid bearer token before retrying.",
+            ),
         )
 
 
 def auth_context(context: grpc.ServicerContext) -> tuple[str, tuple[str, ...], str]:
     cfg = load_security_config()
-    if cfg.auth_mode == _AUTH_STATIC_TOKEN:
-        return cfg.static_token_subject, cfg.static_token_roles, cfg.static_token_tenant
-
     md = _metadata(context)
+    if cfg.auth_mode == _AUTH_STATIC_TOKEN:
+        tenant = md.get("x-eigen-tenant", "") or cfg.static_token_tenant
+        raw_roles = md.get("x-eigen-roles", "")
+        roles = tuple(role.strip().lower() for role in raw_roles.split(",") if role.strip())
+        return cfg.static_token_subject, roles or cfg.static_token_roles, tenant
+
     subject = md.get("x-eigen-sub", "anonymous")
     tenant = md.get("x-eigen-tenant", "")
     raw_roles = md.get("x-eigen-roles", "admin")
@@ -160,9 +172,16 @@ def enforce_authz(context: grpc.ServicerContext, *, required_permission: str) ->
             subject=subject or "unknown",
             permission="POLICY_DENY_MISSING_AUTH_CONTEXT",
         )
-        context.abort(
-            grpc.StatusCode.PERMISSION_DENIED,
-            "POLICY_DENY_MISSING_AUTH_CONTEXT: subject and tenant are required",
+        abort_public(
+            context,
+            PublicErrorSpec(
+                grpc_code=grpc.StatusCode.PERMISSION_DENIED,
+                message="subject and tenant are required",
+                reason="EIGEN_PUBLIC_PERMISSION_DENIED",
+                retryable=False,
+                metadata={"policy": "POLICY_DENY_MISSING_AUTH_CONTEXT"},
+                detail="Provide authenticated subject and tenant context.",
+            ),
         )
 
     if need in granted or wildcard in granted or "*" in granted:
@@ -173,7 +192,14 @@ def enforce_authz(context: grpc.ServicerContext, *, required_permission: str) ->
         subject=subject,
         permission=f"POLICY_DENY_PERMISSION_REQUIRED:{need}",
     )
-    context.abort(
-        grpc.StatusCode.PERMISSION_DENIED,
-        f"POLICY_DENY_PERMISSION_REQUIRED: requires {required_permission}",
+    abort_public(
+        context,
+        PublicErrorSpec(
+            grpc_code=grpc.StatusCode.PERMISSION_DENIED,
+            message=f"requires {required_permission}",
+            reason="EIGEN_PUBLIC_PERMISSION_DENIED",
+            retryable=False,
+            metadata={"policy": "POLICY_DENY_PERMISSION_REQUIRED", "permission": required_permission},
+            detail="Caller lacks the required permission for this public API method.",
+        ),
     )

--- a/src/services/system-api/tests/test_public_envelope_versioning.py
+++ b/src/services/system-api/tests/test_public_envelope_versioning.py
@@ -61,7 +61,7 @@ def test_missing_contract_version_defaults_to_product_1(grpc_addr: str) -> None:
                 envelope=types_pb.ApiRequestEnvelope(contract_version="not-semver"),
             ),
             grpc.StatusCode.INVALID_ARGUMENT,
-            "PUBLIC_CONTRACT_VERSION_MALFORMED",
+            "EIGEN_PUBLIC_CONTRACT_VERSION_MALFORMED",
         ),
         (
             job_pb.GetJobStatusRequest(
@@ -69,7 +69,7 @@ def test_missing_contract_version_defaults_to_product_1(grpc_addr: str) -> None:
                 envelope=types_pb.ApiRequestEnvelope(contract_version="2.0.0"),
             ),
             grpc.StatusCode.FAILED_PRECONDITION,
-            "PUBLIC_CONTRACT_VERSION_UNSUPPORTED",
+            "EIGEN_PUBLIC_CONTRACT_VERSION_UNSUPPORTED",
         ),
         (
             job_pb.GetJobStatusRequest(
@@ -77,7 +77,7 @@ def test_missing_contract_version_defaults_to_product_1(grpc_addr: str) -> None:
                 envelope=types_pb.ApiRequestEnvelope(contract_version="1.1.0"),
             ),
             grpc.StatusCode.FAILED_PRECONDITION,
-            "PUBLIC_CONTRACT_VERSION_UNSUPPORTED",
+            "EIGEN_PUBLIC_CONTRACT_VERSION_UNSUPPORTED",
         ),
     ],
 )
@@ -109,6 +109,6 @@ def test_metadata_contract_version_is_validated_before_device_dispatch(grpc_addr
 
     assert err.value.code() == grpc.StatusCode.FAILED_PRECONDITION
     info = _error_info(err.value)
-    assert info.reason == "PUBLIC_CONTRACT_VERSION_UNSUPPORTED"
+    assert info.reason == "EIGEN_PUBLIC_CONTRACT_VERSION_UNSUPPORTED"
     assert info.metadata["supported_contract_version"] == "1.0.0"
     

--- a/src/services/system-api/tests/test_public_error_conformance.py
+++ b/src/services/system-api/tests/test_public_error_conformance.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import grpc
+import pytest
+from google.rpc import error_details_pb2
+from grpc_status import rpc_status
+
+from system_api.errors import FieldViolation, PublicErrorSpec, build_public_status
+from system_api.proto_gen import ensure_generated
+
+ensure_generated()
+
+from eigen.api.v1 import job_service_pb2 as job_pb  # noqa: E402
+from eigen.api.v1 import job_service_pb2_grpc as job_pb_grpc  # noqa: E402
+from eigen.api.v1 import types_pb2 as types_pb  # noqa: E402
+
+
+def _unpack(err: grpc.RpcError):
+    status = rpc_status.from_call(err)
+    assert status is not None
+    info = error_details_pb2.ErrorInfo()
+    assert status.details[0].Unpack(info)
+    bad = error_details_pb2.BadRequest()
+    precondition = error_details_pb2.PreconditionFailure()
+    quota = error_details_pb2.QuotaFailure()
+    retry = error_details_pb2.RetryInfo()
+    resource = error_details_pb2.ResourceInfo()
+    return status, info, bad, precondition, quota, retry, resource
+
+
+def _assert_status(status, *, code: grpc.StatusCode, reason: str, retryable: bool) -> None:
+    info = error_details_pb2.ErrorInfo()
+    assert status.code == code.value[0]
+    assert status.details[0].Unpack(info)
+    assert info.reason == reason
+    assert info.metadata["retryable"] == ("true" if retryable else "false")
+
+
+def test_validation_negative_fixture_has_reason_retryability_and_bad_request(grpc_addr: str) -> None:
+    stub = job_pb_grpc.JobServiceStub(grpc.insecure_channel(grpc_addr))
+
+    with pytest.raises(grpc.RpcError) as exc:
+        stub.SubmitJob(job_pb.SubmitJobRequest())
+
+    status, info, bad, *_ = _unpack(exc.value)
+    assert exc.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    assert status.message == "validation failed"
+    assert info.reason == "EIGEN_PUBLIC_VALIDATION_FAILED"
+    assert info.metadata["retryable"] == "false"
+    assert any(detail.Unpack(bad) for detail in status.details)
+    assert {v.field for v in bad.field_violations} >= {"name", "target", "program"}
+
+
+def test_idempotency_conflict_negative_fixture_has_precondition_detail(grpc_addr: str) -> None:
+    stub = job_pb_grpc.JobServiceStub(grpc.insecure_channel(grpc_addr))
+    envelope = types_pb.ApiRequestEnvelope(idempotency_key="idem-conflict")
+    base = job_pb.SubmitJobRequest(
+        name="idem-a",
+        target="sim:local",
+        envelope=envelope,
+        eigen_lang=types_pb.EigenLangSource(source=b"fn main() {}", entrypoint="main", sha256="idem-sha"),
+    )
+    stub.SubmitJob(base)
+
+    with pytest.raises(grpc.RpcError) as exc:
+        stub.SubmitJob(
+            job_pb.SubmitJobRequest(
+                name="idem-b",
+                target="sim:local",
+                envelope=envelope,
+                eigen_lang=types_pb.EigenLangSource(source=b"fn main() {}", entrypoint="main", sha256="idem-sha"),
+            )
+        )
+
+    status, info, _, precondition, *_ = _unpack(exc.value)
+    assert exc.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+    assert info.reason == "EIGEN_PUBLIC_IDEMPOTENCY_CONFLICT"
+    assert info.metadata["retryable"] == "false"
+    assert any(detail.Unpack(precondition) for detail in status.details)
+    assert precondition.violations[0].type == "IDEMPOTENCY_CONFLICT"
+
+
+def test_version_mismatch_negative_fixture_has_public_reason(grpc_addr: str) -> None:
+    stub = job_pb_grpc.JobServiceStub(grpc.insecure_channel(grpc_addr))
+
+    with pytest.raises(grpc.RpcError) as exc:
+        stub.GetJobStatus(
+            job_pb.GetJobStatusRequest(
+                job_id="job_missing",
+                envelope=types_pb.ApiRequestEnvelope(contract_version="2.0.0"),
+            )
+        )
+
+    status, info, *_ = _unpack(exc.value)
+    assert exc.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+    assert status.message == "unsupported public contract_version: 2.0.0"
+    assert info.reason == "EIGEN_PUBLIC_CONTRACT_VERSION_UNSUPPORTED"
+    assert info.metadata["retryable"] == "false"
+    assert info.metadata["supported_contract_version"] == "1.0.0"
+
+
+def test_payload_limit_negative_fixture_has_quota_shape(grpc_addr: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SYSTEM_API_MAX_PROGRAM_SOURCE_BYTES", "8")
+    stub = job_pb_grpc.JobServiceStub(grpc.insecure_channel(grpc_addr))
+
+    with pytest.raises(grpc.RpcError) as exc:
+        stub.SubmitJob(
+            job_pb.SubmitJobRequest(
+                name="payload-limit",
+                target="sim:local",
+                eigen_lang=types_pb.EigenLangSource(source=b"0123456789", entrypoint="main"),
+            )
+        )
+
+    status, info, bad, _, quota, *_ = _unpack(exc.value)
+    assert exc.value.code() == grpc.StatusCode.RESOURCE_EXHAUSTED
+    assert info.reason == "EIGEN_PUBLIC_PAYLOAD_LIMIT_EXCEEDED"
+    assert info.metadata["retryable"] == "false"
+    assert any(detail.Unpack(bad) for detail in status.details)
+    assert any(detail.Unpack(quota) for detail in status.details)
+    assert quota.violations[0].subject == "request.payload"
+
+
+@pytest.mark.parametrize(
+    "name,spec,detail_type",
+    [
+        (
+            "auth",
+            PublicErrorSpec(grpc.StatusCode.UNAUTHENTICATED, "authentication required", "EIGEN_PUBLIC_UNAUTHENTICATED", True),
+            None,
+        ),
+        (
+            "deadline",
+            PublicErrorSpec(
+                grpc.StatusCode.DEADLINE_EXCEEDED,
+                "deadline exceeded",
+                "EIGEN_PUBLIC_DEADLINE_EXCEEDED",
+                True,
+                retry_delay_seconds=1,
+            ),
+            error_details_pb2.RetryInfo,
+        ),
+        (
+            "cancellation",
+            PublicErrorSpec(grpc.StatusCode.CANCELLED, "operation cancelled", "EIGEN_PUBLIC_CANCELLED", False, request_id="req_cancel"),
+            error_details_pb2.RequestInfo,
+        ),
+        (
+            "unavailable",
+            PublicErrorSpec(
+                grpc.StatusCode.UNAVAILABLE,
+                "service unavailable",
+                "EIGEN_PUBLIC_UNAVAILABLE",
+                True,
+                retry_delay_seconds=1,
+            ),
+            error_details_pb2.RetryInfo,
+        ),
+        (
+            "internal",
+            PublicErrorSpec(grpc.StatusCode.INTERNAL, "internal failure", "EIGEN_PUBLIC_INTERNAL", False, request_id="req_internal"),
+            error_details_pb2.RequestInfo,
+        ),
+    ],
+)
+def test_canonical_mapping_fixture_status_reason_retryability_and_detail_shape(name, spec, detail_type) -> None:
+    status = build_public_status(spec)
+    _assert_status(status, code=spec.grpc_code, reason=spec.reason, retryable=spec.retryable)
+    assert "raw" not in status.message.lower()
+    if detail_type is not None:
+        detail = detail_type()
+        assert any(item.Unpack(detail) for item in status.details), name

--- a/src/services/system-api/tests/test_security_baseline.py
+++ b/src/services/system-api/tests/test_security_baseline.py
@@ -33,7 +33,7 @@ def _extract_bad_request(err: grpc.RpcError) -> error_details_pb2.BadRequest:
     assert st is not None
     bad = error_details_pb2.BadRequest()
     assert len(st.details) >= 1
-    assert st.details[0].Unpack(bad)
+    assert any(detail.Unpack(bad) for detail in st.details)
     return bad
 
 
@@ -97,7 +97,7 @@ def test_submit_job_enforces_source_and_yaml_size_limits(
             )
         )
 
-    assert exc.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    assert exc.value.code() == grpc.StatusCode.RESOURCE_EXHAUSTED
     bad = _extract_bad_request(exc.value)
     fields = {v.field for v in bad.field_violations}
     assert "eigen_lang.source" in fields

--- a/src/services/system-api/tests/test_validation_errors.py
+++ b/src/services/system-api/tests/test_validation_errors.py
@@ -22,8 +22,7 @@ def _extract_bad_request(err: grpc.RpcError) -> error_details_pb2.BadRequest:
 
     bad = error_details_pb2.BadRequest()
     assert len(st.details) >= 1
-    unpacked = st.details[0].Unpack(bad)
-    assert unpacked
+    assert any(detail.Unpack(bad) for detail in st.details)
     return bad
 
 


### PR DESCRIPTION
## Summary

- Implemented the Wave-1 W1-05 canonical public error model for System API public boundary failures.

- Public errors now emit deterministic google.rpc.Status details with ErrorInfo first, stable EIGEN_PUBLIC_* reason codes, retryability metadata, and scenario-specific structured detail shapes.

- Added/updated conformance coverage for validation, auth, idempotency conflict, version mismatch, payload limit, deadline, cancellation, unavailable, and internal failures.

- Updated architecture/reference documentation and changelog migration notes.


## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MAJOR
- **Affected Interfaces**: Public System API gRPC error surface, SDK/CLI error parsing, public error-model and error-mapping documentation
- **Compatibility**: Breaking for clients that match old `PUBLIC_CONTRACT_VERSION`_* `reasons`, assume `BadRequest` is detail index 0, or map public payload limits as `INVALID_ARGUMENT`.
- **Breaking Marker**: true
- **Migration Notes**: Clients should read google.rpc.ErrorInfo from detail index 0, switch to `EIGEN_PUBLIC_*` reason codes, use ErrorInfo.metadata.retryable, and handle payload limits as `RESOURCE_EXHAUSTED` with BadRequest and `QuotaFailure` details

## Release Notes Draft

### Added
- Canonical public `google.rpc.Status` normalization with stable `EIGEN_PUBLIC_*` reasons, retryability metadata, and conformance fixtures for required negative scenarios.

### Changed
- Public payload-limit failures now map to `RESOURCE_EXHAUSTED`; contract-version reasons now use the `EIGEN_PUBLIC_*` namespace; public structured detail ordering now starts with `ErrorInfo`.

### Fixed
- Covered public System API errors no longer rely on raw `context.abort` messages and now expose structured detail shapes suitable for SDK/client parsing.