### PR TITLE
Public API observability markers and trace continuity smoke gate

### DIFF
--- a/docs/architecture/components/client-sdks.md
+++ b/docs/architecture/components/client-sdks.md
@@ -269,7 +269,7 @@ Every released SDK MUST include conformance tests for:
 - missing or malformed program source rejected as `INVALID_ARGUMENT`;
 - path traversal in `spec.program.path` rejected before transport;
 - idempotency-key replay guidance, including same-key/same-payload success and same-key/different-payload conflict handling;
-- W3C `traceparent` propagation without mutation;
+- W3C `traceparent` propagation without mutation and smoke coverage proving the System API derives the same trace ID from envelope- and metadata-carried trace context;
 - canonical error extraction from gRPC status and structured details.
 
 The CLI tests in `src/rust/apps/cli/src/jobspec.rs` are the Wave 1 reference baseline for future language SDKs.

--- a/docs/architecture/components/observability.md
+++ b/docs/architecture/components/observability.md
@@ -186,6 +186,10 @@ Target environments SHOULD additionally expose:
   - cluster/distributed runtime (split/merge): `eigen_cluster_*` (where defined by contract)
 - Global contract markers:
   - `eigen_observability_contract_info{version=...} 1`
+- Public API ingress contract markers (System API):
+  - `eigen_api_public_contract_requests_total{contract_version,outcome}`
+  - `eigen_public_api_contract_requests_total{contract_version,outcome}` (catalog-compatible alias)
+  - labels MUST remain bounded to `contract_version in {1.0.0,unsupported}` and `outcome in {accepted,replayed,conflict,limit,error}`.
 
 ---
 
@@ -238,6 +242,8 @@ Use the dedicated contracts for required catalogs:
 ### 7.1 Propagation
 
 Eigen OS uses **W3C TraceContext**. Required header: `traceparent`
+
+System API MUST accept `traceparent` from gRPC metadata or the Product 1.0 public request envelope, preserve the original parent string, and derive `trace_id` from it before emitting public-boundary logs or constructing job/runtime correlation metadata.
 
 Propagation path (minimum MVP baseline):
 

--- a/docs/architecture/components/system-api.md
+++ b/docs/architecture/components/system-api.md
@@ -420,8 +420,8 @@ Recommended outputs:
 
 - structured JSON logs
 - request correlation metadata
-- trace context extraction (`traceparent`)
-- Prometheus `/metrics`
+- trace context extraction (`traceparent`) from public metadata and `ApiRequestEnvelope`
+- Prometheus `/metrics`, including the bounded public API contract marker counters
 
 ---
 
@@ -430,6 +430,7 @@ Recommended outputs:
 System API SHALL:
 
 - propagate W3C TraceContext across downstream calls,
+- preserve public ingress `traceparent` and derived `trace_id` in request logs and job correlation metadata,
 - emit ingress spans and downstream forwarding spans,
 - export ingress metrics including propagation failures and downstream error rates,
 - ensure telemetry is safe (no secrets, bounded labels).

--- a/docs/development/product-1.0-wave-1-compatibility-report.md
+++ b/docs/development/product-1.0-wave-1-compatibility-report.md
@@ -31,7 +31,7 @@ Wave 1 changes must follow these rules:
 | W1-04 JobSpec 1.0 schema, parser/normalizer, canonical digest, and fixtures | MINOR | JobSpec; CLI payloads; System API SubmitJob mapping; AQO packaging | Backward-compatible: native `eigen.os/v1` is added and documented `eigen.os/v0.1` inputs continue to normalize through migration metadata. | false | Prefer `apiVersion: eigen.os/v1` and `spec.program.path`/`spec.program.source`; legacy `spec.program_path` and inline string `spec.program` remain accepted as v0.1 migration inputs. | Added JobSpec 1.0 JSON Schema, fixtures, shared System API normalizer/digest behavior, CLI v1 parser support, and compatibility report. | `docs/reference/jobspec.md`; `docs/reference/schemas/jobspec-1.0.schema.json`; `docs/reference/fixtures/jobspec/1.0/`; `src/services/system-api/src/system_api/jobspec_parser.py`; `src/services/system-api/tests/test_jobspec_parser.py`; `src/rust/apps/cli/src/jobspec.rs` |
 | W1-05 Canonical public error model and error mapping conformance | TBD | API; CLI payloads; Metrics | TBD | TBD | TBD | TBD | TBD |
 | W1-06 CLI/SDK public submission conformance baseline | MINOR | CLI payloads; JobSpec; API; SDK conformance | Backward-compatible Product 1.0 envelope and JobSpec normalization added for CLI submissions; inline and file-backed JobSpecs are accepted. | false | Prefer Product 1.0 public payloads with canonical envelope fields; legacy bare CLI submit request JSON remains present only as a compatibility shim during migration. | Added CLI public submission payload normalization, deterministic default request/idempotency keys, trace context propagation, and SDK negative-test obligations. | `src/rust/apps/cli/src/jobspec.rs`; `src/rust/apps/cli/src/main.rs`; `src/rust/apps/cli/README.md`; `docs/architecture/components/client-sdks.md`; `docs/reference/api/grpc-public.md` |
-| W1-07 Public API observability markers and trace continuity smoke gate | TBD | Metrics; API | TBD | TBD | TBD | TBD | TBD |
+| W1-07 Public API observability markers and trace continuity smoke gate | MINOR | Metrics; API; CLI/SDK trace propagation | Backward-compatible additive metrics and correlation behavior; existing metrics are retained. | false | None; Product 1.0 clients should continue sending W3C `traceparent` via metadata or `ApiRequestEnvelope.traceparent`. | Added bounded public API contract marker counters and trace continuity smoke evidence from public envelope/metadata through System API request handling. | `src/services/system-api/src/system_api/observability.py`; `src/services/system-api/src/system_api/grpc_impl.py`; `src/services/system-api/tests/test_observability_smoke.py`; `docs/reference/api/grpc-public.md`; `docs/architecture/components/observability.md`; `docs/architecture/components/system-api.md`; `docs/architecture/components/client-sdks.md` |
 | W1-08 Wave 1 compatibility report, migration notes, and release evidence bundle | NONE | Compatibility matrix | Backward-compatible | false | None | TBD | This report and exit evidence bundle |
 
 ---
@@ -57,7 +57,7 @@ When `Breaking Marker=true`, record:
 - [ ] Error mapping fixture set attached or linked.
 - [ ] CLI/API parity evidence attached or linked.
 - [ ] Idempotency replay/conflict evidence attached or linked.
-- [ ] Public metrics/trace smoke evidence attached or linked.
+- [x] Public metrics/trace smoke evidence attached or linked.
 - [ ] Manifest/inventory diff reviewed for changed schema/proto/test mappings.
 - [ ] Release notes draft copied from every issue and consolidated.
 

--- a/docs/reference/api/grpc-public.md
+++ b/docs/reference/api/grpc-public.md
@@ -618,7 +618,7 @@ Structured protobuf error details are mandatory at the public boundary where sup
 
 #### Required Trace Propagation
 
-All services MUST propagate:
+All public clients (CLI and SDKs) SHOULD send W3C TraceContext as the `traceparent` gRPC metadata key or as `ApiRequestEnvelope.traceparent`. System API MUST preserve that value, derive the 32-character `trace_id` from it when present, and include the correlation identifiers in request logs, downstream trace context, job status messages, result metadata, and dispatch rationale where the downstream contract exposes them.
 
 ```text
 traceparent
@@ -632,7 +632,8 @@ Minimum metrics:
 
 | **Metric** | **Type** |
 |----------|-----------|
-| `eigen_public_api_contract_requests_total` | Counter |
+| `eigen_api_public_contract_requests_total{contract_version,outcome}` | Counter with bounded `contract_version in {1.0.0,unsupported}` and `outcome in {accepted,replayed,conflict,limit,error}`; canonical System API public-boundary marker. |
+| `eigen_public_api_contract_requests_total{contract_version,outcome}` | Counter alias for the public API contract marker, emitted with the same bounded labels for compatibility with the global public API catalog. |
 | `eigen_public_api_contract_request_duration_ms` | Histogram |
 | `grpc.requests_total` | Counter |
 | `grpc.request_duration_ms` | Histogram |

--- a/src/services/system-api/src/system_api/grpc_impl.py
+++ b/src/services/system-api/src/system_api/grpc_impl.py
@@ -27,7 +27,9 @@ from .observability import (
     log_request_end,
     log_request_start,
     new_request_context,
+    record_public_api_contract_marker,
     record_submit_job_outcome,
+    trace_id_from_traceparent,
 )
 from .qfs_store import QFS_STORE
 from .security import auth_context, enforce_authn, enforce_authz
@@ -83,6 +85,7 @@ def _public_envelope(request, context: grpc.ServicerContext) -> NormalizedPublic
         or PUBLIC_API_CONTRACT_VERSION
     ).strip()
     if not _SEMVER_RE.match(contract_version):
+        record_public_api_contract_marker(contract_version, "error")
         abort_with_error_info(
             context,
             grpc_code=grpc.StatusCode.INVALID_ARGUMENT,
@@ -92,6 +95,7 @@ def _public_envelope(request, context: grpc.ServicerContext) -> NormalizedPublic
             metadata={"contract_version": contract_version},
         )
     if contract_version != PUBLIC_API_CONTRACT_VERSION:
+        record_public_api_contract_marker(contract_version, "error")
         abort_with_error_info(
             context,
             grpc_code=grpc.StatusCode.FAILED_PRECONDITION,
@@ -155,6 +159,16 @@ def _apply_public_envelope_context(rc, envelope: NormalizedPublicEnvelope) -> No
     rc.request_id = envelope.request_id
     if envelope.traceparent and not rc.traceparent:
         rc.traceparent = envelope.traceparent
+    if rc.trace_id is None and rc.traceparent:
+        rc.trace_id = trace_id_from_traceparent(rc.traceparent)
+
+
+def _public_contract_version_label(envelope: NormalizedPublicEnvelope | None) -> str:
+    return envelope.contract_version if envelope is not None else PUBLIC_API_CONTRACT_VERSION
+
+
+def _record_submit_public_marker(envelope: NormalizedPublicEnvelope | None, outcome: str) -> None:
+    record_public_api_contract_marker(_public_contract_version_label(envelope), outcome)
 
 
 def _envelope_value(envelope, field: str) -> str:
@@ -1214,21 +1228,24 @@ class JobService:
         enforce_authn(context, method_name="JobService.SubmitJob")
         enforce_authz(context, required_permission="jobs:submit")
         rc = new_request_context(context)
-        log_request_start("JobService.SubmitJob", rc)
 
         envelope = _public_envelope(request, context)
         _apply_public_envelope_context(rc, envelope)
+        log_request_start("JobService.SubmitJob", rc)
 
         violations = validate_submit_job(request)
         if violations:
             if any("exceeds max allowed size" in violation.description for violation in violations):
                 record_submit_job_outcome("limit")
+                _record_submit_public_marker(envelope, "limit")
                 abort_payload_limit(context, "payload limit exceeded", violations)
+                _record_submit_public_marker(envelope, "error")
             abort_invalid_argument(context, "validation failed", violations)
 
         dag_nodes = sorted({request.name, *list(request.dependencies)})
         dag = resolve_dag(dag_nodes, {request.name: list(request.dependencies)})
         if not dag.ok:
+            _record_submit_public_marker(envelope, "error")
             abort_public(
                 context,
                 PublicErrorSpec(
@@ -1255,6 +1272,7 @@ class JobService:
                 if previous:
                     if previous.request_fingerprint != request_fingerprint:
                         record_submit_job_outcome("conflict")
+                        _record_submit_public_marker(envelope, "conflict")
                         abort_public(
                             context,
                             PublicErrorSpec(
@@ -1273,6 +1291,7 @@ class JobService:
                         now = _ts_now()
                         rc.job_id = previous.job_id
                         record_submit_job_outcome("replayed")
+                        _record_submit_public_marker(envelope, "replayed")
                         log_request_end("JobService.SubmitJob", rc)
                         return self._job_pb.SubmitJobResponse(
                             job_id=previous.job_id,
@@ -1290,6 +1309,7 @@ class JobService:
                     latest = existing.updates[-1]
                     rc.job_id = existing.job_id
                     record_submit_job_outcome("replayed")
+                    _record_submit_public_marker(envelope, "replayed")
                     log_request_end("JobService.SubmitJob", rc)
                     return self._job_pb.SubmitJobResponse(
                         job_id=existing.job_id,
@@ -1329,6 +1349,7 @@ class JobService:
                     envelope=envelope,
                 )
             record_submit_job_outcome("accepted")
+            _record_submit_public_marker(envelope, "accepted")
 
         resp = self._job_pb.SubmitJobResponse(
             job_id=job_id,

--- a/src/services/system-api/src/system_api/observability.py
+++ b/src/services/system-api/src/system_api/observability.py
@@ -45,6 +45,10 @@ class JsonFormatter(logging.Formatter):
         return json.dumps(payload, ensure_ascii=False)
 
 
+PUBLIC_API_CONTRACT_OUTCOMES = {"accepted", "replayed", "conflict", "limit", "error"}
+PUBLIC_API_CONTRACT_VERSION_LABELS = {"1.0.0", "unsupported"}
+
+
 class _MetricsState:
     lock = threading.Lock()
     requests_total = 0
@@ -55,6 +59,11 @@ class _MetricsState:
         "replayed": 0,
         "conflict": 0,
         "limit": 0,
+    }
+    public_api_contract_requests_total: dict[tuple[str, str], int] = {
+        (version, outcome): 0
+        for version in sorted(PUBLIC_API_CONTRACT_VERSION_LABELS)
+        for outcome in sorted(PUBLIC_API_CONTRACT_OUTCOMES)
     }
 
 
@@ -69,9 +78,24 @@ class _MetricsHandler(BaseHTTPRequestHandler):
             req_sum = _MetricsState.request_duration_seconds_sum
             authz_denied = _MetricsState.authz_denied_total
             submit_outcomes = dict(_MetricsState.submit_job_outcomes_total)
+            public_contract_outcomes = dict(_MetricsState.public_api_contract_requests_total)
         outcome_lines = "".join(
             f'eigen_api_submit_job_outcomes_total{{outcome="{outcome}"}} {count}\n'
             for outcome, count in sorted(submit_outcomes.items())
+        )
+        contract_marker_lines = "".join(
+            (
+                "eigen_api_public_contract_requests_total"
+                f'{{contract_version="{contract_version}",outcome="{outcome}"}} {count}\n'
+            )
+            for (contract_version, outcome), count in sorted(public_contract_outcomes.items())
+        )
+        public_api_contract_marker_lines = "".join(
+            (
+                "eigen_public_api_contract_requests_total"
+                f'{{contract_version="{contract_version}",outcome="{outcome}"}} {count}\n'
+            )
+            for (contract_version, outcome), count in sorted(public_contract_outcomes.items())
         )
         body = (
             "# TYPE eigen_api_requests_total counter\n"
@@ -82,6 +106,10 @@ class _MetricsHandler(BaseHTTPRequestHandler):
             f"eigen_api_authz_denied_total {authz_denied}\n"
             "# TYPE eigen_api_submit_job_outcomes_total counter\n"
             f"{outcome_lines}"
+            "# TYPE eigen_api_public_contract_requests_total counter\n"
+            f"{contract_marker_lines}"
+            "# TYPE eigen_public_api_contract_requests_total counter\n"
+            f"{public_api_contract_marker_lines}"
         ).encode()
         self.send_response(200)
         self.send_header("Content-Type", "text/plain; version=0.0.4")
@@ -100,16 +128,20 @@ def start_metrics_server(port: int) -> ThreadingHTTPServer:
     return server
 
 
+def trace_id_from_traceparent(traceparent: str | None) -> str | None:
+    if not traceparent:
+        return None
+    m = _TRACEPARENT_RE.match(traceparent)
+    if not m:
+        return None
+    return m.group("trace_id")
+
+
 def new_request_context(context: grpc.ServicerContext) -> RequestContext:
     md = {k.lower(): v for (k, v) in (context.invocation_metadata() or [])}
 
     traceparent = md.get("traceparent")
-    trace_id = md.get("trace_id")
-
-    if trace_id is None and traceparent:
-        m = _TRACEPARENT_RE.match(traceparent)
-        if m:
-            trace_id = m.group("trace_id")
+    trace_id = md.get("trace_id") or trace_id_from_traceparent(traceparent)
 
     return RequestContext(
         request_id=str(uuid.uuid4()),
@@ -120,7 +152,16 @@ def new_request_context(context: grpc.ServicerContext) -> RequestContext:
 
 def log_request_start(method: str, rc: RequestContext) -> None:
     setattr(rc, "_started_at", time.perf_counter())
-    _LOG.info("rpc_start", extra={"method": method, "request_id": rc.request_id, "trace_id": rc.trace_id, "traceparent": rc.traceparent, "job_id": rc.job_id})
+    _LOG.info(
+        "rpc_start",
+        extra={
+            "method": method,
+            "request_id": rc.request_id,
+            "trace_id": rc.trace_id,
+            "traceparent": rc.traceparent,
+            "job_id": rc.job_id,
+        },
+    )
 
 
 def log_request_end(method: str, rc: RequestContext) -> None:
@@ -128,7 +169,15 @@ def log_request_end(method: str, rc: RequestContext) -> None:
     with _MetricsState.lock:
         _MetricsState.requests_total += 1
         _MetricsState.request_duration_seconds_sum += elapsed
-    _LOG.info("rpc_end", extra={"method": method, "request_id": rc.request_id, "trace_id": rc.trace_id, "job_id": rc.job_id})
+    _LOG.info(
+        "rpc_end",
+        extra={
+            "method": method,
+            "request_id": rc.request_id,
+            "trace_id": rc.trace_id,
+            "job_id": rc.job_id,
+        },
+    )
 
 
 def log_authz_denied(*, method: str, subject: str, permission: str, job_id: str | None = None) -> None:
@@ -152,4 +201,17 @@ def record_submit_job_outcome(outcome: str) -> None:
     with _MetricsState.lock:
         _MetricsState.submit_job_outcomes_total[outcome] = (
             _MetricsState.submit_job_outcomes_total.get(outcome, 0) + 1
+        )
+
+
+def record_public_api_contract_marker(contract_version: str, outcome: str) -> None:
+    """Increment the public-boundary contract marker metric with bounded labels."""
+    version_label = (
+        contract_version if contract_version in PUBLIC_API_CONTRACT_VERSION_LABELS else "unsupported"
+    )
+    outcome_label = outcome if outcome in PUBLIC_API_CONTRACT_OUTCOMES else "error"
+    with _MetricsState.lock:
+        _MetricsState.public_api_contract_requests_total[(version_label, outcome_label)] = (
+            _MetricsState.public_api_contract_requests_total.get((version_label, outcome_label), 0)
+            + 1
         )

--- a/src/services/system-api/tests/test_observability_smoke.py
+++ b/src/services/system-api/tests/test_observability_smoke.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 import socket
 import urllib.request
 
-from system_api.observability import _MetricsState, start_metrics_server
+from system_api.grpc_impl import JobService
+from system_api.observability import _MetricsState, record_public_api_contract_marker, start_metrics_server
+from system_api.proto_gen import ensure_generated
+
+ensure_generated()
+
+from eigen.api.v1 import job_service_pb2 as job_pb  # noqa: E402
+from eigen.api.v1 import types_pb2 as types_pb  # noqa: E402
 
 
 def _free_port() -> int:
@@ -22,6 +29,18 @@ def test_metrics_endpoint_exposes_prometheus_payload():
         "conflict": 1,
         "limit": 1,
     }
+    _MetricsState.public_api_contract_requests_total = {
+        ("1.0.0", "accepted"): 2,
+        ("1.0.0", "replayed"): 1,
+        ("1.0.0", "conflict"): 1,
+        ("1.0.0", "limit"): 1,
+        ("1.0.0", "error"): 0,
+        ("unsupported", "accepted"): 0,
+        ("unsupported", "replayed"): 0,
+        ("unsupported", "conflict"): 0,
+        ("unsupported", "limit"): 0,
+        ("unsupported", "error"): 0,
+    }
     server = start_metrics_server(port)
     try:
         body = urllib.request.urlopen(f"http://127.0.0.1:{port}/metrics", timeout=2).read().decode()
@@ -35,3 +54,75 @@ def test_metrics_endpoint_exposes_prometheus_payload():
     assert 'eigen_api_submit_job_outcomes_total{outcome="replayed"} 1' in body
     assert 'eigen_api_submit_job_outcomes_total{outcome="conflict"} 1' in body
     assert 'eigen_api_submit_job_outcomes_total{outcome="limit"} 1' in body
+    assert (
+        'eigen_api_public_contract_requests_total{contract_version="1.0.0",outcome="accepted"} 2'
+        in body
+    )
+    assert (
+        'eigen_public_api_contract_requests_total{contract_version="1.0.0",outcome="accepted"} 2'
+        in body
+    )
+
+
+def _reset_public_contract_metrics() -> None:
+    _MetricsState.public_api_contract_requests_total = {
+        (version, outcome): 0
+        for version in ("1.0.0", "unsupported")
+        for outcome in ("accepted", "conflict", "error", "limit", "replayed")
+    }
+
+
+def test_public_contract_marker_uses_bounded_labels_and_contract_version():
+    _reset_public_contract_metrics()
+
+    record_public_api_contract_marker("1.0.0", "accepted")
+    record_public_api_contract_marker("9.9.9-custom-build", "tenant-freeform-outcome")
+
+    assert _MetricsState.public_api_contract_requests_total[("1.0.0", "accepted")] == 1
+    assert _MetricsState.public_api_contract_requests_total[("unsupported", "error")] == 1
+    assert {version for version, _ in _MetricsState.public_api_contract_requests_total} == {
+        "1.0.0",
+        "unsupported",
+    }
+    assert {outcome for _, outcome in _MetricsState.public_api_contract_requests_total} == {
+        "accepted",
+        "conflict",
+        "error",
+        "limit",
+        "replayed",
+    }
+
+
+def test_submit_job_marker_and_traceparent_correlation_from_public_envelope(caplog):
+    class _Context:
+        def invocation_metadata(self):
+            return []
+
+        def abort(self, code, details):
+            raise RuntimeError(f"{code}: {details}")
+
+    _reset_public_contract_metrics()
+    traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+    request = job_pb.SubmitJobRequest(
+        name="observability-smoke",
+        target="sim:local",
+        envelope=types_pb.ApiRequestEnvelope(
+            contract_version="1.0.0",
+            request_id="req-observability-smoke",
+            traceparent=traceparent,
+        ),
+        eigen_lang=types_pb.EigenLangSource(source=b"fn main() {}\n", entrypoint="main"),
+    )
+
+    caplog.set_level("INFO", logger="system_api")
+    response = JobService(job_pb=job_pb, types_pb=types_pb).SubmitJob(request, _Context())
+
+    assert response.job_id
+    assert _MetricsState.public_api_contract_requests_total[("1.0.0", "accepted")] == 1
+    assert any(
+        record.message == "rpc_start"
+        and record.request_id == "req-observability-smoke"
+        and record.traceparent == traceparent
+        and record.trace_id == "4bf92f3577b34da6a3ce929d0e0e4736"
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary

- Added bounded public API contract marker counters for Product 1.0 System API ingress, retaining the global catalog metric name and adding the System API namespace metric name.

- Propagated public-envelope traceparent into request context trace correlation so CLI/SDK metadata and envelope flows derive the same trace_id before public-boundary logging and job correlation.

- Added smoke coverage for marker emission, bounded labels, and request/trace correlation, and updated architecture/reference compatibility documentation.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: Metrics | API | CLI/SDK trace propagation | Compatibility report
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Added bounded public API contract marker counters for Product 1.0 System API ingress outcomes and trace continuity smoke coverage.

### Changed
- System API now derives request `trace_id` from `ApiRequestEnvelope.traceparent` as well as gRPC metadata before public-boundary request logging.

### Fixed
- Documented public API metric additions and compatibility evidence for Wave 1 observability closure.