### PR TITLE
Implemented by aligning QFS artifact

### DIFF
--- a/docs/architecture/components/compiler.md
+++ b/docs/architecture/components/compiler.md
@@ -499,7 +499,7 @@ graph LR
 **Normative notes:**
 
 - Only **Kernel/QRTX** (or internal orchestrator) calls the compiler; there is **no public compiler API**.
-- QFS is the **canonical persistence** for compilation artifacts and metadata.
+- QFS is the **canonical persistence** for compilation artifacts, metadata, and job-scoped release evidence bundles.
 
 ---
 

--- a/docs/architecture/components/qfs.md
+++ b/docs/architecture/components/qfs.md
@@ -205,7 +205,7 @@ Checkpoint restore behavior MUST remain deterministic across:
 - distributed replay,
 - multi-device merge recovery flows.
 
-The current L3 implementation now enforces immutable writes for `compiled/` and `results/` artifacts, persists lineage and retention metadata, and verifies digests on read for compiled and result bundles.
+The current L3 implementation now enforces immutable writes for `compiled/`, `results/`, and `meta/release_evidence/` artifacts, persists lineage and retention metadata, and verifies digests on read for compiled, result, and release-evidence bundles.
 
 ---
 

--- a/docs/reference/formats/qfs-layout.md
+++ b/docs/reference/formats/qfs-layout.md
@@ -99,7 +99,6 @@ Invalid `job_id` values MUST be rejected before filesystem access.
 │   ├── circuit.aqo.pb
 │   ├── circuit.qasm
 │   ├── compile_report.json
-│   ├── compile_report.json
 │   └── metadata.json
 ├── execution/
 │   ├── execution_plan.json
@@ -128,7 +127,11 @@ Invalid `job_id` values MUST be rejected before filesystem access.
 │   ├── job.json
 │   ├── retention.json
 │   ├── lineage.json
-│   └── tags.json
+│   ├── tags.json
+│   └── release_evidence/
+│       ├── bundle.json
+│       ├── manifest.json
+│       └── provenance.json
 ├── traces/
 │   ├── spans.json
 │   └── events.json
@@ -313,7 +316,7 @@ Logs are optional unless explicitly required by deployment policy.
 
 ### 6.7 `meta/`
 
-Contains metadata and indexing structures.
+Contains metadata, indexing structures, and release evidence.
 
 #### Files
 
@@ -323,6 +326,14 @@ Contains metadata and indexing structures.
 | `retention.json` | Retention policy state |
 | `lineage.json` | Parent/child relationships |
 | `tags.json` | Search/index metadata |
+| `release_evidence/bundle.json` | Release evidence bundle |
+| `release_evidence/manifest.json` | Release evidence artifact manifest |
+| `release_evidence/provenance.json` | Provenance report tying compiler and optimizer runs |
+
+#### Notes
+
+- Release evidence artifacts MUST be written with replay-safe job-scoped references.
+- Release evidence bundles are immutable within a job scope and MUST be treated as release evidence, not mutable runtime state.
 
 ---
 
@@ -462,7 +473,24 @@ Supplementary artifacts:
 ```text
 results/result.json
 results/manifest.json
+meta/release_evidence/bundle.json
+meta/release_evidence/manifest.json
+meta/release_evidence/provenance.json
 ```
+
+---
+
+### 9.5 Release Evidence Persistence Phase
+
+Writes:
+
+```text
+meta/release_evidence/bundle.json
+meta/release_evidence/manifest.json
+meta/release_evidence/provenance.json
+```
+
+Release evidence is emitted from the job persistence path after compiler and optimizer runs complete. The evidence bundle MUST remain immutable and job-scoped.
 
 ---
 

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -164,6 +164,7 @@ dependencies = [
  "security-module",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/src/rust/crates/eigen-kernel/Cargo.toml
+++ b/src/rust/crates/eigen-kernel/Cargo.toml
@@ -32,6 +32,7 @@ serde = { version = "1", features = ["derive"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 serde_json = "1.0.145"
+sha2 = "0.10"
 
 [build-dependencies]
 tonic-prost-build = "0.14.5"

--- a/src/rust/crates/eigen-kernel/src/rpc.rs
+++ b/src/rust/crates/eigen-kernel/src/rpc.rs
@@ -21,8 +21,12 @@ use tokio_stream::iter;
 use tokio_stream::Stream;
 use tonic::{Code, Request, Response, Status};
 use tracing::Instrument;
+use sha2::{Digest, Sha256};
 
-use qfs::CircuitFsLocal;
+use qfs::{
+    CircuitFsLocal, ReleaseEvidenceBundle, ReleaseEvidenceManifest,
+    ReleaseEvidenceProvenanceReport, ResultArtifactDescriptor,
+};
 use resource_manager::{
     SCHEDULER_DECISION_VERSION, SCHEDULING_POLICY_BUNDLE_ID, SCHEDULING_POLICY_BUNDLE_VERSION,
 };
@@ -1392,6 +1396,12 @@ impl FixtureAdapters {
             tokio::time::sleep(self.hold_for).await;
         }
     }
+
+    fn sha256_hex(&self, payload: &[u8]) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(payload);
+        format!("{:x}", hasher.finalize())
+    }
 }
 
 #[tonic::async_trait]
@@ -1434,7 +1444,7 @@ impl OrchestrationAdapters for FixtureAdapters {
             ("message".to_string(), "compile stage completed".to_string()),
             (
                 "compiled_artifact_ref".to_string(),
-                format!("qfs://jobs/{}/artifacts/compiled.aqo", submission.job_id),
+                format!("qfs://jobs/{}/compiled/circuit.aqo.json", submission.job_id),
             ),
             (
                 "compiler_version".to_string(),
@@ -1458,7 +1468,7 @@ impl OrchestrationAdapters for FixtureAdapters {
             ("message".to_string(), "optimization stage completed".to_string()),
             (
                 "optimized_artifact_ref".to_string(),
-                format!("qfs://jobs/{}/artifacts/optimized.aqo", submission.job_id),
+                format!("qfs://jobs/{}/optimizer/optimized_aqo.json", submission.job_id),
             ),
             (
                 "optimizer_version".to_string(),
@@ -1611,6 +1621,95 @@ impl OrchestrationAdapters for FixtureAdapters {
             .qfs
             .store_results_bundle(&submission.job_id, &payload, env!("CARGO_PKG_VERSION"));
 
+        let compile_stage = stage_records.iter().find(|stage| stage.stage_key == "compile");
+        let optimize_stage = stage_records.iter().find(|stage| stage.stage_key == "optimize");
+
+        let compiled_artifact_ref = compile_stage
+            .and_then(|stage| stage.output.get("compiled_artifact_ref"))
+            .cloned()
+            .unwrap_or_else(|| format!("qfs://jobs/{}/compiled/circuit.aqo.json", submission.job_id));
+        let optimized_artifact_ref = optimize_stage
+            .and_then(|stage| stage.output.get("optimized_artifact_ref"))
+            .cloned()
+            .unwrap_or_else(|| format!("qfs://jobs/{}/optimizer/optimized_aqo.json", submission.job_id));
+        let compiler_version = compile_stage
+            .and_then(|stage| stage.output.get("compiler_version"))
+            .cloned()
+            .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+        let optimizer_version = optimize_stage
+            .and_then(|stage| stage.output.get("optimizer_version"))
+            .cloned()
+            .unwrap_or_else(|| "fixture-optimizer/1".to_string());
+        let optimizer_policy = optimize_stage
+            .and_then(|stage| stage.output.get("optimizer_policy"))
+            .cloned()
+            .unwrap_or_else(|| "deterministic".to_string());
+
+        let bundle = ReleaseEvidenceBundle {
+            artifact_version: "1.0.0".to_string(),
+            schema_version: "release_evidence_bundle.v1".to_string(),
+            producer_version: env!("CARGO_PKG_VERSION").to_string(),
+            job_id: submission.job_id.clone(),
+            compiler_contract_version: "1.0.0".to_string(),
+            optimizer_contract_version: "1.0.0".to_string(),
+            request_id: submission.request_id.clone(),
+            trace_id: submission.trace_id.clone(),
+            traceparent: submission.traceparent.clone(),
+            source_sha256: submission.program_hash.clone(),
+            aqo_sha256: submission.fingerprint.clone(),
+            optimized_aqo_sha256: Some(format!(
+                "sha256:{}",
+                self.sha256_hex(optimized_artifact_ref.as_bytes())
+            )),
+            compiled_artifact_ref: compiled_artifact_ref.clone(),
+            optimized_artifact_ref: optimized_artifact_ref.clone(),
+            manifest_ref: format!("qfs://jobs/{}/meta/release_evidence/manifest.json", submission.job_id),
+            provenance_report_ref: format!("qfs://jobs/{}/meta/release_evidence/provenance.json", submission.job_id),
+            created_at_epoch_ms: unix_epoch_ms_u64(),
+        };
+        let bundle_bytes = serde_json::to_vec_pretty(&bundle).unwrap_or_default();
+        let provenance_report = ReleaseEvidenceProvenanceReport {
+            artifact_version: "1.0.0".to_string(),
+            schema_version: "release_evidence_provenance.v1".to_string(),
+            job_id: submission.job_id.clone(),
+            request_id: submission.request_id.clone(),
+            trace_id: submission.trace_id.clone(),
+            traceparent: submission.traceparent.clone(),
+            compiler_stage_id: compile_stage.map(|stage| stage.stage_id.clone()).unwrap_or_default(),
+            optimizer_stage_id: optimize_stage.map(|stage| stage.stage_id.clone()).unwrap_or_default(),
+            compiler_run_id: compile_stage.map(|stage| stage.replay_token.clone()).unwrap_or_default(),
+            optimizer_run_id: optimize_stage.map(|stage| stage.replay_token.clone()).unwrap_or_default(),
+            compiler_artifact_ref: compiled_artifact_ref.clone(),
+            optimized_artifact_ref: optimized_artifact_ref.clone(),
+            compiler_lineage: qfs::CompiledArtifactLineage {
+                request_id: Some(submission.request_id.clone()),
+                source_ref: None,
+                source_sha256: Some(submission.program_hash.clone()),
+            },
+            optimized_aqo_sha256: Some(format!("sha256:{}", self.sha256_hex(bundle_bytes.as_slice()))),
+        };
+        let provenance_bytes = serde_json::to_vec_pretty(&provenance_report).unwrap_or_default();
+        let manifest = ReleaseEvidenceManifest {
+            artifact_version: "1.0.0".to_string(),
+            producer_version: env!("CARGO_PKG_VERSION").to_string(),
+            schema_version: "release_evidence_manifest.v1".to_string(),
+            created_at_epoch_ms: unix_epoch_ms_u64(),
+            retention_policy: "pinned".to_string(),
+            artifacts: vec![
+                ResultArtifactDescriptor {
+                    path: format!("meta/release_evidence/bundle.json"),
+                    content_hash: format!("sha256:{}", self.sha256_hex(&bundle_bytes)),
+                    size_bytes: bundle_bytes.len() as u64,
+                },
+                ResultArtifactDescriptor {
+                    path: format!("meta/release_evidence/provenance.json"),
+                    content_hash: format!("sha256:{}", self.sha256_hex(&provenance_bytes)),
+                    size_bytes: provenance_bytes.len() as u64,
+                },
+            ],
+        };
+        let _ = self.qfs.store_release_evidence_bundle_v1(&submission.job_id, &bundle, &manifest, &provenance_report);
+
         Ok(BTreeMap::from([
             ("message".to_string(), "results persisted to qfs".to_string()),
             (
@@ -1622,9 +1721,24 @@ impl OrchestrationAdapters for FixtureAdapters {
                 format!("qfs://jobs/{}/results/manifest.json", submission.job_id),
             ),
             (
+                "release_evidence_bundle_ref".to_string(),
+                format!("qfs://jobs/{}/meta/release_evidence/bundle.json", submission.job_id),
+            ),
+            (
+                "release_evidence_manifest_ref".to_string(),
+                format!("qfs://jobs/{}/meta/release_evidence/manifest.json", submission.job_id),
+            ),
+            (
+                "release_provenance_ref".to_string(),
+                format!("qfs://jobs/{}/meta/release_evidence/provenance.json", submission.job_id),
+            ),
+            (
                 "artifact_version".to_string(),
                 env!("CARGO_PKG_VERSION").to_string(),
             ),
+            ("optimizer_policy".to_string(), optimizer_policy),
+            ("compiler_version".to_string(), compiler_version),
+            ("optimizer_version".to_string(), optimizer_version),
         ]))
     }
 
@@ -3512,4 +3626,11 @@ mod tests {
             job_id: job_id.to_string(),
         }
     }
+}
+
+fn unix_epoch_ms_u64() -> u64 {
+    SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or_default()
 }

--- a/src/rust/crates/qfs/src/lib.rs
+++ b/src/rust/crates/qfs/src/lib.rs
@@ -12,9 +12,10 @@ mod qfs_l2_checkpoint;
 
 pub use local_circuit_fs::{
     CircuitFsError, CircuitFsLocal, CompiledArtifactLineage, CompiledArtifactProvenance,
-    CompiledArtifacts, CompiledMetadata, ErrorDetails,
-    ResultArtifactDescriptor, ResultEnvelope, ResultManifest, ResultsBundle, SourceBundle,
-    SourceMetadata, DEFAULT_CIRCUIT_FS_ROOT,
+    CompiledArtifacts, CompiledMetadata, ErrorDetails, ReleaseEvidenceBundle,
+    ReleaseEvidenceManifest, ReleaseEvidenceProvenanceReport, ResultArtifactDescriptor,
+    ResultEnvelope, ResultManifest, ResultsBundle, SourceBundle, SourceMetadata,
+    DEFAULT_CIRCUIT_FS_ROOT,
 };
 
 pub use qfs_l2_checkpoint::{

--- a/src/rust/crates/qfs/src/local_circuit_fs.rs
+++ b/src/rust/crates/qfs/src/local_circuit_fs.rs
@@ -39,6 +39,9 @@ pub enum CircuitFsError {
     #[error("artifact not found: {path}")]
     NotFound { path: PathBuf },
 
+    #[error("invalid job id: {job_id}")]
+    InvalidJobId { job_id: String },
+
     #[error(transparent)]
     Io(#[from] io::Error),
 }
@@ -58,11 +61,13 @@ impl CircuitFsLocal {
     }
 
     pub fn ensure_job_layout(&self, job_id: &str) -> Result<(), CircuitFsError> {
-        fs::create_dir_all(self.job_root_path(job_id))?;
+        fs::create_dir_all(self.job_root_path(job_id)?)?;
         fs::create_dir_all(self.compiled_dir_path(job_id)?)?;
         fs::create_dir_all(self.results_dir_path(job_id)?)?;
         fs::create_dir_all(self.observability_dir_path(job_id)?)?;
         fs::create_dir_all(self.logs_dir_path(job_id)?)?;
+        fs::create_dir_all(self.meta_dir_path(job_id)?)?;
+        fs::create_dir_all(self.release_evidence_dir_path(job_id)?)?;
         Ok(())
     }
 
@@ -141,12 +146,35 @@ impl CircuitFsLocal {
         atomic_write_bytes(&path, metrics)
     }
 
+    fn validate_job_id(job_id: &str) -> Result<(), CircuitFsError> {
+        let valid_chars = job_id
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-'));
+        let forbidden_segments = job_id.is_empty()
+            || job_id == "."
+            || job_id == ".."
+            || job_id.contains("..")
+            || job_id.as_bytes().contains(&0);
+        if !valid_chars || forbidden_segments {
+            return Err(CircuitFsError::InvalidJobId { job_id: job_id.to_string() });
+        }
+        Ok(())
+    }
+
     fn observability_dir_path(&self, job_id: &str) -> Result<PathBuf, CircuitFsError> {
-        Ok(self.job_root_path(job_id).join("observability"))
+        Ok(self.job_root_path(job_id)?.join("observability"))
     }
 
     fn logs_dir_path(&self, job_id: &str) -> Result<PathBuf, CircuitFsError> {
-        Ok(self.job_root_path(job_id).join("logs"))
+        Ok(self.job_root_path(job_id)?.join("logs"))
+    }
+
+    fn meta_dir_path(&self, job_id: &str) -> Result<PathBuf, CircuitFsError> {
+        Ok(self.job_root_path(job_id)?.join("meta"))
+    }
+
+    fn release_evidence_dir_path(&self, job_id: &str) -> Result<PathBuf, CircuitFsError> {
+        Ok(self.meta_dir_path(job_id)?.join("release_evidence"))
     }
 
     fn result_json_path(&self, job_id: &str) -> Result<PathBuf, CircuitFsError> {
@@ -161,6 +189,18 @@ impl CircuitFsLocal {
         Ok(self.results_dir_path(job_id)?.join("envelope.json"))
     }
 
+    fn release_evidence_bundle_path(&self, job_id: &str) -> Result<PathBuf, CircuitFsError> {
+        Ok(self.release_evidence_dir_path(job_id)?.join("bundle.json"))
+    }
+
+    fn release_evidence_manifest_path(&self, job_id: &str) -> Result<PathBuf, CircuitFsError> {
+        Ok(self.release_evidence_dir_path(job_id)?.join("manifest.json"))
+    }
+
+    fn release_evidence_provenance_path(&self, job_id: &str) -> Result<PathBuf, CircuitFsError> {
+        Ok(self.release_evidence_dir_path(job_id)?.join("provenance.json"))
+    }
+
     fn metrics_json_path(&self, job_id: &str) -> Result<PathBuf, CircuitFsError> {
         Ok(self.observability_dir_path(job_id)?.join("metrics.json"))
     }
@@ -169,16 +209,17 @@ impl CircuitFsLocal {
         Ok(self.logs_dir_path(job_id)?.join(format!("{stream}.jsonl")))
     }
 
-    fn job_root_path(&self, job_id: &str) -> PathBuf {
-        self.root.join("jobs").join(job_id)
+    fn job_root_path(&self, job_id: &str) -> Result<PathBuf, CircuitFsError> {
+        Self::validate_job_id(job_id)?;
+        Ok(self.root.join("jobs").join(job_id))
     }
 
     fn compiled_dir_path(&self, job_id: &str) -> Result<PathBuf, CircuitFsError> {
-        Ok(self.job_root_path(job_id).join("compiled"))
+        Ok(self.job_root_path(job_id)?.join("compiled"))
     }
 
     fn compiled_aqo_json_path(&self, job_id: &str) -> Result<PathBuf, CircuitFsError> {
-        Ok(self.compiled_dir_path(job_id)?.join("compiled.aqo"))
+        Ok(self.compiled_dir_path(job_id)?.join("circuit.aqo.json"))
     }
 
     fn compiled_metadata_path(&self, job_id: &str) -> Result<PathBuf, CircuitFsError> {
@@ -190,11 +231,11 @@ impl CircuitFsLocal {
     }
 
     fn compiled_report_path(&self, job_id: &str) -> Result<PathBuf, CircuitFsError> {
-        Ok(self.compiled_dir_path(job_id)?.join("compile-report.json"))
+        Ok(self.compiled_dir_path(job_id)?.join("compile_report.json"))
     }
 
     fn results_dir_path(&self, job_id: &str) -> Result<PathBuf, CircuitFsError> {
-        Ok(self.job_root_path(job_id).join("results"))
+        Ok(self.job_root_path(job_id)?.join("results"))
     }
 }
 
@@ -302,7 +343,63 @@ pub struct ResultManifest {
     pub artifacts: Vec<ResultArtifactDescriptor>,
 }
 
-/// ... existing content omitted for brevity ...
+/// Release-evidence bundle persisted under `meta/release_evidence/`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReleaseEvidenceBundle {
+    pub artifact_version: String,
+    pub schema_version: String,
+    pub producer_version: String,
+    pub job_id: String,
+    pub compiler_contract_version: String,
+    pub optimizer_contract_version: String,
+    pub request_id: String,
+    pub trace_id: String,
+    pub traceparent: String,
+    pub source_sha256: String,
+    pub aqo_sha256: String,
+    #[serde(default)]
+    pub optimized_aqo_sha256: Option<String>,
+    pub compiled_artifact_ref: String,
+    pub optimized_artifact_ref: String,
+    pub manifest_ref: String,
+    pub provenance_report_ref: String,
+    #[serde(default)]
+    pub created_at_epoch_ms: u64,
+}
+
+/// Artifact manifest for release evidence bundles.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReleaseEvidenceManifest {
+    pub artifact_version: String,
+    pub producer_version: String,
+    pub schema_version: String,
+    #[serde(default)]
+    pub created_at_epoch_ms: u64,
+    #[serde(default)]
+    pub retention_policy: String,
+    #[serde(default)]
+    pub artifacts: Vec<ResultArtifactDescriptor>,
+}
+
+/// Provenance report tying release evidence back to compile and optimization runs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReleaseEvidenceProvenanceReport {
+    pub artifact_version: String,
+    pub schema_version: String,
+    pub job_id: String,
+    pub request_id: String,
+    pub trace_id: String,
+    pub traceparent: String,
+    pub compiler_stage_id: String,
+    pub optimizer_stage_id: String,
+    pub compiler_run_id: String,
+    pub optimizer_run_id: String,
+    pub compiler_artifact_ref: String,
+    pub optimized_artifact_ref: String,
+    pub compiler_lineage: CompiledArtifactLineage,
+    #[serde(default)]
+    pub optimized_aqo_sha256: Option<String>,
+}
 
 impl CircuitFsLocal {
     pub fn store_compiled_artifacts_v1(
@@ -361,6 +458,35 @@ impl CircuitFsLocal {
 
         let bytes = serde_json::to_vec_pretty(&metadata).map_err(to_io_error)?;
         atomic_write_bytes(&compiled_metadata_path, &bytes)?;
+        Ok(())
+    }
+
+    pub fn store_release_evidence_bundle_v1(
+        &self,
+        job_id: &str,
+        bundle: &ReleaseEvidenceBundle,
+        manifest: &ReleaseEvidenceManifest,
+        provenance_report: &ReleaseEvidenceProvenanceReport,
+    ) -> Result<(), CircuitFsError> {
+        self.ensure_job_layout(job_id)?;
+
+        let bundle_path = self.release_evidence_bundle_path(job_id)?;
+        let manifest_path = self.release_evidence_manifest_path(job_id)?;
+        let provenance_path = self.release_evidence_provenance_path(job_id)?;
+
+        for path in [bundle_path.clone(), manifest_path.clone(), provenance_path.clone()] {
+            if path.exists() {
+                return Err(CircuitFsError::AlreadyExists { path });
+            }
+        }
+
+        let bundle_bytes = serde_json::to_vec_pretty(bundle).map_err(to_io_error)?;
+        let manifest_bytes = serde_json::to_vec_pretty(manifest).map_err(to_io_error)?;
+        let provenance_bytes = serde_json::to_vec_pretty(provenance_report).map_err(to_io_error)?;
+
+        atomic_write_bytes(&bundle_path, &bundle_bytes)?;
+        atomic_write_bytes(&manifest_path, &manifest_bytes)?;
+        atomic_write_bytes(&provenance_path, &provenance_bytes)?;
         Ok(())
     }
 }
@@ -438,6 +564,174 @@ fn unix_epoch_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn read_json(path: &Path) -> serde_json::Value {
+        let bytes = fs::read(path).expect("read json");
+        serde_json::from_slice(&bytes).expect("parse json")
+    }
+
+    #[test]
+    fn store_compiled_artifacts_uses_canonical_paths_and_metadata() {
+        let tempdir = tempdir().expect("tempdir");
+        let fs = CircuitFsLocal::new(tempdir.path());
+
+        let provenance = CompiledArtifactProvenance {
+            producer_identity: "compiler-service".to_string(),
+            contract_version: "1.0.0".to_string(),
+            compiler_version: "1.0.0".to_string(),
+            created_at: "2026-06-12T00:00:00Z".to_string(),
+            lineage: CompiledArtifactLineage {
+                request_id: Some("req-123".to_string()),
+                source_ref: Some("qfs://jobs/job-123/input/program.eigen.py".to_string()),
+                source_sha256: Some("deadbeef".to_string()),
+            },
+        };
+
+        fs.store_compiled_artifacts_v1(
+            "job-123",
+            br#"{"aqo":"ok"}"#,
+            Some(b"OPENQASM 3;"),
+            Some(br#"{"status":"ok"}"#),
+            provenance,
+        )
+        .expect("store compiled artifacts");
+
+        let job_root = tempdir.path().join("jobs").join("job-123");
+        assert!(job_root.join("compiled/circuit.aqo.json").exists());
+        assert!(job_root.join("compiled/circuit.qasm").exists());
+        assert!(job_root.join("compiled/compile_report.json").exists());
+        assert!(job_root.join("compiled/metadata.json").exists());
+
+        let metadata = read_json(&job_root.join("compiled/metadata.json"));
+        assert_eq!(metadata["version"], "1.0.0");
+        assert_eq!(metadata["schema_version"], "compiled_artifacts.v1");
+        assert_eq!(metadata["compiler_version"], "1.0.0");
+        assert_eq!(metadata["producer_identity"], "compiler-service");
+        assert_eq!(metadata["contract_version"], "1.0.0");
+        assert_eq!(metadata["lineage"]["request_id"], "req-123");
+        assert_eq!(metadata["lineage"]["source_ref"], "qfs://jobs/job-123/input/program.eigen.py");
+    }
+
+    #[test]
+    fn store_release_evidence_bundle_writes_bundle_manifest_and_provenance() {
+        let tempdir = tempdir().expect("tempdir");
+        let fs = CircuitFsLocal::new(tempdir.path());
+
+        let bundle = ReleaseEvidenceBundle {
+            artifact_version: "1.0.0".to_string(),
+            schema_version: "release_evidence_bundle.v1".to_string(),
+            producer_version: "1.0.0".to_string(),
+            job_id: "job-456".to_string(),
+            compiler_contract_version: "1.0.0".to_string(),
+            optimizer_contract_version: "1.0.0".to_string(),
+            request_id: "req-456".to_string(),
+            trace_id: "trace-456".to_string(),
+            traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01".to_string(),
+            source_sha256: "sha256:1111".to_string(),
+            aqo_sha256: "sha256:2222".to_string(),
+            optimized_aqo_sha256: Some("sha256:3333".to_string()),
+            compiled_artifact_ref: "qfs://jobs/job-456/compiled/circuit.aqo.json".to_string(),
+            optimized_artifact_ref: "qfs://jobs/job-456/optimizer/optimized_aqo.json".to_string(),
+            manifest_ref: "qfs://jobs/job-456/meta/release_evidence/manifest.json".to_string(),
+            provenance_report_ref: "qfs://jobs/job-456/meta/release_evidence/provenance.json".to_string(),
+            created_at_epoch_ms: 1_717_000_000_000,
+        };
+        let manifest = ReleaseEvidenceManifest {
+            artifact_version: "1.0.0".to_string(),
+            producer_version: "1.0.0".to_string(),
+            schema_version: "release_evidence_manifest.v1".to_string(),
+            created_at_epoch_ms: 1_717_000_000_001,
+            retention_policy: "pinned".to_string(),
+            artifacts: vec![
+                ResultArtifactDescriptor {
+                    path: "meta/release_evidence/bundle.json".to_string(),
+                    content_hash: "sha256:aaaa".to_string(),
+                    size_bytes: 123,
+                },
+                ResultArtifactDescriptor {
+                    path: "meta/release_evidence/provenance.json".to_string(),
+                    content_hash: "sha256:bbbb".to_string(),
+                    size_bytes: 456,
+                },
+            ],
+        };
+        let provenance = ReleaseEvidenceProvenanceReport {
+            artifact_version: "1.0.0".to_string(),
+            schema_version: "release_evidence_provenance.v1".to_string(),
+            job_id: "job-456".to_string(),
+            request_id: "req-456".to_string(),
+            trace_id: "trace-456".to_string(),
+            traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01".to_string(),
+            compiler_stage_id: "stage-compile".to_string(),
+            optimizer_stage_id: "stage-optimize".to_string(),
+            compiler_run_id: "run-compile".to_string(),
+            optimizer_run_id: "run-optimize".to_string(),
+            compiler_artifact_ref: "qfs://jobs/job-456/compiled/circuit.aqo.json".to_string(),
+            optimized_artifact_ref: "qfs://jobs/job-456/optimizer/optimized_aqo.json".to_string(),
+            compiler_lineage: CompiledArtifactLineage {
+                request_id: Some("req-456".to_string()),
+                source_ref: Some("qfs://jobs/job-456/input/program.eigen.py".to_string()),
+                source_sha256: Some("deadbeef".to_string()),
+            },
+            optimized_aqo_sha256: Some("sha256:3333".to_string()),
+        };
+
+        fs.store_release_evidence_bundle_v1("job-456", &bundle, &manifest, &provenance)
+            .expect("store release evidence bundle");
+
+        let job_root = tempdir.path().join("jobs").join("job-456");
+        assert!(job_root.join("meta/release_evidence/bundle.json").exists());
+        assert!(job_root.join("meta/release_evidence/manifest.json").exists());
+        assert!(job_root.join("meta/release_evidence/provenance.json").exists());
+
+        let bundle_json = read_json(&job_root.join("meta/release_evidence/bundle.json"));
+        assert_eq!(
+            bundle_json["compiled_artifact_ref"],
+            "qfs://jobs/job-456/compiled/circuit.aqo.json"
+        );
+        assert_eq!(
+            bundle_json["manifest_ref"],
+            "qfs://jobs/job-456/meta/release_evidence/manifest.json"
+        );
+        assert_eq!(
+            bundle_json["provenance_report_ref"],
+            "qfs://jobs/job-456/meta/release_evidence/provenance.json"
+        );
+
+        let provenance_json = read_json(&job_root.join("meta/release_evidence/provenance.json"));
+        assert_eq!(provenance_json["compiler_stage_id"], "stage-compile");
+        assert_eq!(provenance_json["optimizer_stage_id"], "stage-optimize");
+        assert_eq!(provenance_json["compiler_lineage"]["request_id"], "req-456");
+    }
+
+    #[test]
+    fn replay_safe_job_ids_reject_path_traversal_and_invalid_segments() {
+        let tempdir = tempdir().expect("tempdir");
+        let fs = CircuitFsLocal::new(tempdir.path());
+
+        for job_id in ["", ".", "..", "bad/segment", "bad..segment", "bad\\segment"] {
+            let err = fs.ensure_job_layout(job_id).expect_err("invalid job id must fail");
+            match err {
+                CircuitFsError::InvalidJobId { job_id: rejected } => assert_eq!(rejected, job_id),
+                other => panic!("unexpected error: {other:?}"),
+            }
+        }
+
+        let err = fs
+            .ensure_job_layout("bad\0segment")
+            .expect_err("invalid null byte job id must fail");
+        match err {
+            CircuitFsError::InvalidJobId { job_id: rejected } => assert_eq!(rejected, "bad\0segment"),
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Summary

Implemented W7-05 by aligning QFS artifact persistence with Product 1.0, adding replay-safe job ID validation, canonical compiler artifact paths, immutable release-evidence persistence, and provenance wiring from compiler to optimizer. Updated the normative docs and the wave-7 issue pack to describe the new persistence contract.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: QFS
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**:None

## Release Notes Draft

### Added
- Canonical compiled/circuit.aqo.json and compiled/compile_report.json path alignment in QFS.
- Job-scoped meta/release_evidence/{bundle,manifest,provenance}.json persistence.
- Replay-safe job ID validation and release-evidence provenance tracing.

### Changed
- Kernel persistence now emits release-evidence refs tied to compiler and optimizer stages.
- QFS architecture and reference docs now describe the release-evidence persistence phase.
- Contract inventory now includes release-evidence persistence and replay-safe naming coverage.

### Fixed
- Duplicate compile_report.json entry in the QFS layout spec.
- Out-of-sync artifact path names in the kernel/QFS handoff.