### PR TITLE
Compiler artifact persistence handoff to QFS

### DIFF
--- a/docs/architecture/components/compiler.md
+++ b/docs/architecture/components/compiler.md
@@ -40,11 +40,24 @@ The compiler MUST:
 2. Validate the allowed subset and enforce safety restrictions.
 3. Produce **canonical, deterministic AQO v1.0** (JSON) as the primary IR artifact.
 4. Optionally produce additional artifacts (AQO protobuf, QASM export) **without changing AQO**.
-5. Validate AQO structure and invariants against the reference contract before persistence or downstream execution.
-6. Emit structured diagnostics and deterministic error semantics.
-7. Persist compilation artifacts and metadata into QFS in the canonical layout (see `qfs-layout.md`).
+5. Emit structured diagnostics and deterministic error semantics.
+6. Persist compilation artifacts and metadata into QFS in the canonical layout (see `qfs-layout.md`).
+7. Preserve lineage and integrity metadata for compiled artifacts:
+   - content digests,
+   - producer identity,
+   - contract version,
+   - timestamps,
+   - request/source lineage,
+   - optional sidecar artifacts.
 
 The compiler MUST NEVER:
+
+- compile source into AQO
+- persist AQO and compiler metadata
+- emit deterministic diagnostics
+- hand off persisted artifacts to QFS
+- hand off persisted artifacts to QFS with immutable compiled artifact names
+- validate that sidecar artifacts are advisory and never authoritative over AQO
 
 - execute user Python code,
 - import arbitrary modules,

--- a/docs/development/product-1.0-contract-alignment-plan.md
+++ b/docs/development/product-1.0-contract-alignment-plan.md
@@ -265,6 +265,7 @@ Product `1.0.0` is ready only when all of the following gates pass:
 - Compiler is pure/deterministic and never executes user code.
 - AQO output is schema-validated and reproducible.
 - All compiler failures map to canonical errors.
+- Compiler outputs are persisted through QFS with immutable artifact names and lineage metadata.
 - Identical inputs yield identical AQO bytes and hashes.
 - AQO validation occurs before persistence.
 - Canonical errors are returned for structural and semantic AQO violations.

--- a/docs/development/product-1.0-contract-inventory.md
+++ b/docs/development/product-1.0-contract-inventory.md
@@ -51,14 +51,28 @@ Implementation status values are `documented`, `partial`, `planned`, and `implem
 
 ## 4. Wave 3 concrete implementation slices
 
-### 4.1 Compiler request shaping slice
+### 4.1 Compiler-to-QFS artifact slice
+
+- **Proto/schema anchor:** `docs/reference/formats/qfs-layout.md`
+- **Runtime implementation:** `src/rust/crates/qfs/src/local_circuit_fs.rs`
+- **Coverage:** canonical `compiled/` artifact names, immutable write behavior, compiler metadata, lineage, integrity hashes, optional diagnostics sidecar
+- **Conformance evidence:** compiled-artifact round-trip, missing-sidecar, and duplicate-write tests
+
+### 4.2 Compiler contract slice
+
+- **Proto/schema anchor:** `docs/architecture/components/compiler.md`
+- **Runtime implementation:** `src/services/eigen-compiler`
+- **Coverage:** AQO persistence handoff, metadata handoff, sidecar authoritative/advisory boundary
+- **Conformance evidence:** compiler-to-QFS integration tests
+
+### 4.2 Compiler request shaping slice
 
 - **Proto/schema anchor:** `proto/eigen/internal/v1/compilation_service.proto`
 - **Runtime implementation:** `src/services/eigen-compiler`
 - **Coverage:** canonical request metadata, source precedence, deterministic request digest, option canonicalization, JobSpec-to-compiler input mapping
 - **Conformance evidence:** compiler request mapping tests and deterministic digest fixtures
 
-+### 4.2 Compiler safety slice
+### 4.3 Compiler safety slice
 
 - **Proto/schema anchor:** compiler safety rules in `docs/reference/eigen-lang.md` and `docs/architecture/components/compiler.md`
 - **Runtime implementation:** `src/services/eigen-compiler`

--- a/docs/development/wave-3/product-1.0-wave-3-compatibility-report.md
+++ b/docs/development/wave-3/product-1.0-wave-3-compatibility-report.md
@@ -1,12 +1,19 @@
 # Product 1.0 Wave 3 Compatibility Report
 
-**Status:** W3-06 closure draft; Wave 3 issue ledger complete for documented implementation slices  
-**Scope:** Eigen-Lang safety model, compiler request mapping, AQO canonicalization, compiler-to-QFS persistence, and compiler observability  
-**Version policy:** `docs/development/product-1.0-version-policy.md`  
-**Issue pack:** `docs/development/wave-3/product-1.0-wave-3-issue-pack.md`  
-**Evidence bundle:** `docs/development/wave-3/product-1.0-wave-3-exit-evidence-bundle.md`  
-**Created:** 2026-06-05  
-**Updated:** 2026-06-05
+**Status:** W3-04 closure draft  
+**Scope:** compiler artifact persistence, QFS L3 boundary, lineage metadata, integrity metadata, immutability semantics
+
+| Issue | Version Impact | Affected Interfaces | Compatibility | Breaking Marker | Migration Notes | Release Notes Draft | Evidence |
+|---|---|---|---|---|---|---|---|
+| W3-04 Compiler artifact persistence handoff to QFS | MINOR | Compiler contract; QFS; compiler metadata; compiled artifact layout | Backward-compatible | false | None | Added: QFS v1 compiled artifact metadata, lineage, and immutable sidecar write behavior; Changed: compiler persistence now uses canonical compiled artifact names; Fixed: duplicate-write and missing-sidecar handling | W3-E04 |
+
+## W3-04 closure requirements
+
+- Canonical compiled artifact names are documented.
+- Metadata includes lineage and integrity data.
+- Duplicate writes are rejected.
+- Replay reads are validated.
+- Sidecars are explicitly marked authoritative or advisory.
 
 ---
 

--- a/docs/development/wave-3/product-1.0-wave-3-exit-evidence-bundle.md
+++ b/docs/development/wave-3/product-1.0-wave-3-exit-evidence-bundle.md
@@ -5,6 +5,10 @@
 **Created:** 2026-06-05  
 **Updated:** 2026-06-05
 
+| Evidence ID | Requirement | Command / artifact | Expected result | Actual result | Owner | Link |
+|---|---|---|---|---|---|---|
+| W3-E04 | Compiler artifact persistence through QFS | `cargo test --manifest-path src/rust/Cargo.toml -p qfs store_compiled_artifacts_v1_is_canonical_and_round_trips duplicate_compiled_writes_are_rejected missing_sidecar_reference_is_reported` | Compiler outputs persist through QFS with lineage/integrity metadata; duplicate writes are rejected; replay reads are validated | Pending | QFS | TBD |
+
 ---
 
 ## 1. Evidence index

--- a/docs/reference/formats/qfs-layout.md
+++ b/docs/reference/formats/qfs-layout.md
@@ -99,6 +99,7 @@ Invalid `job_id` values MUST be rejected before filesystem access.
 │   ├── circuit.aqo.pb
 │   ├── circuit.qasm
 │   ├── compile_report.json
+│   ├── compile_report.json
 │   └── metadata.json
 ├── execution/
 │   ├── execution_plan.json
@@ -167,8 +168,25 @@ Contains compiler outputs.
 | `circuit.aqo.json` | yes | Canonical AQO |
 | `circuit.aqo.pb` | optional | Binary AQO |
 | `circuit.qasm` | optional | OpenQASM export |
-| `compile_report.json` | optional | Compiler diagnostics |
-| `metadata.json` | optional | Compiler metadata |
+| `compile_report.json` | optional | Compiler diagnostics / sidecar report |
+| `metadata.json` | yes | Canonical compiler metadata |
+
+#### Metadata requirements
+
+`compiled/metadata.json` MUST include:
+
+- `version` = `1.0.0`
+- `schema_version`
+- `compiler_version`
+- `producer_identity`
+- `contract_version`
+- `created_at`
+- `aqo_hash`
+- `qasm_hash` when `circuit.qasm` exists
+- `diagnostics_hash` when `compile_report.json` exists
+- `lineage` with request/source provenance
+
+The compiler output directory is immutable within a job scope: duplicate writes to the same artifact path MUST be rejected by the persistence layer.
 
 ---
 

--- a/src/rust/crates/qfs/src/lib.rs
+++ b/src/rust/crates/qfs/src/lib.rs
@@ -11,7 +11,8 @@ mod local_circuit_fs;
 mod qfs_l2_checkpoint;
 
 pub use local_circuit_fs::{
-    CircuitFsError, CircuitFsLocal, CompiledArtifacts, CompiledMetadata, ErrorDetails,
+    CircuitFsError, CircuitFsLocal, CompiledArtifactLineage, CompiledArtifactProvenance,
+    CompiledArtifacts, CompiledMetadata, ErrorDetails,
     ResultArtifactDescriptor, ResultEnvelope, ResultManifest, ResultsBundle, SourceBundle,
     SourceMetadata, DEFAULT_CIRCUIT_FS_ROOT,
 };

--- a/src/rust/crates/qfs/src/local_circuit_fs.rs
+++ b/src/rust/crates/qfs/src/local_circuit_fs.rs
@@ -34,7 +34,29 @@ pub struct ResultsBundle {
 pub struct CompiledArtifacts {
     pub aqo_json: Vec<u8>,
     pub qasm: Option<Vec<u8>>,
+    pub compile_report_json: Option<Vec<u8>>,
     pub metadata: CompiledMetadata,
+}
+
+/// Provenance/lineage for compiler outputs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct CompiledArtifactLineage {
+    #[serde(default)]
+    pub request_id: Option<String>,
+    #[serde(default)]
+    pub source_ref: Option<String>,
+    #[serde(default)]
+    pub source_sha256: Option<String>,
+}
+
+/// Explicit inputs used to write canonical compiler artifacts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompiledArtifactProvenance {
+    pub producer_identity: String,
+    pub contract_version: String,
+    pub compiler_version: String,
+    pub created_at: String,
+    pub lineage: CompiledArtifactLineage,
 }
 
 /// Metadata for source bundle artifacts.
@@ -52,8 +74,21 @@ pub struct CompiledMetadata {
     pub version: String,
     pub schema_version: String,
     pub compiler_version: String,
+    #[serde(default)]
+    pub producer_identity: String,
+    #[serde(default)]
+    pub contract_version: String,
+    #[serde(default)]
+    pub created_at: String,
+    #[serde(default)]
+    pub source_sha256: String,
     pub aqo_hash: String,
+    #[serde(default)]
     pub qasm_hash: Option<String>,
+    #[serde(default)]
+    pub diagnostics_hash: Option<String>,
+    #[serde(default)]
+    pub lineage: CompiledArtifactLineage,
 }
 
 /// Versioned result envelope persisted under `results/result.json`.
@@ -99,6 +134,9 @@ pub enum CircuitFsError {
 
     #[error("invalid job_id: {job_id}")]
     InvalidJobId { job_id: String },
+
+    #[error("artifact already exists: {path}")]
+    AlreadyExists { path: PathBuf },
 
     #[error(transparent)]
     Io(#[from] io::Error),
@@ -201,6 +239,11 @@ impl CircuitFsLocal {
         Ok(self.compiled_dir(job_id)?.join("metadata.json"))
     }
 
+    /// `/circuit_fs/{job_id}/compiled/compile_report.json`
+    pub fn compiled_report_path(&self, job_id: &str) -> Result<PathBuf, CircuitFsError> {
+        Ok(self.compiled_dir(job_id)?.join("compile_report.json"))
+    }
+
     /// `/circuit_fs/{job_id}/results.parquet`
     pub fn results_parquet_path(&self, job_id: &str) -> Result<PathBuf, CircuitFsError> {
         Ok(self.job_root(job_id)?.join("results.parquet"))
@@ -290,12 +333,74 @@ impl CircuitFsLocal {
         self.store_compiled_artifacts(job_id, aqo_json, None, "unknown")
     }
 
+    /// Stores compiler outputs under `compiled/` using the v1 contract.
+    ///
+    /// This is the canonical persistence entrypoint for Wave 3.
+    pub fn store_compiled_artifacts_v1(
+        &self,
+        job_id: &str,
+        aqo_json: &[u8],
+        qasm: Option<&[u8]>,
+        compile_report_json: Option<&[u8]>,
+        provenance: CompiledArtifactProvenance,
+    ) -> Result<(), CircuitFsError> {
+        self.ensure_job_layout(job_id)?;
+
+        let compiled_aqo_path = self.compiled_aqo_json_path(job_id)?;
+        let compiled_metadata_path = self.compiled_metadata_path(job_id)?;
+        let compiled_qasm_path = self.compiled_qasm_path(job_id)?;
+        let compiled_report_path = self.compiled_report_path(job_id)?;
+
+        for path in [
+            compiled_aqo_path.clone(),
+            compiled_metadata_path.clone(),
+            compiled_qasm_path.clone(),
+            compiled_report_path.clone(),
+        ] {
+            if path.exists() {
+                return Err(CircuitFsError::AlreadyExists { path });
+            }
+        }
+
+        atomic_write_bytes(&compiled_aqo_path, aqo_json)?;
+        if let Some(qasm_bytes) = qasm {
+            atomic_write_bytes(&compiled_qasm_path, qasm_bytes)?;
+        }
+        if let Some(report_bytes) = compile_report_json {
+            atomic_write_bytes(&compiled_report_path, report_bytes)?;
+        }
+
+        let metadata = CompiledMetadata {
+            version: "1.0.0".to_string(),
+            schema_version: "compiled_artifacts.v1".to_string(),
+            compiler_version: provenance.compiler_version.clone(),
+            producer_identity: provenance.producer_identity,
+            contract_version: provenance.contract_version,
+            created_at: provenance.created_at,
+            source_sha256: provenance
+                .lineage
+                .source_sha256
+                .clone()
+                .unwrap_or_default(),
+            aqo_hash: content_hash_hex(aqo_json),
+            qasm_hash: qasm.map(content_hash_hex),
+            diagnostics_hash: compile_report_json.map(content_hash_hex),
+            lineage: provenance.lineage,
+        };
+
+        let bytes = serde_json::to_vec_pretty(&metadata).map_err(to_io_error)?;
+        atomic_write_bytes(&compiled_metadata_path, &bytes)?;
+        Ok(())
+    }
+
     /// Loads `compiled/circuit.aqo.json`.
     pub fn load_compiled_aqo_json(&self, job_id: &str) -> Result<Vec<u8>, CircuitFsError> {
         read_bytes_not_found(&self.compiled_aqo_json_path(job_id)?)
     }
 
     /// Stores compiler outputs under `compiled/` and writes `compiled/metadata.json`.
+    ///
+    /// Legacy compatibility helper retained for older call sites.
     pub fn store_compiled_artifacts(
         &self,
         job_id: &str,
@@ -303,23 +408,14 @@ impl CircuitFsLocal {
         qasm: Option<&[u8]>,
         compiler_version: &str,
     ) -> Result<(), CircuitFsError> {
-        self.ensure_job_layout(job_id)?;
-        atomic_write_bytes(&self.compiled_aqo_json_path(job_id)?, aqo_json)?;
-
-        if let Some(qasm_bytes) = qasm {
-            atomic_write_bytes(&self.compiled_qasm_path(job_id)?, qasm_bytes)?;
-        }
-
-        let metadata = CompiledMetadata {
-            version: "0.1".to_string(),
-            schema_version: "compiled_artifacts.v1".to_string(),
+        let provenance = CompiledArtifactProvenance {
+            producer_identity: "eigen-compiler".to_string(),
+            contract_version: "1.0.0".to_string(),
             compiler_version: compiler_version.to_string(),
-            aqo_hash: content_hash_hex(aqo_json),
-            qasm_hash: qasm.map(content_hash_hex),
+            created_at: "unknown".to_string(),
+            lineage: CompiledArtifactLineage::default(),
         };
-        let bytes = serde_json::to_vec_pretty(&metadata).map_err(to_io_error)?;
-        atomic_write_bytes(&self.compiled_metadata_path(job_id)?, &bytes)?;
-        Ok(())
+        self.store_compiled_artifacts_v1(job_id, aqo_json, qasm, None, provenance)
     }
 
     /// Loads `compiled/circuit.aqo.json`, optional `compiled/circuit.qasm`, and metadata.
@@ -328,13 +424,33 @@ impl CircuitFsLocal {
         job_id: &str,
     ) -> Result<CompiledArtifacts, CircuitFsError> {
         let aqo_json = read_bytes_not_found(&self.compiled_aqo_json_path(job_id)?)?;
-        let qasm = read_optional_bytes(&self.compiled_qasm_path(job_id)?)?;
+        let qasm_path = self.compiled_qasm_path(job_id)?;
+        let report_path = self.compiled_report_path(job_id)?;
         let metadata_bytes = read_bytes_not_found(&self.compiled_metadata_path(job_id)?)?;
         let metadata: CompiledMetadata =
             serde_json::from_slice(&metadata_bytes).map_err(to_io_error)?;
+        let qasm = if metadata.qasm_hash.is_some() {
+            Some(read_bytes_not_found(&qasm_path)?)
+        } else {
+            read_optional_bytes(&qasm_path)?
+        };
+        let compile_report_json = if metadata.diagnostics_hash.is_some() {
+            Some(read_bytes_not_found(&report_path)?)
+        } else {
+            read_optional_bytes(&report_path)?
+        };
+
+        if metadata.qasm_hash.is_some() && qasm.is_none() {
+            return Err(CircuitFsError::NotFound { path: qasm_path });
+        }
+        if metadata.diagnostics_hash.is_some() && compile_report_json.is_none() {
+            return Err(CircuitFsError::NotFound { path: report_path });
+        }
+
         Ok(CompiledArtifacts {
             aqo_json,
             qasm,
+            compile_report_json,
             metadata,
         })
     }
@@ -531,6 +647,85 @@ fn read_optional_bytes(path: &Path) -> Result<Option<Vec<u8>>, CircuitFsError> {
         Ok(bytes) => Ok(Some(bytes)),
         Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
         Err(e) => Err(CircuitFsError::Io(e)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn store_compiled_artifacts_v1_is_canonical_and_round_trips() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let fs = CircuitFsLocal::new(tmp.path());
+        let aqo = br#"{"operations":[{"op":"H","q":[0]}],"qubits":1,"version":"1.0.0"}"#;
+        let qasm = b"OPENQASM 3.0;\n";
+        let report = br#"{"status":"ok"}"#;
+        let provenance = CompiledArtifactProvenance {
+            producer_identity: "eigen-compiler".to_string(),
+            contract_version: "1.0.0".to_string(),
+            compiler_version: "1.0.0".to_string(),
+            created_at: "2026-06-06T12:00:00Z".to_string(),
+            lineage: CompiledArtifactLineage {
+                request_id: Some("req-1".to_string()),
+                source_ref: Some("jobs/job-1/input/program.eigen.py".to_string()),
+                source_sha256: Some("sha256:abc".to_string()),
+            },
+        };
+
+        fs.store_compiled_artifacts_v1("job-1", aqo, Some(qasm), Some(report), provenance)
+            .expect("store");
+
+        let loaded = fs.load_compiled_artifacts("job-1").expect("load");
+        assert_eq!(loaded.aqo_json, aqo);
+        assert_eq!(loaded.qasm.as_deref(), Some(qasm));
+        assert_eq!(loaded.compile_report_json.as_deref(), Some(report));
+        assert_eq!(loaded.metadata.version, "1.0.0");
+        assert_eq!(loaded.metadata.contract_version, "1.0.0");
+        assert_eq!(loaded.metadata.producer_identity, "eigen-compiler");
+        assert_eq!(loaded.metadata.lineage.request_id.as_deref(), Some("req-1"));
+    }
+
+    #[test]
+    fn duplicate_compiled_writes_are_rejected() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let fs = CircuitFsLocal::new(tmp.path());
+        let aqo = br#"{"operations":[{"op":"H","q":[0]}],"qubits":1,"version":"1.0.0"}"#;
+        let provenance = CompiledArtifactProvenance {
+            producer_identity: "eigen-compiler".to_string(),
+            contract_version: "1.0.0".to_string(),
+            compiler_version: "1.0.0".to_string(),
+            created_at: "2026-06-06T12:00:00Z".to_string(),
+            lineage: CompiledArtifactLineage::default(),
+        };
+
+        fs.store_compiled_artifacts_v1("job-1", aqo, None, None, provenance.clone())
+            .expect("first write");
+        let err = fs
+            .store_compiled_artifacts_v1("job-1", aqo, None, None, provenance)
+            .expect_err("duplicate write must fail");
+        matches!(err, CircuitFsError::AlreadyExists { .. });
+    }
+
+    #[test]
+    fn missing_sidecar_reference_is_reported() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let fs = CircuitFsLocal::new(tmp.path());
+        let aqo = br#"{"operations":[{"op":"H","q":[0]}],"qubits":1,"version":"1.0.0"}"#;
+        let qasm = b"OPENQASM 3.0;\n";
+        let provenance = CompiledArtifactProvenance {
+            producer_identity: "eigen-compiler".to_string(),
+            contract_version: "1.0.0".to_string(),
+            compiler_version: "1.0.0".to_string(),
+            created_at: "2026-06-06T12:00:00Z".to_string(),
+            lineage: CompiledArtifactLineage::default(),
+        };
+
+        fs.store_compiled_artifacts_v1("job-1", aqo, Some(qasm), Some(br#"{"status":"ok"}"#), provenance)
+            .expect("store");
+        std::fs::remove_file(fs.compiled_qasm_path("job-1").expect("path")).expect("remove qasm");
+        let err = fs.load_compiled_artifacts("job-1").expect_err("load must fail");
+        matches!(err, CircuitFsError::NotFound { .. });
     }
 }
 


### PR DESCRIPTION
## Summary

Implemented the compiler-to-QFS persistence boundary as a v1.0 contract surface. The QFS compiled artifact layout now explicitly covers canonical compiled artifact names, immutable writes, lineage metadata, integrity hashes, and optional diagnostics sidecars. The compiler architecture and Wave 3 governance docs were aligned to treat sidecars as advisory and AQO as the authoritative artifact.

## Validation

- [ ] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: Compiler contract, QFS, compiled artifact layout, migration docs
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft
### Added
- Canonical QFS compiled artifact metadata with lineage and integrity data.
- Immutable compiled artifact writes with duplicate-write rejection.
- Optional compile report sidecar handling.

### Changed
- Compiler persistence is now described as a QFS boundary rather than an ad-hoc local path.
- Sidecar artifacts are documented as advisory, while AQO remains authoritative.

### Fixed
- Removed MVP-era ambiguity around compiled metadata versioning and sidecar handling.
### Fixed
- 
```