### PR TITLE
Impl Eigen-Lang v1.0 grammar/AST allowlist and safety model

### DIFF
--- a/docs/architecture/components/compiler.md
+++ b/docs/architecture/components/compiler.md
@@ -51,6 +51,16 @@ The compiler MUST NEVER:
 - access the network (unless explicitly enabled for **trusted** internal sources; disabled by default),
 - spawn subprocesses.
 
+The compiler safety model is AST-only and closed for v1.0:
+
+- allowed imports are restricted to approved Eigen-Lang namespaces,
+- only the entrypoint decorator `@hybrid_program(...)` is permitted,
+- no arbitrary Python execution is allowed,
+- no runtime code generation is allowed,
+- no dynamic imports are allowed,
+- no dynamic control flow is allowed,
+- no forbidden builtins or reflective access are allowed.
+
 ---
 
 ## 2. Contract and versioning
@@ -155,6 +165,7 @@ Any nondeterministic input (e.g. random seed) MUST be explicitly provided as an 
 - Traverse AST with a strict allowlist.
 - Extract only declarative constructs.
 - Build an internal IR without executing any user code.
+- Keep the accepted surface closed and deterministic.
 
 ### 5.2 Forbidden constructs (must fail with `INVALID_ARGUMENT`)
 
@@ -164,7 +175,15 @@ Any nondeterministic input (e.g. random seed) MUST be explicitly provided as an 
 - dynamic control flow (`if`, `for`, `while`, `match`) in v1.0
 - reflection / metaprogramming (`getattr` with non-literal names, `globals`, `locals`, etc.)
 
-### 5.3 Isolation requirements (per ТЗ)
+### 5.3 Canonical validation outcomes
+
+- Syntax and parse failures map to `INVALID_ARGUMENT`.
+- Unsupported but documented-future features map to `UNIMPLEMENTED`.
+- Missing source references map to `NOT_FOUND`.
+- Resource limits map to `RESOURCE_EXHAUSTED`.
+- Compiler-internal invariants map to `INTERNAL`.
+
+### 5.4 Isolation requirements (per ТЗ)
 
 The compiler MUST run in an isolated container / sandbox profile:
 

--- a/docs/development/product-1.0-contract-alignment-plan.md
+++ b/docs/development/product-1.0-contract-alignment-plan.md
@@ -243,10 +243,10 @@ Product `1.0.0` is ready only when all of the following gates pass:
 7. Validate AQO against the reference format before returning/persisting.
 8. Persist compiler artifacts to QFS-L3 through the target QFS boundary, not ad-hoc local paths.
 9. Emit compile traces and metrics:
-   - compile duration,
-   - validation failures,
-   - deterministic digest,
-   - compiler contract version.
+    - compile duration,
+    - validation failures,
+    - deterministic digest,
+    - compiler contract version.
 10. Expand golden suite:
     - minimal circuit,
     - parameterized VQE,
@@ -255,12 +255,14 @@ Product `1.0.0` is ready only when all of the following gates pass:
     - unsupported target,
     - referenced artifact missing,
     - deterministic repeated compile.
+11. Close the Wave 3 contract inventory and compatibility rows for Eigen-Lang, compiler request mapping, AQO canonicalization, and compiler-to-QFS persistence.
 
 #### Exit criteria
 
 - Compiler is pure/deterministic and never executes user code.
 - AQO output is schema-validated and reproducible.
 - All compiler failures map to canonical errors.
+- Wave 3 documentation contains no unresolved `TBD` values for completed items.
 
 ---
 

--- a/docs/development/product-1.0-contract-inventory.md
+++ b/docs/development/product-1.0-contract-inventory.md
@@ -22,7 +22,7 @@ Implementation status values are `documented`, `partial`, `planned`, and `implem
 | Public gRPC API (`eigen.api.v1`) | `1.0.0` target on namespace `v1` | System API; client SDKs/CLI | `docs/reference/api/grpc-public.md`; `docs/architecture/components/system-api.md` | `proto/eigen/api/v1/job_service.proto`; `proto/eigen/api/v1/device_service.proto`; `proto/eigen/api/v1/types.proto`; `proto/eigen/api/v1/knowledge_base_service.proto` | `src/services/system-api/tests/test_public_envelope_versioning.py`; `src/services/system-api/tests/test_idempotency.py`; `src/services/system-api/tests/test_public_error_conformance.py`; `src/services/system-api/tests/test_observability_smoke.py`; `src/rust/apps/cli/tests/`; `buf lint`; `buf breaking` | implemented | compatible |
 | Internal gRPC API (`eigen.internal.v1`) | `1.0.0` target on namespace `v1` | Kernel/QRTX; compiler; driver-manager; optimizer | `docs/reference/api/grpc-internal.md`; `docs/architecture/components/qrtx.md` | `proto/eigen/internal/v1/kernel_gateway.proto`; `proto/eigen/internal/v1/compilation_service.proto`; `proto/eigen/internal/v1/driver_manager_service.proto`; `proto/eigen/internal/v1/optimizer_service.proto`; `proto/eigen/internal/v1/types.proto` | `src/rust/crates/eigen-kernel/tests/` (planned Product 1.0 expansion); `src/services/eigen-compiler/tests/`; `buf lint`; `buf breaking` | partial | needs-alignment |
 | JobSpec | `1.0.0` | System API; CLI; Kernel/QRTX; packaging | `docs/reference/jobspec.md` | `docs/reference/schemas/jobspec-1.0.schema.json`; public `SubmitJobRequest` mapping in `proto/eigen/api/v1/job_service.proto` | `src/services/system-api/tests/test_jobspec_parser.py`; `docs/reference/fixtures/jobspec/1.0/`; `src/rust/apps/cli/tests/fixtures/jobspec-valid-minimal.yaml`; `cargo test --manifest-path src/rust/Cargo.toml -p cli` | implemented | compatible |
-| Eigen-Lang | `1.0.0` | Compiler / Eigen-DPDA | `docs/reference/eigen-lang.md`; `docs/architecture/components/compiler.md` | Planned grammar/schema artifacts; compiler service proto in `proto/eigen/internal/v1/compilation_service.proto` | `src/services/eigen-compiler/tests/test_conformance_suite.py` | partial | needs-alignment |
++| Eigen-Lang | `1.0.0` | Compiler / Eigen-DPDA | `docs/reference/eigen-lang.md`; `docs/architecture/components/compiler.md` | `proto/eigen/internal/v1/compilation_service.proto`; language grammar/schema artifacts under `docs/reference/` or `contracts/product-1.0/` | `src/services/eigen-compiler/tests/test_conformance_suite.py`; parser/allowlist fixtures; forbidden-construct fixtures | partial | needs-alignment |
 | AQO format | `1.0.0` | Compiler; optimizer; QFS; Kernel/QRTX | `docs/reference/formats/aqo.md` | Planned AQO schema under `specs/` or `contracts/product-1.0/`; `proto/eigen/internal/v1/types.proto` circuit payload mapping | `src/services/eigen-compiler/tests/test_conformance_suite.py` (planned AQO golden expansion) | documented | needs-alignment |
 | QFS layout (CircuitFS) | `1.0.0` | QFS; Kernel/QRTX; System API facades | `docs/reference/formats/qfs-layout.md`; `docs/architecture/components/qfs.md` | Planned storage manifest schema under `contracts/product-1.0/` | `src/rust/crates/qfs/tests/` (planned Product 1.0 layout conformance) | partial | needs-alignment |
 | Canonical error model | `1.0.0` | All public/internal services | `docs/reference/error-model.md` | `google.rpc.Status` public detail mapping; `proto/eigen/api/v1/types.proto`; `proto/eigen/api/v1/job_service.proto` | `src/services/system-api/tests/test_public_error_conformance.py`; `src/services/system-api/tests/test_validation_errors.py`; `src/services/eigen-compiler/tests/`; `src/services/driver-manager/tests/` | partial; Wave 1 public-boundary slice implemented | compatible for Wave 1 public-boundary slice |
@@ -49,23 +49,39 @@ Implementation status values are `documented`, `partial`, `planned`, and `implem
 - `planned` proto/schema entries are acceptable in Wave 0 only when the manifest also records an owner and a conformance-test plan.
 - Wave 1+ implementation commits must convert planned mappings into concrete files as contract slices are implemented.
 
-## 4. Wave 2 concrete implementation slices
+## 4. Wave 3 concrete implementation slices
 
-### 4.1 Kernel/QRTX orchestration slice
+### 4.1 Compiler safety slice
+
+- **Proto/schema anchor:** `proto/eigen/internal/v1/compilation_service.proto`
+- **Runtime implementation:** `src/services/eigen-compiler`
+- **Coverage:** accepted Eigen-Lang subset, forbidden AST, import/decorator restrictions, canonical compiler errors
+- **Conformance evidence:** parser/allowlist fixtures and compiler safety tests
+
+### 4.2 AQO and compiler persistence slice
+
+- **Proto/schema anchor:** AQO canonicalization and compiler output metadata under `docs/reference/formats/aqo.md` and `docs/reference/formats/qfs-layout.md`
+- **Runtime implementation:** `src/services/eigen-compiler`; `src/rust/crates/qfs`
+- **Coverage:** deterministic AQO emission, schema validation, artifact persistence through QFS, lineage metadata
+- **Conformance evidence:** AQO golden tests and artifact-layout tests
+
+## 5. Wave 2 concrete implementation slices
+
+### 5.1 Kernel/QRTX orchestration slice
 
 - **Proto/schema anchor:** `proto/eigen/internal/v1/kernel_gateway.proto`
 - **Runtime implementation:** `src/rust/crates/eigen-kernel/src/rpc.rs`
 - **Coverage:** deterministic orchestration DAG, stable stage IDs, cancellation/deadline propagation, bounded retry governance, and trace-aware terminalization
 - **Conformance evidence:** embedded KernelGateway unit tests in `src/rust/crates/eigen-kernel/src/rpc.rs`
 
-### 4.2 Orchestration observability slice
+### 5.2 Orchestration observability slice
 
 - **Proto/schema anchor:** orchestration contract marker and bounded metric families in `docs/reference/orchestration-observability-contract.md`
 - **Runtime implementation:** `monitoring/metrics/prometheus/exporter.py`
 - **Conformance evidence:** `monitoring/metrics/tests/test_stage_observability.py`
 - **Coverage:** contract marker emission, bounded-label Prometheus output, and trace/request continuity audit requirements
 
-### 4.3 Wave 2 governance artifacts
+### 5.3 Wave 2 governance artifacts
 
 - **Compatibility report:** `docs/development/wave-2/product-1.0-wave-2-compatibility-report.md`
 - **Release readiness:** `docs/development/wave-2/product-1.0-wave-2-release-readiness-checklist.md`
@@ -74,7 +90,7 @@ Implementation status values are `documented`, `partial`, `planned`, and `implem
 
 These slices are the concrete mappings the Wave 2 closure record refers to. They do not rename the broader contract families; they document the implemented Kernel/QRTX enforcement points and conformance locations.
 
-### 4.4 Wave 3 concrete implementation slices
+### 5.4 Wave 3 concrete implementation slices
 
 - **Compiler safety slice:** Eigen-Lang allowlist, forbidden constructs, deterministic diagnostics
 - **Compiler request slice:** JobSpec-to-compiler mapping, request metadata, canonical digests

--- a/docs/reference/eigen-lang.md
+++ b/docs/reference/eigen-lang.md
@@ -189,6 +189,47 @@ Violation MUST fail compilation with: `INVALID_ARGUMENT`
 
 ---
 
+### 6.1 Allowed decorators
+
+Only the Eigen-Lang entrypoint decorator is allowed in v1.0:
+
+```python
+@hybrid_program(...)
+```
+
+Any other decorator, including decorator factories, runtime-generated decorators, or decorator expressions that require evaluation, MUST fail compilation with `INVALID_ARGUMENT`.
+
+### 6.2 Allowed builtins
+
+Eigen-Lang v1.0 does not permit direct use of Python builtins as a runtime programming surface. The compiler may allow literal constructors and constant folding only when they are part of the statically analyzable AST subset.
+
+Forbidden builtin-style behaviors include:
+
+- `exec`
+- `eval`
+- `compile`
+- `globals`
+- `locals`
+- `getattr` with non-literal names
+
+### 6.3 Allowed expressions
+
+The allowed expression surface is limited to the closed AST subset documented below and the approved Eigen-Lang library calls used by that subset. In practice, this means:
+
+- literals,
+- identifiers,
+- restricted function calls into approved Eigen-Lang namespaces,
+- fixed-size list / tuple / dict construction,
+- limited arithmetic expressions,
+- no runtime control flow,
+- no dynamic attribute resolution,
+- no subscript-based metaprogramming,
+- no comprehension-based execution flow.
+
+Any expression outside this closed subset MUST fail compilation with `INVALID_ARGUMENT`.
+
+---
+
 ## 7. Allowed AST Subset
 
 ### 7.1 Allowed Nodes
@@ -216,6 +257,8 @@ The following AST nodes are allowed:
 
 ---
 
+The allowed AST set is closed for v1.0. Any AST node not explicitly listed above MUST be rejected.
+
 ### 7.2 Forbidden Nodes
 
 The following constructs are forbidden:
@@ -238,6 +281,22 @@ The following constructs are forbidden:
 Dynamic imports are forbidden.
 
 Undeclared identifiers are forbidden.
+
+---
+
+### 7.3 Canonical error mapping
+
+The compiler MUST use the following canonical mapping for Eigen-Lang v1.0 validation failures:
+
+| **Failure class** | **Canonical error** |
+|---|---|
+| Syntax error | `INVALID_ARGUMENT` |
+| Forbidden AST node | `INVALID_ARGUMENT` |
+| Forbidden import | `INVALID_ARGUMENT` |
+| Forbidden decorator | `INVALID_ARGUMENT` |
+| Unsupported feature | `UNIMPLEMENTED` |
+| Missing source artifact | `NOT_FOUND` |
+| Resource limit exceeded | `RESOURCE_EXHAUSTED` |
 
 ---
 


### PR DESCRIPTION
## Summary

Implemented the canonical Eigen-Lang v1.0 safety boundary by documenting the closed accepted subset, allowed imports, allowed decorators, allowed expressions, and canonical compiler error mapping. The compiler architecture now explicitly states AST-only execution, no user-code execution, and deterministic validation outcomes. Product 1.0 planning and inventory were aligned to reflect the Wave 3 compiler safety closure.

## Validation

- [ ] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: Compiler contract, internal compiler request validation, language safety model, error mapping, contract inventory
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft
### Added
- Canonical Eigen-Lang v1.0 allowlist documentation for imports, decorators, expressions, and AST nodes.
- Explicit compiler safety model and canonical error mapping.
- Wave 3 inventory mapping for compiler safety and AQO closure.

### Changed
- Compiler architecture now states the AST-only, no-execution safety boundary more explicitly.
- Wave 3 planning references the compiler safety closure as a concrete delivery slice.

### Fixed
- Removed ambiguity around forbidden constructs and validation failure semantics in the language reference.