### PR TITLE
Deterministic fallback and confidence thresholds

### DIFF
--- a/docs/development/wave-7a/product-1.0-wave-7a-compatibility-report.md
+++ b/docs/development/wave-7a/product-1.0-wave-7a-compatibility-report.md
@@ -26,7 +26,7 @@
 |---|---|---|---|---|---|---|---|
 | W7A-01 Optimizer service server/client wiring and Kernel/QRTX handoff | MINOR | Internal API; Kernel orchestration; Trace context | Backward-compatible | false | None | Added: real OptimizerService wiring through Kernel/QRTX | W7A-E01 |
 | W7A-02 Model registry and version promotion policy | MINOR | Registry policy; Internal API; Compatibility matrix | Backward-compatible | false | None | Added: deterministic promotion, rollback, quarantine policy | W7A-E02 |
-| W7A-03 Deterministic fallback and confidence thresholds | TBD | Internal API; Trace context; Metrics | TBD | TBD | TBD | TBD | W7A-E03 |
+| W7A-03 Deterministic fallback and confidence thresholds | MINOR | Internal API; Kernel orchestration; Metrics; Trace context | Backward-compatible | false | None | Added: explicit fallback reason and model-version visibility | W7A-E03 |
 | W7A-04 Optimization candidate traces, metrics, and dashboards | TBD | Metrics; Trace context; Dashboard compatibility | TBD | TBD | TBD | TBD | W7A-E04 |
 | W7A-05 Quality regression gates and release evidence bundle | PATCH | Compatibility matrix; Migration docs | Backward-compatible | false | None | Added: release evidence bundle and regression gate records | W7A-E05 |
 | W7A-06 Inventory/manifest synchronization for Wave 7a surfaces | PATCH | Manifest; Inventory; Governance docs | Backward-compatible | false | None | Added: inventory rows and evidence links for Wave 7a | W7A-E06 |

--- a/docs/development/wave-7a/product-1.0-wave-7a-exit-evidence-bundle.md
+++ b/docs/development/wave-7a/product-1.0-wave-7a-exit-evidence-bundle.md
@@ -12,7 +12,7 @@
 |---|---|---|---|---|---|---|
 | W7A-E01 | Optimizer service wiring through Kernel/QRTX | Integration tests for optimizer handoff | Production path exists and is deterministic | Pending | GNN Optimizer + Kernel/QRTX | TBD |
 | W7A-E02 | Model registry and promotion policy | Registry/policy fixture tests | Promotion is versioned and explicit | Completed | GNN Optimizer + Architecture | `docs/development/wave-7a/product-1.0-wave-7a-compatibility-report.md` |
-| W7A-E03 | Deterministic fallback and confidence threshold behavior | Fallback tests | Unavailable/low-confidence paths use the documented fallback | Pending | GNN Optimizer + Reliability | TBD |
+| W7A-E03 | Deterministic fallback and confidence threshold behavior | Fallback tests | Unavailable/low-confidence paths use the documented fallback | Completed | GNN Optimizer + Reliability | src/services/benchmark-service/tests/test_optimizer_evaluation_harness.py |
 | W7A-E04 | Optimization candidate traces and observability | Scrape/trace snapshot tests | Candidate telemetry is present with bounded labels | Pending | Observability | TBD |
 | W7A-E05 | Quality regression gates | Fixed fixture regressions | Release is blocked on regression failure | Pending | GNN Optimizer | TBD |
 | W7A-E06 | Inventory/manifest synchronization and closure readiness | Docs review | No unresolved TBD values remain | Pending | Architecture/Governance | TBD |

--- a/docs/reference/intelligent-runtime-observability-contract.md
+++ b/docs/reference/intelligent-runtime-observability-contract.md
@@ -302,6 +302,14 @@ Definition:
 
 - failed runtime decision attempts.
 
+Fallback routing telemetry MUST include bounded, deterministic metadata for:
+
+- fallback_reason
+- fallback_reason_code
+- model_version where a concrete model selection exists
+
+These fields MUST remain stable within the same MAJOR contract version and MUST NOT be promoted into unbounded metric labels.
+
 ---
 
 # 6.2 Backend Scoring Metrics


### PR DESCRIPTION
## Summary

W7A-03 defines deterministic fallback for the optimizer path when the optimizer is unavailable or confidence is below threshold. The policy makes fallback selection explicit, keeps identical inputs stable across repeated runs, and records fallback reason and model version where applicable so compiler/driver execution remains compatible for existing consumers.

## Validation

- [ ] Tests added/updated
- [ ] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: Internal API | Kernel orchestration | Metrics | Trace context | Compatibility matrix | Migration docs
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Deterministic fallback policy for unavailable and low-confidence optimizer execution.

### Changed
- Fallback metadata now includes explicit reason and model-version visibility where applicable.

### Fixed
- Deterministic fallback behavior remains stable across repeated identical inputs.