### PR TITLE
Aligned the Kernel/QRTX optimizer request builder

### DIFF
--- a/docs/development/wave-7a/product-1.0-wave-7a-compatibility-report.md
+++ b/docs/development/wave-7a/product-1.0-wave-7a-compatibility-report.md
@@ -24,7 +24,7 @@
 
 | Issue | Version Impact | Affected Interfaces | Compatibility | Breaking Marker | Migration Notes | Release Notes Draft | Evidence |
 |---|---|---|---|---|---|---|---|
-| W7A-01 Optimizer service server/client wiring and Kernel/QRTX handoff | MINOR | Internal API; Kernel orchestration; Trace context | Backward-compatible | false | None | Added: real OptimizerService wiring through Kernel/QRTX | W7A-E01 |
+| W7A-01 Optimizer service server/client wiring and Kernel/QRTX handoff | MINOR | Internal API; Kernel orchestration; Trace context | Backward-compatible | false | None | Added: real OptimizerService wiring through Kernel/QRTX with bounded graph-encoding handoff and deterministic candidate-budget default | W7A-E01 |
 | W7A-02 Model registry and version promotion policy | MINOR | Registry policy; Internal API; Compatibility matrix | Backward-compatible | false | None | Added: deterministic promotion, rollback, quarantine policy | W7A-E02 |
 | W7A-03 Deterministic fallback and confidence thresholds | MINOR | Internal API; Kernel orchestration; Metrics; Trace context | Backward-compatible | false | None | Added: explicit fallback reason and model-version visibility | W7A-E03 |
 | W7A-04 Optimization candidate traces, metrics, and dashboards | 2.1.0 | Metrics; Trace context; Dashboard compatibility | implemented | compatible | low-risk bounded addition | None | W7A-E04 |

--- a/src/rust/crates/eigen-kernel/src/rpc.rs
+++ b/src/rust/crates/eigen-kernel/src/rpc.rs
@@ -1931,8 +1931,19 @@ impl GrpcOptimizerGateway {
             .get("compiled_artifact_ref")
             .cloned()
             .unwrap_or_else(|| format!("qfs://jobs/{}/compiled/circuit.aqo.json", submission.job_id));
-
-        OptimizerServiceOptimizeCircuitRequest {
+        let canonical_graph_json = serde_json::to_string(&serde_json::json!({
+            "canonical_graph_version": "aqo-graph-v1",
+            "compile_digest": compile_digest,
+            "compiled_artifact_ref": compiled_artifact_ref,
+        }))
+        .unwrap_or_else(|_| {
+            format!(
+                r#"{{"canonical_graph_version":"aqo-graph-v1","compile_digest":"{}","compiled_artifact_ref":"{}"}}"#,
+                compile_digest, compiled_artifact_ref
+            )
+        });
+        
+            OptimizerServiceOptimizeCircuitRequest {
             envelope: Some(OptimizerContractEnvelope {
                 contract_version: submission.contract_version.clone(),
             }),
@@ -1959,7 +1970,7 @@ impl GrpcOptimizerGateway {
                 .metadata_kvs
                 .get("optimizer.candidate_budget")
                 .and_then(|s| s.parse::<u32>().ok())
-                .unwrap_or(2),
+                .unwrap_or(1),
             timeout_ms: submission
                 .metadata_kvs
                 .get("optimizer.timeout_ms")
@@ -1973,11 +1984,8 @@ impl GrpcOptimizerGateway {
             graph_encoding: Some(GraphEncodingContext {
                 encoding_version: "aqo-graph-v1".to_string(),
                 canonical_format: "aqo-json".to_string(),
-                canonical_graph_json: compile_digest,
-                canonical_sha256: compile_output
-                    .get("compile_digest")
-                    .cloned()
-                    .unwrap_or_else(|| submission.program_hash.clone()),
+                canonical_graph_json: canonical_graph_json.clone(),
+                canonical_sha256: hash_bytes_hex(canonical_graph_json.as_bytes()),
                 round_trip_stability: true,
             }),
             policy: Some(OptimizerPolicy {
@@ -3689,6 +3697,40 @@ mod tests {
             }),
         };
         NormalizedSubmission::from_request(&req).expect("submission")
+    }
+
+    #[test]
+    fn optimizer_gateway_request_uses_bounded_defaults_and_canonical_graph_json() {
+        let gateway = GrpcOptimizerGateway {
+            endpoint: "http://127.0.0.1:50052".to_string(),
+        };
+        let submission = fixture_submission_with_lease_ms(60_000);
+        let mut compile_output = BTreeMap::new();
+        compile_output.insert("compile_digest".to_string(), "compile-digest-0001".to_string());
+        compile_output.insert(
+            "compiled_artifact_ref".to_string(),
+            "qfs://jobs/job-1/compiled/circuit.aqo.json".to_string(),
+        );
+
+        let request = gateway.build_request(&submission, &compile_output);
+        assert_eq!(request.candidate_budget, 1);
+        assert_eq!(request.timeout_ms, 100);
+        assert_eq!(request.trace_context.get("request_id"), Some(&submission.request_id));
+        assert_eq!(request.trace_context.get("traceparent"), Some(&submission.traceparent));
+
+        let graph_encoding = request.graph_encoding.expect("graph encoding");
+        let graph_json: serde_json::Value = serde_json::from_str(&graph_encoding.canonical_graph_json)
+            .expect("canonical graph json");
+        assert_eq!(graph_json["canonical_graph_version"], "aqo-graph-v1");
+        assert_eq!(graph_json["compile_digest"], "compile-digest-0001");
+        assert_eq!(
+            graph_json["compiled_artifact_ref"],
+            "qfs://jobs/job-1/compiled/circuit.aqo.json"
+        );
+        assert_eq!(
+            graph_encoding.canonical_sha256,
+            hash_bytes_hex(graph_encoding.canonical_graph_json.as_bytes())
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Aligned the Kernel/QRTX optimizer request builder with the frozen W7A-01 contract defaults by using `candidate_budget = 1` when unspecified.
- Replaced the placeholder digest value in `graph_encoding.canonical_graph_json` with a bounded deterministic JSON payload and hashed that payload for `canonical_sha256`.
- Added a kernel unit test covering bounded optimizer request defaults, canonical graph JSON generation, and trace-context propagation.
- Updated the Wave 7a compatibility report to record the bounded graph-encoding handoff and deterministic candidate-budget default.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: Internal API | Kernel orchestration | Trace context | Metrics
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Bounded optimizer request evidence for Kernel/QRTX handoff.
- Kernel unit coverage for optimizer request defaults and canonical graph encoding.

### Changed
- Optimizer request builder now uses the frozen default `candidate_budget = 1`.
- `graph_encoding.canonical_graph_json` now carries deterministic bounded JSON instead of a digest placeholder.

### Fixed
- Removed contract drift in optimizer request shaping and trace evidence generation.