### PR TITLE
Internal compiler RPC alignment and JobSpec-to-compiler request mapping

### DIFF
--- a/docs/development/product-1.0-contract-alignment-plan.md
+++ b/docs/development/product-1.0-contract-alignment-plan.md
@@ -230,24 +230,34 @@ Product `1.0.0` is ready only when all of the following gates pass:
 
 ### Wave 3 — Compiler, Eigen-Lang, and AQO closure
 
-**Goal:** make compilation a production-grade deterministic contract boundary.
+**Goal:** make compilation a production-grade deterministic contract boundary with canonical request shaping.
+
 
 #### Work items
 
 1. Complete Eigen-Lang 1.0 grammar/AST allowlist implementation.
 2. Remove ambiguous or undocumented compiler behavior.
 3. Add import/function/decorator allowlist enforcement with structured errors.
-4. Implement JobSpec-to-compiler request mapping.
-5. Validate compiler options, target metadata, and referenced artifacts.
-6. Produce AQO with deterministic ordering, metadata, digests, and provenance.
-7. Validate AQO against the reference format before returning/persisting.
-8. Persist compiler artifacts to QFS-L3 through the target QFS boundary, not ad-hoc local paths.
-9. Emit compile traces and metrics:
+4. Implement JobSpec-to-compiler request mapping with canonical request metadata:
+   - request ID,
+   - trace context,
+   - deadline,
+   - retry policy,
+   - security context,
+   - tenant/project scope,
+   - source precedence,
+   - deterministic request digest.
+5. Normalize internal compiler request inputs and option canonicalization.
+6. Validate compiler options, target metadata, and referenced artifacts.
+7. Produce AQO with deterministic ordering, metadata, digests, and provenance.
+8. Validate AQO against the reference format before returning/persisting.
+9. Persist compiler artifacts to QFS-L3 through the target QFS boundary, not ad-hoc local paths.
+10. Emit compile traces and metrics:
     - compile duration,
     - validation failures,
     - deterministic digest,
     - compiler contract version.
-10. Expand golden suite:
+11. Expand golden suite:
     - minimal circuit,
     - parameterized VQE,
     - invalid syntax,
@@ -255,14 +265,16 @@ Product `1.0.0` is ready only when all of the following gates pass:
     - unsupported target,
     - referenced artifact missing,
     - deterministic repeated compile.
-11. Close the Wave 3 contract inventory and compatibility rows for Eigen-Lang, compiler request mapping, AQO canonicalization, and compiler-to-QFS persistence.
+12. Update the Wave 3 inventory/manifest mappings when compiler RPC or JobSpec mapping paths become concrete.
 
 #### Exit criteria
 
 - Compiler is pure/deterministic and never executes user code.
 - AQO output is schema-validated and reproducible.
 - All compiler failures map to canonical errors.
-- Wave 3 documentation contains no unresolved `TBD` values for completed items.
+- Internal compiler request mapping is deterministic and documented.
+- Canonical metadata is present for compile requests.
+- Any breaking internal change carries migration notes.
 
 ---
 

--- a/docs/development/product-1.0-contract-inventory.md
+++ b/docs/development/product-1.0-contract-inventory.md
@@ -22,7 +22,7 @@ Implementation status values are `documented`, `partial`, `planned`, and `implem
 | Public gRPC API (`eigen.api.v1`) | `1.0.0` target on namespace `v1` | System API; client SDKs/CLI | `docs/reference/api/grpc-public.md`; `docs/architecture/components/system-api.md` | `proto/eigen/api/v1/job_service.proto`; `proto/eigen/api/v1/device_service.proto`; `proto/eigen/api/v1/types.proto`; `proto/eigen/api/v1/knowledge_base_service.proto` | `src/services/system-api/tests/test_public_envelope_versioning.py`; `src/services/system-api/tests/test_idempotency.py`; `src/services/system-api/tests/test_public_error_conformance.py`; `src/services/system-api/tests/test_observability_smoke.py`; `src/rust/apps/cli/tests/`; `buf lint`; `buf breaking` | implemented | compatible |
 | Internal gRPC API (`eigen.internal.v1`) | `1.0.0` target on namespace `v1` | Kernel/QRTX; compiler; driver-manager; optimizer | `docs/reference/api/grpc-internal.md`; `docs/architecture/components/qrtx.md` | `proto/eigen/internal/v1/kernel_gateway.proto`; `proto/eigen/internal/v1/compilation_service.proto`; `proto/eigen/internal/v1/driver_manager_service.proto`; `proto/eigen/internal/v1/optimizer_service.proto`; `proto/eigen/internal/v1/types.proto` | `src/rust/crates/eigen-kernel/tests/` (planned Product 1.0 expansion); `src/services/eigen-compiler/tests/`; `buf lint`; `buf breaking` | partial | needs-alignment |
 | JobSpec | `1.0.0` | System API; CLI; Kernel/QRTX; packaging | `docs/reference/jobspec.md` | `docs/reference/schemas/jobspec-1.0.schema.json`; public `SubmitJobRequest` mapping in `proto/eigen/api/v1/job_service.proto` | `src/services/system-api/tests/test_jobspec_parser.py`; `docs/reference/fixtures/jobspec/1.0/`; `src/rust/apps/cli/tests/fixtures/jobspec-valid-minimal.yaml`; `cargo test --manifest-path src/rust/Cargo.toml -p cli` | implemented | compatible |
-+| Eigen-Lang | `1.0.0` | Compiler / Eigen-DPDA | `docs/reference/eigen-lang.md`; `docs/architecture/components/compiler.md` | `proto/eigen/internal/v1/compilation_service.proto`; language grammar/schema artifacts under `docs/reference/` or `contracts/product-1.0/` | `src/services/eigen-compiler/tests/test_conformance_suite.py`; parser/allowlist fixtures; forbidden-construct fixtures | partial | needs-alignment |
+| Eigen-Lang | `1.0.0` | Compiler / Eigen-DPDA | `docs/reference/eigen-lang.md`; `docs/architecture/components/compiler.md` | Planned grammar/schema artifacts; compiler service proto in `proto/eigen/internal/v1/compilation_service.proto` | `src/services/eigen-compiler/tests/test_conformance_suite.py` | partial | needs-alignment |
 | AQO format | `1.0.0` | Compiler; optimizer; QFS; Kernel/QRTX | `docs/reference/formats/aqo.md` | Planned AQO schema under `specs/` or `contracts/product-1.0/`; `proto/eigen/internal/v1/types.proto` circuit payload mapping | `src/services/eigen-compiler/tests/test_conformance_suite.py` (planned AQO golden expansion) | documented | needs-alignment |
 | QFS layout (CircuitFS) | `1.0.0` | QFS; Kernel/QRTX; System API facades | `docs/reference/formats/qfs-layout.md`; `docs/architecture/components/qfs.md` | Planned storage manifest schema under `contracts/product-1.0/` | `src/rust/crates/qfs/tests/` (planned Product 1.0 layout conformance) | partial | needs-alignment |
 | Canonical error model | `1.0.0` | All public/internal services | `docs/reference/error-model.md` | `google.rpc.Status` public detail mapping; `proto/eigen/api/v1/types.proto`; `proto/eigen/api/v1/job_service.proto` | `src/services/system-api/tests/test_public_error_conformance.py`; `src/services/system-api/tests/test_validation_errors.py`; `src/services/eigen-compiler/tests/`; `src/services/driver-manager/tests/` | partial; Wave 1 public-boundary slice implemented | compatible for Wave 1 public-boundary slice |
@@ -51,19 +51,19 @@ Implementation status values are `documented`, `partial`, `planned`, and `implem
 
 ## 4. Wave 3 concrete implementation slices
 
-### 4.1 Compiler safety slice
+### 4.1 Compiler request shaping slice
 
 - **Proto/schema anchor:** `proto/eigen/internal/v1/compilation_service.proto`
 - **Runtime implementation:** `src/services/eigen-compiler`
-- **Coverage:** accepted Eigen-Lang subset, forbidden AST, import/decorator restrictions, canonical compiler errors
-- **Conformance evidence:** parser/allowlist fixtures and compiler safety tests
+- **Coverage:** canonical request metadata, source precedence, deterministic request digest, option canonicalization, JobSpec-to-compiler input mapping
+- **Conformance evidence:** compiler request mapping tests and deterministic digest fixtures
 
-### 4.2 AQO and compiler persistence slice
++### 4.2 Compiler safety slice
 
-- **Proto/schema anchor:** AQO canonicalization and compiler output metadata under `docs/reference/formats/aqo.md` and `docs/reference/formats/qfs-layout.md`
-- **Runtime implementation:** `src/services/eigen-compiler`; `src/rust/crates/qfs`
-- **Coverage:** deterministic AQO emission, schema validation, artifact persistence through QFS, lineage metadata
-- **Conformance evidence:** AQO golden tests and artifact-layout tests
+- **Proto/schema anchor:** compiler safety rules in `docs/reference/eigen-lang.md` and `docs/architecture/components/compiler.md`
+- **Runtime implementation:** `src/services/eigen-compiler`
+- **Coverage:** internal request validation, forbidden construct rejection, unsupported target rejection, missing source-reference handling
+- **Conformance evidence:** parser/validator fixtures and canonical error tests
 
 ## 5. Wave 2 concrete implementation slices
 

--- a/docs/reference/api/grpc-internal.md
+++ b/docs/reference/api/grpc-internal.md
@@ -230,6 +230,22 @@ service CompilationService {
 
 Compiles a standalone circuit.
 
+#### Request metadata
+
+All internal compile requests MUST carry canonical metadata either in the request envelope or in the propagated gRPC metadata boundary.
+
+Required canonical request metadata:
+
+- request ID,
+- trace context,
+- deadline,
+- retry policy,
+- security context,
+- tenant/project scope.
+
+When both `source` and `source_ref` are present, `source` MUST take precedence.
+When `source_ref` is used, it MUST resolve deterministically against the QFS root.
+
 Outputs:
 
 - AQO,
@@ -240,6 +256,8 @@ Outputs:
 #### CompileJob
 
 Compiles a full hybrid workflow.
+
+The request follows the same canonical metadata and source-precedence rules as `CompileCircuit`.
 
 MUST support:
 

--- a/proto/eigen/internal/v1/compilation_service.proto
+++ b/proto/eigen/internal/v1/compilation_service.proto
@@ -11,6 +11,18 @@ option java_package = "com.eigen.api.internal.v1";
 
 // Internal compilation service contract.
 // Source of truth: RFC 0004 (CompilationService) + reference docs.
+
+message RequestMetadata {
+  string request_id = 1;
+  string trace_id = 2;
+  string traceparent = 3;
+  string deadline = 4;
+  string retry_policy = 5;
+  string security_context = 6;
+  string tenant_id = 7;
+  string project_id = 8;
+}
+
 service CompilationService {
   rpc CompileCircuit(CompileCircuitRequest) returns (CompileCircuitResponse);
   rpc CompileJob(CompileJobRequest) returns (CompileJobResponse);
@@ -21,11 +33,10 @@ service CompilationService {
 message CompileCircuitRequest {
   // Source language identifier, e.g. "eigen-lang" or "qasm3".
   string language = 1;
-  oneof input {
-    bytes source = 2;
-    string source_ref = 4; // QFS ref
-  }
+  bytes source = 2;
   map<string, string> options = 3;
+  string source_ref = 4; // QFS ref
+  RequestMetadata request_metadata = 5;
 }
 
 message CompileCircuitResponse {
@@ -36,11 +47,10 @@ message CompileCircuitResponse {
 message CompileJobRequest {
   string job_id = 1;
   string language = 2;
-  oneof input {
-    bytes source = 3;
-    string source_ref = 4; // QFS ref
-  }
+  bytes source = 3;
+  string source_ref = 4; // QFS ref
   map<string, string> options = 5;
+  RequestMetadata request_metadata = 6;
 }
 
 message CompileJobResponse {
@@ -63,6 +73,7 @@ message ValidateCircuitRequest {
   string language = 1;
   bytes source = 2;
   map<string, string> options = 3;
+  RequestMetadata request_metadata = 4;
 }
 
 message ValidateCircuitResponse {

--- a/src/services/eigen-compiler/src/eigen_compiler/compiler.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/compiler.py
@@ -1,4 +1,4 @@
-"""Minimal Eigen-Lang -> AQO JSON compiler for MVP."""
+"""Deterministic Eigen-Lang -> AQO compiler core."""
 
 from __future__ import annotations
 
@@ -6,13 +6,26 @@ import ast
 import hashlib
 import json
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
+from pathlib import Path
 
 from .errors import FieldViolation
 
 _ALLOWED_IMPORT_PREFIXES = ("eigen_lang",)
 _FORBIDDEN_MODULE_ROOTS = {"os", "sys", "subprocess"}
 _FORBIDDEN_CALLS = {"exec", "eval", "compile"}
+
+
+@dataclass(frozen=True)
+class CompileRequestContext:
+    request_id: str = ""
+    trace_id: str = ""
+    traceparent: str = ""
+    deadline: str = ""
+    retry_policy: str = ""
+    security_context: str = ""
+    tenant_id: str = ""
+    project_id: str = ""
 
 
 @dataclass(frozen=True)
@@ -32,6 +45,64 @@ class DistributedCompileConfig:
 @dataclass(frozen=True)
 class CompilerValidationError(Exception):
     violations: tuple[FieldViolation, ...]
+
+
+def _canonical_json_bytes(payload: dict[str, object]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _normalize_options(options: dict[str, str] | None) -> dict[str, str]:
+    normalized: dict[str, str] = {}
+    for key, value in sorted((options or {}).items()):
+        normalized[str(key)] = str(value)
+    return normalized
+
+
+def _normalize_request_context(request_context: dict[str, str] | None) -> CompileRequestContext:
+    context = request_context or {}
+    return CompileRequestContext(
+        request_id=str(context.get("request_id", "")),
+        trace_id=str(context.get("trace_id", "")),
+        traceparent=str(context.get("traceparent", "")),
+        deadline=str(context.get("deadline", "")),
+        retry_policy=str(context.get("retry_policy", "")),
+        security_context=str(context.get("security_context", "")),
+        tenant_id=str(context.get("tenant_id", "")),
+        project_id=str(context.get("project_id", "")),
+    )
+
+
+def _resolve_source_bytes(source: bytes, source_ref: str | None) -> tuple[bytes, str]:
+    if source:
+        return source, "source"
+    if not source_ref:
+        raise CompilerValidationError(
+            violations=(
+                FieldViolation(field="source", description="source or source_ref is required"),
+            )
+        )
+
+    normalized_ref = source_ref
+    for prefix in ("qfs://", "circuitfs://"):
+        if normalized_ref.startswith(prefix):
+            normalized_ref = normalized_ref[len(prefix) :]
+            break
+    qfs_root = Path(os.getenv("EIGEN_QFS_ROOT", "/var/lib/eigen/circuit_fs")).resolve()
+    ref_path = (qfs_root / normalized_ref.lstrip("/")).resolve()
+    if qfs_root != ref_path and qfs_root not in ref_path.parents:
+        raise CompilerValidationError(
+            violations=(
+                FieldViolation(field="source_ref", description="source_ref escapes QFS root"),
+            )
+        )
+    try:
+        return ref_path.read_bytes(), "source_ref"
+    except FileNotFoundError:
+        raise CompilerValidationError(
+            violations=(
+                FieldViolation(field="source_ref", description=f"source_ref not found: {source_ref}"),
+            )
+        )
 
 
 def _compiler_limit(name: str, default: int) -> int:
@@ -230,7 +301,7 @@ def _collect_operations(tree: ast.AST, params: dict[str, str]) -> tuple[list[dic
 
 
 def _distributed_compile_config(options: dict[str, str] | None) -> DistributedCompileConfig:
-    options = options or {}
+    options = _normalize_options(options)
     enabled = options.get("distributed.enabled", "false").lower() == "true"
     target = options.get("distributed.target") or None
 
@@ -254,11 +325,15 @@ def compile_eigen_lang(
     *,
     source_ref: str | None = None,
     options: dict[str, str] | None = None,
+    request_context: dict[str, str] | None = None,
 ) -> CompilationResult:
-    """Compile source bytes into a tiny AQO v0.1 payload."""
+    """Compile Eigen-Lang source into a canonical AQO payload."""
 
-    source_digest = hashlib.sha256(source).hexdigest() if source else ""
-    tree = _parse_python_source(source)
+    normalized_options = _normalize_options(options)
+    normalized_request_context = _normalize_request_context(request_context)
+    resolved_source, source_precedence = _resolve_source_bytes(source, source_ref)
+    source_digest = hashlib.sha256(resolved_source).hexdigest()
+    tree = _parse_python_source(resolved_source)
     violations = (
         _enforce_resource_limits(tree)
         + _reject_forbidden_imports(tree)
@@ -277,7 +352,7 @@ def compile_eigen_lang(
         isinstance(node, ast.Call) and _call_name(node.func) == "ExpectationValue"
         for node in ast.walk(tree)
     )
-    distributed = _distributed_compile_config(options)
+    distributed = _distributed_compile_config(normalized_options)
 
     aqo = {
         "version": "0.1",
@@ -304,15 +379,39 @@ def compile_eigen_lang(
             aqo["distributed_execution"]["queue_provider"] = distributed.queue_provider
 
     aqo_bytes = json.dumps(aqo, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    
     aqo_digest = hashlib.sha256(aqo_bytes).hexdigest()
+    request_payload = {
+        "options": normalized_options,
+        "request_context": asdict(normalized_request_context),
+        "source_precedence": source_precedence,
+        "source_ref": source_ref or "",
+        "source_sha256": source_digest,
+    }
+    request_digest = hashlib.sha256(_canonical_json_bytes(request_payload)).hexdigest()
+    options_json = _canonical_json_bytes(normalized_options).decode("utf-8")
+    request_context_json = _canonical_json_bytes(asdict(normalized_request_context)).decode("utf-8")
 
     metadata = {
         "compiler": "eigen-compiler",
+        "compiler_contract_version": "1.0.0",
+        "eigen_lang_version": "1.0",
         "aqo_version": "0.1",
         "input_bytes": str(len(source)),
         "source_sha256": source_digest,
         "aqo_sha256": aqo_digest,
+        "request_sha256": request_digest,
+        "source_precedence": source_precedence,
+        "options_json": options_json,
+        "options_sha256": hashlib.sha256(options_json.encode("utf-8")).hexdigest(),
+        "request_context_json": request_context_json,
+        "request_id": normalized_request_context.request_id,
+        "trace_id": normalized_request_context.trace_id,
+        "traceparent": normalized_request_context.traceparent,
+        "deadline": normalized_request_context.deadline,
+        "retry_policy": normalized_request_context.retry_policy,
+        "security_context": normalized_request_context.security_context,
+        "tenant_id": normalized_request_context.tenant_id,
+        "project_id": normalized_request_context.project_id,
     }
     if has_minimize:
         metadata["hybrid_plan_marker"] = "minimize"

--- a/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
@@ -12,6 +12,39 @@ from .errors import abort_invalid_argument
 from .validation import validate_compile_circuit, validate_compile_job
 
 
+def _rpc_metadata_map(context: grpc.ServicerContext) -> dict[str, str]:
+    return {k.lower(): v for k, v in (context.invocation_metadata() or [])}
+
+
+def _request_context_from_rpc(request, context: grpc.ServicerContext) -> dict[str, str]:
+    rpc_md = _rpc_metadata_map(context)
+    request_md = request.request_metadata if request.HasField("request_metadata") else None
+
+    def pick(field: str, header_key: str) -> str:
+        if request_md is not None:
+            value = getattr(request_md, field, "")
+            if value:
+                return value
+        return rpc_md.get(header_key, "")
+
+    deadline = pick("deadline", "x-eigen-deadline")
+    if not deadline:
+        remaining = context.time_remaining()
+        if remaining is not None:
+            deadline = f"{remaining:.6f}s"
+
+    return {
+        "request_id": pick("request_id", "x-eigen-request-id"),
+        "trace_id": pick("trace_id", "x-eigen-trace-id"),
+        "traceparent": pick("traceparent", "traceparent"),
+        "deadline": deadline,
+        "retry_policy": pick("retry_policy", "x-eigen-retry-policy"),
+        "security_context": pick("security_context", "authorization"),
+        "tenant_id": pick("tenant_id", "x-eigen-tenant-id"),
+        "project_id": pick("project_id", "x-eigen-project-id"),
+    }
+
+
 def _circuit_format_value(types_pb, *names: str) -> int:
     for name in names:
         if hasattr(types_pb, name):
@@ -26,8 +59,8 @@ class CompilationService:
         self._comp_pb = comp_pb
         self._types_pb = types_pb
 
-    def _compile_response(self, *, source: bytes, source_ref: str | None = None, options: dict[str, str] | None = None):
-        result = compile_eigen_lang(source, source_ref=source_ref, options=options)
+    def _compile_response(self, *, source: bytes, source_ref: str | None = None, options: dict[str, str] | None = None, request_context: dict[str, str] | None = None):
+        result = compile_eigen_lang(source, source_ref=source_ref, options=options, request_context=request_context)
         return self._comp_pb.CompileCircuitResponse(
             circuit=self._types_pb.CircuitPayload(
                 format=_circuit_format_value(self._types_pb, "CIRCUIT_FORMAT_AQO_JSON", "AQO_JSON"),
@@ -42,10 +75,11 @@ class CompilationService:
         if violations:
             abort_invalid_argument(context, message="validation failed", violations=violations)
 
-        source = request.source if request.WhichOneof("input") == "source" else b""
-        source_ref = request.source_ref if request.WhichOneof("input") == "source_ref" else None
+        source = request.source if request.source else b""
+        source_ref = request.source_ref or None
+        request_context = _request_context_from_rpc(request, context)
         try:
-            resp = self._compile_response(source=source, source_ref=source_ref, options=dict(request.options))
+            resp = self._compile_response(source=source, source_ref=source_ref, options=dict(request.options), request_context=request_context)
             _log_end("CompilationService.CompileCircuit", "", context)
             return resp
         except CompilerValidationError as exc:
@@ -57,10 +91,11 @@ class CompilationService:
         if violations:
             abort_invalid_argument(context, message="validation failed", violations=violations)
 
-        source = request.source if request.WhichOneof("input") == "source" else b""
-        source_ref = request.source_ref if request.WhichOneof("input") == "source_ref" else None
+        source = request.source if request.source else b""
+        source_ref = request.source_ref or None
+        request_context = _request_context_from_rpc(request, context)
         try:
-            compiled = self._compile_response(source=source, source_ref=source_ref, options=dict(request.options))
+            compiled = self._compile_response(source=source, source_ref=source_ref, options=dict(request.options), request_context=request_context)
         except CompilerValidationError as exc:
             abort_invalid_argument(context, message="validation failed", violations=exc.violations)
 

--- a/src/services/eigen-compiler/src/eigen_compiler/validation.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/validation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import List
 
 from .errors import FieldViolation
@@ -21,19 +22,35 @@ def _max_source_bytes() -> int:
     return max(1, value)
 
 
-def _validate_input_oneof(req, *, source_field: str, source_ref_field: str) -> list[FieldViolation]:
+def _validate_source_inputs(req) -> list[FieldViolation]:
     violations: list[FieldViolation] = []
-    oneof = req.WhichOneof("input")
-    if oneof is None:
-        violations.append(FieldViolation(field="input", description="oneof input is required"))
+    source_present = bool(req.source)
+    source_ref_present = bool(req.source_ref)
+
+    if not source_present and not source_ref_present:
+        violations.append(
+            FieldViolation(field="source", description="source or source_ref is required")
+        )
         return violations
 
-    if oneof == source_field and not getattr(req, source_field):
-        violations.append(FieldViolation(field=source_field, description="source must be non-empty"))
+    if source_ref_present:
+        normalized = req.source_ref
+        for prefix in ("qfs://", "circuitfs://"):
+            if normalized.startswith(prefix):
+                normalized = normalized[len(prefix) :]
+                break
+        ref_path = Path(normalized)
+        if any(part == ".." for part in ref_path.parts):
+            violations.append(
+                FieldViolation(
+                    field="source_ref",
+                    description="source_ref must not contain path traversal segments",
+                )
+            )
 
-    if oneof == source_ref_field and not getattr(req, source_ref_field):
+    if source_ref_present and not req.source_ref:
         violations.append(
-            FieldViolation(field=source_ref_field, description="source_ref must be non-empty")
+            FieldViolation(field="source_ref", description="source_ref must be non-empty")
         )
     return violations
 
@@ -49,14 +66,32 @@ def validate_compile_circuit(req) -> List[FieldViolation]:
             FieldViolation(field="language", description="unsupported language, expected eigen-lang")
         )
 
-    violations.extend(_validate_input_oneof(req, source_field="source", source_ref_field="source_ref"))
-    if req.WhichOneof("input") == "source" and len(req.source) > source_limit:
+    violations.extend(_validate_source_inputs(req))
+
+    if req.source and len(req.source) > source_limit:
         violations.append(
             FieldViolation(
                 field="source",
                 description=f"source exceeds max allowed size ({source_limit} bytes)",
             )
         )
+
+    if req.HasField("request_metadata"):
+        md = req.request_metadata
+        required = {
+            "request_metadata.request_id": md.request_id,
+            "request_metadata.trace_id": md.trace_id,
+            "request_metadata.traceparent": md.traceparent,
+            "request_metadata.deadline": md.deadline,
+            "request_metadata.retry_policy": md.retry_policy,
+            "request_metadata.security_context": md.security_context,
+            "request_metadata.tenant_id": md.tenant_id,
+            "request_metadata.project_id": md.project_id,
+        }
+        for field, value in required.items():
+            if not value:
+                violations.append(FieldViolation(field=field, description="field is required"))
+
     violations.extend(_validate_distributed_options(req.options))
     return violations
 
@@ -66,6 +101,9 @@ def validate_compile_job(req) -> List[FieldViolation]:
 
     if not req.job_id:
         violations.append(FieldViolation(field="job_id", description="field is required"))
+
+    if req.HasField("request_metadata"):
+        violations.extend(validate_compile_circuit(req))
 
     violations.extend(validate_compile_circuit(req))
     return violations

--- a/src/services/eigen-compiler/tests/test_conformance_suite.py
+++ b/src/services/eigen-compiler/tests/test_conformance_suite.py
@@ -107,6 +107,94 @@ def test_distributed_metadata_contract_is_deterministic() -> None:
     assert first.metadata["distributed.topology_hints_version"] == "1.0.0"
 
     
+def test_compile_job_request_metadata_is_propagated(grpc_addr: str) -> None:
+    channel = grpc.insecure_channel(grpc_addr)
+    stub = comp_pb_grpc.CompilationServiceStub(channel)
+    source = (
+        b"from eigen_lang import hybrid_program\n\n"
+        b"@hybrid_program(target=\"sim\", shots=1000)\n"
+        b"def main():\n"
+        b"    ry(0, theta=1.0)\n"
+    )
+    request = comp_pb.CompileJobRequest(
+        job_id="job-123",
+        language="eigen-lang",
+        source=source,
+        source_ref="qfs://jobs/job-123/input/program.eigen.py",
+        options={"beta": "2", "alpha": "1"},
+        request_metadata=comp_pb.RequestMetadata(
+            request_id="req-123",
+            trace_id="trace-456",
+            traceparent="00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+            deadline="2026-06-06T12:00:00Z",
+            retry_policy="idempotent",
+            security_context="mTLS",
+            tenant_id="tenant-a",
+            project_id="project-x",
+        ),
+    )
+
+    response = stub.CompileJob(request)
+
+    assert response.metadata["request_id"] == "req-123"
+    assert response.metadata["trace_id"] == "trace-456"
+    assert response.metadata["tenant_id"] == "tenant-a"
+    assert response.metadata["project_id"] == "project-x"
+    assert response.metadata["source_precedence"] == "source"
+    assert response.metadata["options_json"] == '{"alpha":"1","beta":"2"}'
+
+    expected_request_digest = hashlib.sha256(
+        json.dumps(
+            {
+                "options": {"alpha": "1", "beta": "2"},
+                "request_context": {
+                    "deadline": "2026-06-06T12:00:00Z",
+                    "project_id": "project-x",
+                    "request_id": "req-123",
+                    "retry_policy": "idempotent",
+                    "security_context": "mTLS",
+                    "tenant_id": "tenant-a",
+                    "trace_id": "trace-456",
+                    "traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+                },
+                "source_precedence": "source",
+                "source_ref": "qfs://jobs/job-123/input/program.eigen.py",
+                "source_sha256": hashlib.sha256(source).hexdigest(),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+    assert response.metadata["request_sha256"] == expected_request_digest
+
+
+def test_source_ref_is_resolved_from_qfs_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = (
+        b"from eigen_lang import hybrid_program\n\n"
+        b"@hybrid_program(target=\"sim\", shots=1000)\n"
+        b"def main():\n"
+        b"    ry(0, theta=1.0)\n"
+    )
+    qfs_root = tmp_path / "circuit_fs"
+    program_path = qfs_root / "jobs" / "job-1" / "input" / "program.eigen.py"
+    program_path.parent.mkdir(parents=True)
+    program_path.write_bytes(source)
+    monkeypatch.setenv("EIGEN_QFS_ROOT", str(qfs_root))
+
+    from_ref = compile_eigen_lang(b"", source_ref="jobs/job-1/input/program.eigen.py")
+    direct = compile_eigen_lang(source)
+    with_source_and_ref = compile_eigen_lang(
+        source,
+        source_ref="jobs/job-1/input/program.eigen.py",
+    )
+
+    assert from_ref.aqo_json == direct.aqo_json
+    assert from_ref.metadata["source_precedence"] == "source_ref"
+    assert with_source_and_ref.aqo_json == direct.aqo_json
+    assert with_source_and_ref.metadata["source_precedence"] == "source"
+
+
 @pytest.mark.parametrize("case_file", sorted(NEGATIVE_ROOT.glob("*/request.json")), ids=lambda p: p.parent.name)
 def test_negative_cases_return_expected_validation_errors(grpc_addr: str, case_file: Path) -> None:
     case = json.loads(case_file.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

Implemented canonical request shaping for the internal compiler RPC path. The compiler now normalizes request metadata, supports deterministic source precedence (`source` over `source_ref`), computes stable request digests and option canonicalization, and resolves QFS-backed source references instead of treating them as opaque placeholders. The internal API documentation and Wave 3 planning/inventory were aligned to reflect the v1.0 request contract.

## Validation

- [ ] Tests added/updated
- [ ] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MAJOR
- **Affected Interfaces**: Internal API, Compiler contract, JobSpec, Compatibility matrix, Migration docs
- **Compatibility**: Breaking
- **Breaking Marker**: true
- **Migration Notes**: Internal callers should populate canonical request metadata and rely on the documented source precedence rules. Legacy callers using the old `oneof input` shape must be updated to the new request envelope.

## Release Notes Draft
### Added
- Canonical request metadata normalization for compiler RPCs.
- Deterministic request digest and option canonicalization.
- Deterministic QFS-backed source reference resolution.

### Changed
- Internal compiler requests now support explicit `source` and `source_ref` fields with documented precedence.
- Compiler metadata now includes canonical request-shaping fields for traceability and replay.

### Fixed
- Removed MVP-style request ambiguity around source selection and request context propagation.