### PR TITLE
Inventory and plan synchronization for Wave 3 concrete mappings

### DIFF
--- a/docs/development/product-1.0-contract-alignment-plan.md
+++ b/docs/development/product-1.0-contract-alignment-plan.md
@@ -273,6 +273,15 @@ Product `1.0.0` is ready only when all of the following gates pass:
 - AQO validation occurs before persistence.
 - Canonical errors are returned for structural and semantic AQO violations.
 
+#### Concrete implementation artifacts
+
+The concrete Wave 3 mappings are captured in the inventory and closure package:
+
+- **Compiler safety / request shaping:** `src/services/eigen-compiler/tests/test_conformance_suite.py`, `proto/eigen/internal/v1/compilation_service.proto`
+- **AQO canonicalization:** `docs/reference/formats/aqo.md`, `src/services/eigen-compiler/tests/test_conformance_suite.py`
+- **QFS handoff:** `docs/reference/formats/qfs-layout.md`, `src/rust/crates/qfs/src/local_circuit_fs.rs`, `src/rust/crates/qfs/tests/`
+- **Wave 3 closure docs:** `docs/development/wave-3/product-1.0-wave-3-compatibility-report.md`, `docs/development/wave-3/product-1.0-wave-3-exit-evidence-bundle.md`, `docs/development/wave-3/product-1.0-wave-3-release-readiness-checklist.md`, `docs/development/wave-3/product-1.0-wave-3-rfc-adr-gap-analysis.md`
+
 ---
 
 ### Wave 4 — QFS data fabric maturity

--- a/docs/development/product-1.0-contract-inventory.md
+++ b/docs/development/product-1.0-contract-inventory.md
@@ -1,6 +1,6 @@
 # Product 1.0 Contract Inventory
 
-**Status:** Wave 2-aligned inventory with concrete Kernel/QRTX slice mappings
+**Status:** Wave 3-aligned inventory with concrete Kernel/QRTX, compiler, and QFS slice mappings
 **Parent plan:** `docs/development/product-1.0-contract-alignment-plan.md`
 **Version policy:** `docs/development/product-1.0-version-policy.md`
 **Machine-readable manifest:** `contracts/product-1.0/manifest.json`
@@ -78,6 +78,14 @@ Implementation status values are `documented`, `partial`, `planned`, and `implem
 - **Runtime implementation:** `src/services/eigen-compiler`
 - **Coverage:** internal request validation, forbidden construct rejection, unsupported target rejection, missing source-reference handling
 - **Conformance evidence:** parser/validator fixtures and canonical error tests
+
+### 4.4 Wave 3 documentation sync artifacts
+
+- **Compatibility report:** `docs/development/wave-3/product-1.0-wave-3-compatibility-report.md`
+- **Exit evidence:** `docs/development/wave-3/product-1.0-wave-3-exit-evidence-bundle.md`
+- **Release readiness:** `docs/development/wave-3/product-1.0-wave-3-release-readiness-checklist.md`
+- **Governance review:** `docs/development/wave-3/product-1.0-wave-3-rfc-adr-gap-analysis.md`
+- **Coverage:** closure-level mapping for W3-06/W3-07/W3-08, with the parent plan, inventory, evidence bundle, and handoff notes synchronized to the compiler/AQO/QFS slices
 
 ## 5. Wave 2 concrete implementation slices
 


### PR DESCRIPTION
## Summary

Wave 3 documentation sync is aligned to the concrete compiler, AQO, and QFS mappings. The parent plan now points at the closure artifact set, and the inventory records the Wave 3 documentation-sync artifacts alongside the concrete implementation slices.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: PATCH
- **Affected Interfaces**: Compatibility matrix; Inventory; Parent plan; Migration docs
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Wave 3 documentation-sync artifact mapping for closure
- Concrete Wave 3 compiler, AQO, and QFS slice references in the parent plan and inventory

### Changed
- Parent plan now includes explicit Wave 3 concrete implementation artifacts
- Inventory now records Wave 3 closure documentation artifacts alongside the concrete slice mappings

### Fixed
- Stale documentation ambiguity around Wave 3 concrete mappings and closure references