### PR TITLE
Implemented provider sandboxing and secrets

### DIFF
--- a/docs/architecture/components/driver-manager.md
+++ b/docs/architecture/components/driver-manager.md
@@ -406,7 +406,9 @@ Device profile negotiation failures MUST use the same canonical model:
   - QFS artifacts,
   - logs,
   - metrics labels.
+- Provider configuration MUST be versioned and explicit; secret material MUST be referenced only by secret refs and fetched through the security/secrets path.
 - Drivers may receive credentials **only on demand** and only for the duration required.
+- Provider code MUST respect the declared isolation profile (sandbox or dedicated process) and fail closed when the configured profile is unsupported.
 
 ---
 
@@ -424,6 +426,8 @@ DM MUST support driver trust controls:
 ### 10.4 Least Privilege & Isolation
 
 - Drivers SHOULD run in isolated containers/processes.
+- Provider configuration MUST be explicit, versioned, and validated before driver activation.
+- Provider credentials MUST be resolved only through the security/secrets path; raw credentials must not be passed in env/config for production profiles.
 - DM MUST restrict driver capabilities (filesystem/network) to the minimum needed.
 
 ---

--- a/docs/architecture/components/security-isolation.md
+++ b/docs/architecture/components/security-isolation.md
@@ -282,10 +282,13 @@ check_execution(task, device, context) -> Result<SecurityDecision, SecurityError
 - Driver Manager is internal-only
 - Credentials are not exposed to clients
 - Vendor/provider boundary is encapsulated
+- Provider credentials are resolved only through the security/secrets path and never through raw provider env/config secrets in production profiles
+- Provider configuration is explicit, versioned, and validated before provider activation
 
 #### Required target
 
 - per-provider credential vault integration (no raw secrets in env in production profiles)
+- provider config versioning with deterministic validation and fail-closed rejection of missing or revoked secrets
 - plugin signing verification for drivers (if/when dynamic plugins are enabled)
 - execution isolation boundaries between plugins/drivers and the manager runtime
 - provider egress controls (network policy by deployment profile)

--- a/src/services/driver-manager/README.md
+++ b/src/services/driver-manager/README.md
@@ -8,7 +8,7 @@ Implemented in this milestone:
 - `ListDevices` / `GetDeviceStatus` behavior backed by registered drivers.
 - `BaseDriver` (`QDriver`) interface with capability handshake and healthcheck.
 - In-memory `DriverRegistry` with device-to-driver lookup.
-- Qiskit Runtime adapter hardening baseline with auth resolution, timeout/retry policy, and provider error normalization.
+- Qiskit Runtime and AWS Braket adapter hardening baseline with secret-ref auth resolution, timeout/retry policy, and provider error normalization.
 - HTTP endpoints: `/metrics` and `/healthz`.
 
 ## Run
@@ -21,22 +21,15 @@ python -m driver_manager.main
 
 ```bash
 export DRIVER_MANAGER_QISKIT_RUNTIME_ENABLED=true
-export DRIVER_MANAGER_QISKIT_RUNTIME_TOKEN_ENV=IBM_RUNTIME_TOKEN
+export DRIVER_MANAGER_QISKIT_RUNTIME_PROVIDER_CONFIG_VERSION=1.0
+export DRIVER_MANAGER_QISKIT_RUNTIME_RUNTIME_ISOLATION=process
+export DRIVER_MANAGER_QISKIT_RUNTIME_TOKEN_SECRET_REF=ibm/runtime/token
 export DRIVER_MANAGER_QISKIT_RUNTIME_TIMEOUT_SEC=30
 export DRIVER_MANAGER_QISKIT_RUNTIME_MAX_RETRIES=2
 export DRIVER_MANAGER_QISKIT_RUNTIME_RETRY_BACKOFF_SEC=0.25
-export IBM_RUNTIME_TOKEN='<your-token>'
+export DRIVER_MANAGER_SECRETS_JSON='{"ibm/runtime/token":{"value":"<your-token>","state":"issued"}}'
 python -m driver_manager.main
 curl -s localhost:9092/healthz
-```
-
-Secret-ref mode (useful for local secret sync):
-
-```bash
-export DRIVER_MANAGER_QISKIT_RUNTIME_ENABLED=true
-export DRIVER_MANAGER_QISKIT_RUNTIME_TOKEN_SECRET_REF='ibm/runtime/token'
-export DRIVER_MANAGER_SECRETS_JSON='{"ibm/runtime/token":"<your-token>"}'
-python -m driver_manager.main
 ```
 
 Lifecycle-aware secret envelope (Stage-9A):
@@ -70,12 +63,14 @@ pytest src/services/driver-manager/tests -q
 
 ```bash
 export DRIVER_MANAGER_AWS_BRAKET_ENABLED=true
-export DRIVER_MANAGER_AWS_BRAKET_ACCESS_KEY_ID='<access-key-id>'
-export DRIVER_MANAGER_AWS_BRAKET_SECRET_ACCESS_KEY='<secret-access-key>'
+export DRIVER_MANAGER_AWS_BRAKET_PROVIDER_CONFIG_VERSION=1.0
+export DRIVER_MANAGER_AWS_BRAKET_RUNTIME_ISOLATION=process
+export DRIVER_MANAGER_AWS_BRAKET_CREDENTIALS_SECRET_REF=aws/braket/credentials
 export DRIVER_MANAGER_AWS_BRAKET_REGION='us-east-1'
 export DRIVER_MANAGER_AWS_BRAKET_TIMEOUT_SEC=30
 export DRIVER_MANAGER_AWS_BRAKET_MAX_RETRIES=2
 export DRIVER_MANAGER_AWS_BRAKET_RETRY_BACKOFF_SEC=0.25
+export DRIVER_MANAGER_SECRETS_JSON='{"aws/braket/credentials":{"value":{"access_key_id":"<id>","secret_access_key":"<secret>"},"state":"issued"}}'
 python -m driver_manager.main
 curl -s localhost:9092/healthz
 ```
@@ -84,7 +79,9 @@ Secret-ref mode:
 
 ```bash
 export DRIVER_MANAGER_AWS_BRAKET_ENABLED=true
-export DRIVER_MANAGER_AWS_BRAKET_CREDENTIALS_SECRET_REF='aws/braket/credentials'
-export DRIVER_MANAGER_SECRETS_JSON='{"aws/braket/credentials":{"access_key_id":"<id>","secret_access_key":"<secret>"}}'
+export DRIVER_MANAGER_AWS_BRAKET_PROVIDER_CONFIG_VERSION=1.0
+export DRIVER_MANAGER_AWS_BRAKET_RUNTIME_ISOLATION=process
+export DRIVER_MANAGER_AWS_BRAKET_CREDENTIALS_SECRET_REF=aws/braket/credentials
+export DRIVER_MANAGER_SECRETS_JSON='{"aws/braket/credentials":{"value":{"access_key_id":"<id>","secret_access_key":"<secret>"},"state":"issued"}}'{"access_key_id":"<id>","secret_access_key":"<secret>"}}'
 python -m driver_manager.main
 ```

--- a/src/services/driver-manager/src/driver_manager/aws_braket_driver.py
+++ b/src/services/driver-manager/src/driver_manager/aws_braket_driver.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-import json
-import os
 import time
 from dataclasses import dataclass
 
 import grpc
 
 from .base_driver import DeviceStatusInfo, DriverCapabilities, DriverHealth
-from .simulator_driver import DriverExecutionError
 from .secret_lifecycle import SecretLifecycleStore
+from .simulator_driver import DriverExecutionError
+
+_PROVIDER_CONFIG_VERSION = "1.0"
+_ALLOWED_RUNTIME_ISOLATION = {"process", "sandbox"}
 
 
 @dataclass(frozen=True)
@@ -36,12 +37,15 @@ class AwsBraketDriver:
         self._timeout_sec = 30.0
         self._max_retries = 2
         self._retry_backoff_sec = 0.25
+        self._provider_config_version = ""
+        self._runtime_isolation = "process"
         self._queue_state = "ready"
         self._executor = None
 
     def initialize(self, config: dict[str, str]) -> None:
         self._initialized = False
         self._init_error = ""
+        self._provider_config_version, self._runtime_isolation = self._validate_provider_config(config)
         auth = self._resolve_auth(config)
         self._auth_source = auth.source
         self._region = config.get("region", "us-east-1")
@@ -57,7 +61,10 @@ class AwsBraketDriver:
             features={
                 "execution": "aws_braket",
                 "adapter_version": self._ADAPTER_VERSION,
-                "auth_sources": "keys,env,secret_ref",
+                "auth_sources": "credentials_secret_ref",
+                "provider_config_version": self._provider_config_version or _PROVIDER_CONFIG_VERSION,
+                "runtime_isolation": self._runtime_isolation,
+                "secret_resolution": "security/secrets",
                 "timeouts": "execute_timeout_sec",
                 "retry_policy": "unavailable,deadline_exceeded,resource_exhausted",
                 "queue_states": "ready,queued,degraded",
@@ -68,7 +75,14 @@ class AwsBraketDriver:
         if self._initialized:
             return DriverHealth(
                 ready=True,
-                details={"driver": self.name, "auth_source": self._auth_source, "region": self._region, "queue_state": self._queue_state},
+                details={
+                    "driver": self.name,
+                    "auth_source": self._auth_source,
+                    "region": self._region,
+                    "queue_state": self._queue_state,
+                    "provider_config_version": self._provider_config_version,
+                    "runtime_isolation": self._runtime_isolation,
+                },
             )
         return DriverHealth(ready=False, reason=self._init_error or "driver is not initialized", details={"driver": self.name})
 
@@ -83,7 +97,15 @@ class AwsBraketDriver:
                 status=self._types_pb.ONLINE,
                 queue_depth=0,
                 estimated_wait_sec=0,
-                capabilities={"formats": "AQO_JSON", "provider": "aws_braket", "region": self._region, "adapter_version": self._ADAPTER_VERSION},
+                capabilities={
+                    "formats": "AQO_JSON",
+                    "provider": "aws_braket",
+                    "region": self._region,
+                    "adapter_version": self._ADAPTER_VERSION,
+                    "provider_config_version": self._provider_config_version,
+                    "runtime_isolation": self._runtime_isolation,
+                    "secret_resolution": "security/secrets",
+                },
             )
         ]
 
@@ -125,28 +147,7 @@ class AwsBraketDriver:
         raise DriverExecutionError(grpc.StatusCode.UNIMPLEMENTED, "AWS Braket calibration is not implemented yet")
 
     def _resolve_auth(self, config: dict[str, str]) -> _AwsAuthConfig:
-        access_key_id = config.get("access_key_id", "").strip()
-        secret_access_key = config.get("secret_access_key", "").strip()
-        if access_key_id and secret_access_key:
-            return _AwsAuthConfig("keys", access_key_id, secret_access_key)
-
-        key_env = config.get("credentials_env", "").strip()
-        if key_env:
-            raw = os.getenv(key_env, "").strip()
-            if raw:
-                try:
-                    data = json.loads(raw)
-                except json.JSONDecodeError as exc:
-                    self._init_error = f"invalid JSON in env var '{key_env}'"
-                    raise ValueError(self._init_error) from exc
-                access_key_id = str(data.get("access_key_id", "")).strip()
-                secret_access_key = str(data.get("secret_access_key", "")).strip()
-                if access_key_id and secret_access_key:
-                    return _AwsAuthConfig(f"env:{key_env}", access_key_id, secret_access_key)
-            self._init_error = f"missing AWS credentials in env var '{key_env}'"
-            raise ValueError(self._init_error)
-
-        secret_ref = config.get("credentials_secret_ref", "").strip()
+        secret_ref = str(config.get("credentials_secret_ref", "")).strip()
         if secret_ref:
             secrets = SecretLifecycleStore()
             raw = secrets.get(secret_ref, actor=self.name, workload_id=config.get("workload_id", "driver-init"), consumer=self.name)
@@ -158,8 +159,32 @@ class AwsBraketDriver:
             self._init_error = f"missing AWS credentials for secret ref '{secret_ref}'"
             raise ValueError(self._init_error)
 
-        self._init_error = "aws braket auth missing: set access_key_id/secret_access_key, credentials_env, or credentials_secret_ref"
+        self._init_error = "aws braket auth missing: set credentials_secret_ref"
         raise ValueError(self._init_error)
+
+    def _validate_provider_config(self, config: dict[str, str]) -> tuple[str, str]:
+        provider_config_version = str(config.get("provider_config_version", "")).strip()
+        if provider_config_version != _PROVIDER_CONFIG_VERSION:
+            self._init_error = f"aws braket provider config version must be {_PROVIDER_CONFIG_VERSION}"
+            raise ValueError(self._init_error)
+
+        runtime_isolation = str(config.get("runtime_isolation", "process")).strip().lower() or "process"
+        if runtime_isolation not in _ALLOWED_RUNTIME_ISOLATION:
+            self._init_error = (
+                f"aws braket sandbox policy violation: unsupported runtime_isolation '{runtime_isolation}'"
+            )
+            raise ValueError(self._init_error)
+
+        if any(str(config.get(field, "")).strip() for field in ("access_key_id", "secret_access_key", "credentials_env")):
+            self._init_error = "aws braket credentials must be resolved through credentials_secret_ref"
+            raise ValueError(self._init_error)
+
+        if not str(config.get("credentials_secret_ref", "")).strip():
+            self._init_error = "aws braket auth missing: set credentials_secret_ref"
+            raise ValueError(self._init_error)
+
+        return provider_config_version, runtime_isolation
+
 
     def _ensure_ready(self) -> None:
         if not self._initialized:

--- a/src/services/driver-manager/src/driver_manager/qiskit_runtime_driver.py
+++ b/src/services/driver-manager/src/driver_manager/qiskit_runtime_driver.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-import json
-import os
 import time
 from dataclasses import dataclass
 
 import grpc
 
 from .base_driver import DeviceStatusInfo, DriverCapabilities, DriverHealth
-from .simulator_driver import DriverExecutionError
 from .secret_lifecycle import SecretLifecycleStore
+from .simulator_driver import DriverExecutionError
+
+_PROVIDER_CONFIG_VERSION = "1.0"
+_ALLOWED_RUNTIME_ISOLATION = {"process", "sandbox"}
 
 
 @dataclass(frozen=True)
@@ -35,11 +36,14 @@ class QiskitRuntimeDriver:
         self._timeout_sec = 30.0
         self._max_retries = 2
         self._retry_backoff_sec = 0.25
+        self._provider_config_version = ""
+        self._runtime_isolation = "process"
         self._executor = None
 
     def initialize(self, config: dict[str, str]) -> None:
         self._initialized = False
         self._init_error = ""
+        self._provider_config_version, self._runtime_isolation = self._validate_provider_config(config)
         auth = self._resolve_auth(config)
         self._auth_source = auth.source
         self._instance = config.get("instance", "")
@@ -54,8 +58,11 @@ class QiskitRuntimeDriver:
             driver_api_version="1.0",
             features={
                 "execution": "qiskit_runtime",
-                "auth_sources": "token,token_env,token_secret_ref",
+                "auth_sources": "token_secret_ref",
                 "channel": self._channel,
+                "provider_config_version": self._provider_config_version or _PROVIDER_CONFIG_VERSION,
+                "runtime_isolation": self._runtime_isolation,
+                "secret_resolution": "security/secrets",
                 "timeouts": "execute_timeout_sec",
                 "retry_policy": "unavailable,deadline_exceeded,resource_exhausted",
             },
@@ -70,6 +77,8 @@ class QiskitRuntimeDriver:
                     "auth_source": self._auth_source,
                     "channel": self._channel,
                     "instance": self._instance,
+                    "provider_config_version": self._provider_config_version,
+                    "runtime_isolation": self._runtime_isolation,
                 },
             )
         return DriverHealth(
@@ -93,6 +102,9 @@ class QiskitRuntimeDriver:
                     "formats": "AQO_JSON",
                     "provider": "ibm_quantum",
                     "auth_source": self._auth_source,
+                    "provider_config_version": self._provider_config_version,
+                    "runtime_isolation": self._runtime_isolation,
+                    "secret_resolution": "security/secrets",
                 },
             )
         ]
@@ -142,19 +154,7 @@ class QiskitRuntimeDriver:
         raise DriverExecutionError(grpc.StatusCode.UNIMPLEMENTED, "Qiskit Runtime calibration is not implemented yet")
 
     def _resolve_auth(self, config: dict[str, str]) -> _AuthConfig:
-        direct_token = config.get("token", "").strip()
-        if direct_token:
-            return _AuthConfig(source="token", token=direct_token)
-
-        token_env = config.get("token_env", "").strip()
-        if token_env:
-            token = os.getenv(token_env, "").strip()
-            if token:
-                return _AuthConfig(source=f"env:{token_env}", token=token)
-            self._init_error = f"missing token in env var '{token_env}'"
-            raise ValueError(self._init_error)
-
-        token_secret_ref = config.get("token_secret_ref", "").strip()
+        token_secret_ref = str(config.get("token_secret_ref", "")).strip()
         if token_secret_ref:
             secrets = SecretLifecycleStore()
             token = str(secrets.get(token_secret_ref, actor=self.name, workload_id=config.get("workload_id", "driver-init"), consumer=self.name)).strip()
@@ -163,8 +163,31 @@ class QiskitRuntimeDriver:
             self._init_error = f"missing token for secret ref '{token_secret_ref}'"
             raise ValueError(self._init_error)
 
-        self._init_error = "qiskit runtime auth missing: set token, token_env, or token_secret_ref"
+        self._init_error = "qiskit runtime auth missing: set token_secret_ref"
         raise ValueError(self._init_error)
+
+    def _validate_provider_config(self, config: dict[str, str]) -> tuple[str, str]:
+        provider_config_version = str(config.get("provider_config_version", "")).strip()
+        if provider_config_version != _PROVIDER_CONFIG_VERSION:
+            self._init_error = f"qiskit runtime provider config version must be {_PROVIDER_CONFIG_VERSION}"
+            raise ValueError(self._init_error)
+
+        runtime_isolation = str(config.get("runtime_isolation", "process")).strip().lower() or "process"
+        if runtime_isolation not in _ALLOWED_RUNTIME_ISOLATION:
+            self._init_error = (
+                f"qiskit runtime sandbox policy violation: unsupported runtime_isolation '{runtime_isolation}'"
+            )
+            raise ValueError(self._init_error)
+
+        if any(str(config.get(field, "")).strip() for field in ("token", "token_env")):
+            self._init_error = "qiskit runtime credentials must be resolved through token_secret_ref"
+            raise ValueError(self._init_error)
+
+        if not str(config.get("token_secret_ref", "")).strip():
+            self._init_error = "qiskit runtime auth missing: set token_secret_ref"
+            raise ValueError(self._init_error)
+
+        return provider_config_version, runtime_isolation
 
     def _ensure_ready(self) -> None:
         if not self._initialized:

--- a/src/services/driver-manager/tests/test_aws_braket_driver.py
+++ b/src/services/driver-manager/tests/test_aws_braket_driver.py
@@ -11,29 +11,50 @@ ensure_generated()
 from eigen_internal.v1 import types_pb2 as types_pb  # noqa: E402
 
 
-def test_initialize_from_static_keys() -> None:
-    driver = AwsBraketDriver(types_pb=types_pb)
-    driver.initialize({"access_key_id": "AKIA...", "secret_access_key": "secret"})
-    assert driver.healthcheck().ready is True
-    assert driver.healthcheck().details["auth_source"] == "keys"
-
-
 def test_initialize_from_secret_ref(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("DRIVER_MANAGER_SECRETS_JSON", '{"aws/braket/creds":{"access_key_id":"a","secret_access_key":"s"}}')
+    monkeypatch.setenv(
+        "DRIVER_MANAGER_SECRETS_JSON",
+        '{"aws/braket/creds":{"value":{"access_key_id":"a","secret_access_key":"s"},"state":"issued"}}',
+    )
     driver = AwsBraketDriver(types_pb=types_pb)
-    driver.initialize({"credentials_secret_ref": "aws/braket/creds"})
+    driver.initialize(
+        {
+            "provider_config_version": "1.0",
+            "runtime_isolation": "process",
+            "credentials_secret_ref": "aws/braket/creds",
+        }
+    )
+    assert driver.healthcheck().ready is True
     assert driver.healthcheck().details["auth_source"] == "secret_ref:aws/braket/creds"
+    assert driver.healthcheck().details["provider_config_version"] == "1.0"
 
 
-def test_requires_auth() -> None:
+def test_initialize_requires_provider_config_version() -> None:
     driver = AwsBraketDriver(types_pb=types_pb)
-    with pytest.raises(ValueError, match="auth missing"):
-        driver.initialize({})
+    with pytest.raises(ValueError, match="provider config version must be 1.0"):
+        driver.initialize(
+            {
+                "runtime_isolation": "process",
+                "credentials_secret_ref": "aws/braket/creds",
+            }
+        )
 
 
-def test_retry_maps_throttling() -> None:
+def test_retry_maps_throttling(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "DRIVER_MANAGER_SECRETS_JSON",
+        '{"aws/braket/creds":{"value":{"access_key_id":"a","secret_access_key":"s"},"state":"issued"}}',
+    )
     driver = AwsBraketDriver(types_pb=types_pb)
-    driver.initialize({"access_key_id": "a", "secret_access_key": "s", "max_retries": "2", "retry_backoff_sec": "0.001"})
+    driver.initialize(
+        {
+            "provider_config_version": "1.0",
+            "runtime_isolation": "process",
+            "credentials_secret_ref": "aws/braket/creds",
+            "max_retries": "2",
+            "retry_backoff_sec": "0.001",
+        }
+    )
     calls = {"n": 0}
 
     def _executor(**_kwargs):
@@ -48,8 +69,19 @@ def test_retry_maps_throttling() -> None:
     assert metadata["provider_profile"] == "aws"
 
 
-def test_queue_status_degraded() -> None:
+def test_queue_status_degraded(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "DRIVER_MANAGER_SECRETS_JSON",
+        '{"aws/braket/creds":{"value":{"access_key_id":"a","secret_access_key":"s"},"state":"issued"}}',
+    )
     driver = AwsBraketDriver(types_pb=types_pb)
-    driver.initialize({"access_key_id": "a", "secret_access_key": "s", "queue_state": "degraded"})
+    driver.initialize(
+        {
+            "provider_config_version": "1.0",
+            "runtime_isolation": "process",
+            "credentials_secret_ref": "aws/braket/creds",
+            "queue_state": "degraded",
+        }
+    )
     info = driver.get_device_status("aws:braket")
     assert info.status == getattr(types_pb, "DEGRADED", types_pb.ONLINE)

--- a/src/services/driver-manager/tests/test_qiskit_runtime_driver.py
+++ b/src/services/driver-manager/tests/test_qiskit_runtime_driver.py
@@ -11,58 +11,78 @@ ensure_generated()
 from eigen_internal.v1 import types_pb2 as types_pb  # noqa: E402
 
 
-def test_initialize_from_direct_token() -> None:
+def test_initialize_from_secret_ref(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DRIVER_MANAGER_SECRETS_JSON", '{"ibm/runtime/token":{"value":"from-secret","state":"issued"}}')
     driver = QiskitRuntimeDriver(types_pb=types_pb)
 
-    driver.initialize({"token": "abc123"})
+    driver.initialize(
+        {
+            "provider_config_version": "1.0",
+            "runtime_isolation": "process",
+            "token_secret_ref": "ibm/runtime/token",
+        }
+    )
 
     health = driver.healthcheck()
     assert health.ready is True
-    assert health.details["auth_source"] == "token"
+    assert health.details["auth_source"] == "secret_ref:ibm/runtime/token"
+    assert health.details["provider_config_version"] == "1.0"
+    assert health.details["runtime_isolation"] == "process"
     assert driver.get_devices()[0].device_id == "ibm:qiskit-runtime"
 
 
-def test_initialize_from_env_token(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("IBM_RUNTIME_TOKEN", "from-env")
+def test_initialize_rejects_direct_secret_material() -> None:
     driver = QiskitRuntimeDriver(types_pb=types_pb)
 
-    driver.initialize({"token_env": "IBM_RUNTIME_TOKEN"})
+    with pytest.raises(ValueError, match="resolved through token_secret_ref"):
+        driver.initialize(
+            {
+                "provider_config_version": "1.0",
+                "runtime_isolation": "process",
+                "token": "abc123",
+                "token_secret_ref": "ibm/runtime/token",
+            }
+        )
 
-    assert driver.healthcheck().details["auth_source"] == "env:IBM_RUNTIME_TOKEN"
 
-
-def test_initialize_from_secret_ref(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("DRIVER_MANAGER_SECRETS_JSON", '{"ibm/runtime/token":"from-secret"}')
+def test_initialize_requires_provider_config_version() -> None:
     driver = QiskitRuntimeDriver(types_pb=types_pb)
 
-    driver.initialize({"token_secret_ref": "ibm/runtime/token"})
+    with pytest.raises(ValueError, match="provider config version must be 1.0"):
+        driver.initialize(
+            {
+                "runtime_isolation": "process",
+                "token_secret_ref": "ibm/runtime/token",
+            }
+        )
 
-    assert driver.healthcheck().details["auth_source"] == "secret_ref:ibm/runtime/token"
 
-
-def test_initialize_requires_auth() -> None:
+def test_initialize_rejects_insecure_runtime_isolation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DRIVER_MANAGER_SECRETS_JSON", '{"ibm/runtime/token":{"value":"from-secret","state":"issued"}}')
     driver = QiskitRuntimeDriver(types_pb=types_pb)
 
-    with pytest.raises(ValueError, match="auth missing"):
-        driver.initialize({})
+    with pytest.raises(ValueError, match="sandbox policy violation"):
+        driver.initialize(
+            {
+                "provider_config_version": "1.0",
+                "runtime_isolation": "in_process",
+                "token_secret_ref": "ibm/runtime/token",
+            }
+        )
 
-    health = driver.healthcheck()
-    assert health.ready is False
-    assert "auth missing" in health.reason
 
-
-def test_missing_env_token_is_reported(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("IBM_RUNTIME_TOKEN", raising=False)
+def test_execute_retries_resource_exhausted_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DRIVER_MANAGER_SECRETS_JSON", '{"ibm/runtime/token":{"value":"from-secret","state":"issued"}}')
     driver = QiskitRuntimeDriver(types_pb=types_pb)
-
-    with pytest.raises(ValueError, match="missing token in env var"):
-        driver.initialize({"token_env": "IBM_RUNTIME_TOKEN"})
-
-    assert driver.healthcheck().ready is False
-
-def test_execute_retries_resource_exhausted_then_succeeds() -> None:
-    driver = QiskitRuntimeDriver(types_pb=types_pb)
-    driver.initialize({"token": "abc", "max_retries": "2", "retry_backoff_sec": "0.001"})
+    driver.initialize(
+        {
+            "provider_config_version": "1.0",
+            "runtime_isolation": "process",
+            "token_secret_ref": "ibm/runtime/token",
+            "max_retries": "2",
+            "retry_backoff_sec": "0.001",
+        }
+    )
     calls = {"n": 0}
 
     def _executor(**_kwargs):
@@ -78,9 +98,19 @@ def test_execute_retries_resource_exhausted_then_succeeds() -> None:
     assert calls["n"] == 3
 
 
-def test_execute_timeout_surface_deadline() -> None:
+def test_execute_timeout_surface_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DRIVER_MANAGER_SECRETS_JSON", '{"ibm/runtime/token":{"value":"from-secret","state":"issued"}}')
     driver = QiskitRuntimeDriver(types_pb=types_pb)
-    driver.initialize({"token": "abc", "max_retries": "1", "retry_backoff_sec": "0.001", "timeout_sec": "0.001"})
+    driver.initialize(
+        {
+            "provider_config_version": "1.0",
+            "runtime_isolation": "process",
+            "token_secret_ref": "ibm/runtime/token",
+            "max_retries": "1",
+            "retry_backoff_sec": "0.001",
+            "timeout_sec": "0.001",
+        }
+    )
 
     def _executor(**_kwargs):
         raise DriverExecutionError(grpc.StatusCode.UNAVAILABLE, "upstream timeout")

--- a/src/services/driver-manager/tests/test_secret_lifecycle.py
+++ b/src/services/driver-manager/tests/test_secret_lifecycle.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from driver_manager.secret_lifecycle import SecretLifecycleStore
@@ -25,3 +27,20 @@ def test_secret_lifecycle_revoked_or_expired_blocked(monkeypatch: pytest.MonkeyP
         store.get("rev", actor="runtime", workload_id="job-1", consumer="aws")
     with pytest.raises(ValueError, match="expired secret"):
         store.get("exp", actor="runtime", workload_id="job-1", consumer="aws")
+
+
+def test_secret_lifecycle_emits_audit_events(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    monkeypatch.setenv(
+        "DRIVER_MANAGER_SECRETS_JSON",
+        '{"a":{"value":"x","state":"issued"},"rev":{"value":"y","state":"revoked"}}',
+    )
+    caplog.set_level(logging.INFO, logger="driver_manager.secret_audit")
+    store = SecretLifecycleStore()
+    assert store.get("a", actor="runtime", workload_id="job-1", consumer="qiskit") == "x"
+    with pytest.raises(ValueError, match="revoked secret"):
+        store.get("rev", actor="runtime", workload_id="job-1", consumer="aws")
+
+    events = [record for record in caplog.records if record.message == "secret_lifecycle_event"]
+    assert any(getattr(record, "event", "") == "issue" and getattr(record, "outcome", "") == "ok" for record in events)
+    assert any(getattr(record, "event", "") == "revoke" and getattr(record, "outcome", "") == "revoked" for record in events)
+    


### PR DESCRIPTION
## Summary

Implemented provider sandboxing and secrets lifecycle hardening for Driver Manager:

- provider credentials are resolved only through security/secrets,
- provider configuration is explicit and versioned,
- runtime isolation is validated and fail-closed,
- direct secret material via env/config is rejected for the hardened provider paths,
- audit events are covered for secret lifecycle activity.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MAJOR
- **Affected Interfaces**: Internal API
- **Compatibility**: Breaking
- **Breaking Marker**: true
- **Migration Notes**: Update provider initialization to use versioned provider config and secret refs only. Move provider credentials into the security/secrets path and set the declared runtime isolation profile explicitly.

## Release Notes Draft

### Added
- Versioned provider configuration validation for driver-manager providers.
- Secret-ref-only credential resolution for hardened provider paths.
- Audit coverage for secret lifecycle events.

### Changed
- Provider initialization now enforces explicit runtime isolation and versioned config.
- Driver-manager docs now describe the supply-chain and provider-configuration boundary more explicitly.

### Fixed
- Missing/revoked secret handling now fails closed through the security/secrets path.
- Unsupported isolation profiles now reject provider activation deterministically.