### PR TITLE
Implemented sandbox-profile propagation

### DIFF
--- a/docs/architecture/components/compiler.md
+++ b/docs/architecture/components/compiler.md
@@ -205,6 +205,7 @@ The compiler MUST run in an isolated container / sandbox profile:
 - strict CPU/memory/time limits,
 - no access to host credentials or secrets,
 - explicit allowlisted environment variables only.
+- the active sandbox profile MUST be selected explicitly via request/deployment context and rejected if it is not one of the documented profiles.
 
 ---
 

--- a/docs/architecture/components/driver-manager.md
+++ b/docs/architecture/components/driver-manager.md
@@ -408,6 +408,7 @@ Device profile negotiation failures MUST use the same canonical model:
   - metrics labels.
 - Provider configuration MUST be versioned and explicit; secret material MUST be referenced only by secret refs and fetched through the security/secrets path.
 - Drivers may receive credentials **only on demand** and only for the duration required.
+- Secret lifecycle audit records SHOULD use redacted references or digests instead of raw secret refs.
 - Provider code MUST respect the declared isolation profile (sandbox or dedicated process) and fail closed when the configured profile is unsupported.
 
 ---

--- a/docs/architecture/components/security-isolation.md
+++ b/docs/architecture/components/security-isolation.md
@@ -181,6 +181,7 @@ Implemented:
 
 - secret redaction
 - secure telemetry policies (no sensitive identifiers in labels)
+- secret lifecycle audit entries MUST carry redacted references or digests only
 - encrypted artifact handling (at rest and in transit)
 - retention enforcement
 - export provenance tracking

--- a/src/services/driver-manager/src/driver_manager/aws_braket_driver.py
+++ b/src/services/driver-manager/src/driver_manager/aws_braket_driver.py
@@ -150,13 +150,17 @@ class AwsBraketDriver:
         secret_ref = str(config.get("credentials_secret_ref", "")).strip()
         if secret_ref:
             secrets = SecretLifecycleStore()
-            raw = secrets.get(secret_ref, actor=self.name, workload_id=config.get("workload_id", "driver-init"), consumer=self.name)
+            try:
+                raw = secrets.get(secret_ref, actor=self.name, workload_id=config.get("workload_id", "driver-init"), consumer=self.name)
+            except ValueError as exc:
+                self._init_error = "missing AWS credentials for configured secret ref"
+                raise ValueError(self._init_error) from exc
             if isinstance(raw, dict):
                 access_key_id = str(raw.get("access_key_id", "")).strip()
                 secret_access_key = str(raw.get("secret_access_key", "")).strip()
                 if access_key_id and secret_access_key:
                     return _AwsAuthConfig(f"secret_ref:{secret_ref}", access_key_id, secret_access_key)
-            self._init_error = f"missing AWS credentials for secret ref '{secret_ref}'"
+            self._init_error = "missing AWS credentials for configured secret ref"
             raise ValueError(self._init_error)
 
         self._init_error = "aws braket auth missing: set credentials_secret_ref"

--- a/src/services/driver-manager/src/driver_manager/qiskit_runtime_driver.py
+++ b/src/services/driver-manager/src/driver_manager/qiskit_runtime_driver.py
@@ -157,10 +157,14 @@ class QiskitRuntimeDriver:
         token_secret_ref = str(config.get("token_secret_ref", "")).strip()
         if token_secret_ref:
             secrets = SecretLifecycleStore()
-            token = str(secrets.get(token_secret_ref, actor=self.name, workload_id=config.get("workload_id", "driver-init"), consumer=self.name)).strip()
+            try:
+                token = str(secrets.get(token_secret_ref, actor=self.name, workload_id=config.get("workload_id", "driver-init"), consumer=self.name)).strip()
+            except ValueError as exc:
+                self._init_error = "missing token for configured secret ref"
+                raise ValueError(self._init_error) from exc
             if token:
                 return _AuthConfig(source=f"secret_ref:{token_secret_ref}", token=token)
-            self._init_error = f"missing token for secret ref '{token_secret_ref}'"
+            self._init_error = "missing token for configured secret ref"
             raise ValueError(self._init_error)
 
         self._init_error = "qiskit runtime auth missing: set token_secret_ref"

--- a/src/services/driver-manager/src/driver_manager/secret_lifecycle.py
+++ b/src/services/driver-manager/src/driver_manager/secret_lifecycle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import hashlib
 import json
 import logging
 import os
@@ -71,30 +72,32 @@ class SecretLifecycleStore:
 
         if record is None:
             self._emit("lookup_denied", secret_ref, actor, workload_id, consumer, "not_found")
-            raise ValueError(f"missing secret for ref '{secret_ref}'")
+            raise ValueError("missing secret")
 
         if record.expires_at and now >= record.expires_at:
             self._emit("expire", secret_ref, actor, workload_id, consumer, "expired")
-            raise ValueError(f"expired secret for ref '{secret_ref}'")
+            raise ValueError("expired secret")
 
         if record.state == "revoked":
             self._emit("revoke", secret_ref, actor, workload_id, consumer, "revoked")
-            raise ValueError(f"revoked secret for ref '{secret_ref}'")
+            raise ValueError("revoked secret")
 
         if record.state not in self._ACTIVE_STATES:
             self._emit("lookup_denied", secret_ref, actor, workload_id, consumer, f"invalid_state:{record.state}")
-            raise ValueError(f"inactive secret for ref '{secret_ref}'")
+            raise ValueError("inactive secret")
 
         action = "issue" if record.state == "issued" else "rotate"
         self._emit(action, secret_ref, actor, workload_id, consumer, "ok")
         return record.value
 
     def _emit(self, event: str, secret_ref: str, actor: str, workload_id: str, consumer: str, outcome: str) -> None:
+        secret_ref_digest = hashlib.sha256(secret_ref.encode("utf-8")).hexdigest()[:16]
         _AUDIT_LOG.info(
             "secret_lifecycle_event",
             extra={
                 "event": event,
-                "secret_ref": secret_ref,
+                "secret_ref_digest": secret_ref_digest,
+                "secret_ref_redacted": "<redacted>",
                 "actor": actor,
                 "workload_id": workload_id,
                 "consumer": consumer,

--- a/src/services/driver-manager/tests/test_aws_braket_driver.py
+++ b/src/services/driver-manager/tests/test_aws_braket_driver.py
@@ -40,6 +40,19 @@ def test_initialize_requires_provider_config_version() -> None:
         )
 
 
+def test_initialize_missing_secret_ref_message_is_redacted() -> None:
+    driver = AwsBraketDriver(types_pb=types_pb)
+
+    with pytest.raises(ValueError, match="configured secret ref"):
+        driver.initialize(
+            {
+                "provider_config_version": "1.0",
+                "runtime_isolation": "process",
+                "credentials_secret_ref": "aws/braket/creds",
+            }
+        )
+
+
 def test_retry_maps_throttling(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(
         "DRIVER_MANAGER_SECRETS_JSON",

--- a/src/services/driver-manager/tests/test_qiskit_runtime_driver.py
+++ b/src/services/driver-manager/tests/test_qiskit_runtime_driver.py
@@ -71,6 +71,19 @@ def test_initialize_rejects_insecure_runtime_isolation(monkeypatch: pytest.Monke
         )
 
 
+def test_initialize_missing_secret_ref_message_is_redacted() -> None:
+    driver = QiskitRuntimeDriver(types_pb=types_pb)
+
+    with pytest.raises(ValueError, match="configured secret ref"):
+        driver.initialize(
+            {
+                "provider_config_version": "1.0",
+                "runtime_isolation": "process",
+                "token_secret_ref": "ibm/runtime/token",
+            }
+        )
+
+
 def test_execute_retries_resource_exhausted_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DRIVER_MANAGER_SECRETS_JSON", '{"ibm/runtime/token":{"value":"from-secret","state":"issued"}}')
     driver = QiskitRuntimeDriver(types_pb=types_pb)

--- a/src/services/driver-manager/tests/test_secret_lifecycle.py
+++ b/src/services/driver-manager/tests/test_secret_lifecycle.py
@@ -43,4 +43,6 @@ def test_secret_lifecycle_emits_audit_events(monkeypatch: pytest.MonkeyPatch, ca
     events = [record for record in caplog.records if record.message == "secret_lifecycle_event"]
     assert any(getattr(record, "event", "") == "issue" and getattr(record, "outcome", "") == "ok" for record in events)
     assert any(getattr(record, "event", "") == "revoke" and getattr(record, "outcome", "") == "revoked" for record in events)
+    assert all("secret_ref" not in record.__dict__ or record.__dict__.get("secret_ref") != "a" for record in events)
+    assert any(getattr(record, "secret_ref_digest", "") for record in events)
     

--- a/src/services/eigen-compiler/src/eigen_compiler/compiler.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/compiler.py
@@ -29,6 +29,7 @@ _AQO_ROTATION_OPS = {"RX", "RY", "RZ"}
 _AQO_MEASUREMENT_BASIS = {"X", "Y", "Z"}
 _AQO_NON_PARAMETERIZED_OPS = {"CX", "CZ", "SWAP", "CCX", "CCZ", "X", "Y", "Z", "H", "S", "T", "RESET"}
 _AQO_ARITY = {"RX": 1, "RY": 1, "RZ": 1, "CX": 2, "CZ": 2, "SWAP": 2, "CCX": 3, "CCZ": 3, "X": 1, "Y": 1, "Z": 1, "H": 1, "S": 1, "T": 1, "MEASURE": 1, "RESET": 1}
+_ALLOWED_SANDBOX_PROFILES = {"default", "restricted", "strict"}
 
 
 @dataclass(frozen=True)
@@ -39,6 +40,7 @@ class CompileRequestContext:
     deadline: str = ""
     retry_policy: str = ""
     security_context: str = ""
+    sandbox_profile: str = "strict"
     tenant_id: str = ""
     project_id: str = ""
 
@@ -213,6 +215,16 @@ def _normalize_options(options: dict[str, str] | None) -> dict[str, str]:
 
 def _normalize_request_context(request_context: dict[str, str] | None) -> CompileRequestContext:
     context = request_context or {}
+    sandbox_profile = str(context.get("sandbox_profile", "")).strip().lower() or "strict"
+    if sandbox_profile not in _ALLOWED_SANDBOX_PROFILES:
+        raise CompilerValidationError(
+            violations=(
+                FieldViolation(
+                    field="request_context.sandbox_profile",
+                    description=f"sandbox profile must be one of {', '.join(sorted(_ALLOWED_SANDBOX_PROFILES))}",
+                ),
+            )
+        )
     return CompileRequestContext(
         request_id=str(context.get("request_id", "")),
         trace_id=str(context.get("trace_id", "")),
@@ -220,6 +232,7 @@ def _normalize_request_context(request_context: dict[str, str] | None) -> Compil
         deadline=str(context.get("deadline", "")),
         retry_policy=str(context.get("retry_policy", "")),
         security_context=str(context.get("security_context", "")),
+        sandbox_profile=sandbox_profile,
         tenant_id=str(context.get("tenant_id", "")),
         project_id=str(context.get("project_id", "")),
     )
@@ -653,6 +666,7 @@ def compile_eigen_lang(
         "deadline": normalized_request_context.deadline,
         "retry_policy": normalized_request_context.retry_policy,
         "security_context": normalized_request_context.security_context,
+        "sandbox_profile": normalized_request_context.sandbox_profile,
         "tenant_id": normalized_request_context.tenant_id,
         "project_id": normalized_request_context.project_id,
     }

--- a/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
@@ -162,6 +162,7 @@ def _request_context_from_rpc(request, context: grpc.ServicerContext) -> dict[st
         "deadline": deadline,
         "retry_policy": pick("retry_policy", "x-eigen-retry-policy"),
         "security_context": pick("security_context", "authorization"),
+        "sandbox_profile": pick("sandbox_profile", "x-eigen-sandbox-profile"),
         "tenant_id": pick("tenant_id", "x-eigen-tenant-id"),
         "project_id": pick("project_id", "x-eigen-project-id"),
     }

--- a/src/services/eigen-compiler/tests/test_conformance_suite.py
+++ b/src/services/eigen-compiler/tests/test_conformance_suite.py
@@ -195,12 +195,13 @@ def test_compile_job_request_metadata_is_propagated(grpc_addr: str) -> None:
         ),
     )
 
-    response = stub.CompileJob(request)
+    response = stub.CompileJob(request, metadata=(("x-eigen-sandbox-profile", "restricted"),))
 
     assert response.metadata["request_id"] == "req-123"
     assert response.metadata["trace_id"] == "trace-456"
     assert response.metadata["tenant_id"] == "tenant-a"
     assert response.metadata["project_id"] == "project-x"
+    assert response.metadata["sandbox_profile"] == "restricted"
     assert response.metadata["source_precedence"] == "source"
     assert response.metadata["options_json"] == '{"alpha":"1","beta":"2"}'
 
@@ -213,6 +214,7 @@ def test_compile_job_request_metadata_is_propagated(grpc_addr: str) -> None:
                     "project_id": "project-x",
                     "request_id": "req-123",
                     "retry_policy": "idempotent",
+                    "sandbox_profile": "restricted",
                     "security_context": "mTLS",
                     "tenant_id": "tenant-a",
                     "trace_id": "trace-456",
@@ -228,6 +230,32 @@ def test_compile_job_request_metadata_is_propagated(grpc_addr: str) -> None:
     ).hexdigest()
 
     assert response.metadata["request_sha256"] == expected_request_digest
+
+
+def test_compile_job_rejects_invalid_sandbox_profile(grpc_addr: str) -> None:
+    channel = grpc.insecure_channel(grpc_addr)
+    stub = comp_pb_grpc.CompilationServiceStub(channel)
+    source = (
+        b"from eigen_lang import hybrid_program\n\n"
+        b"@hybrid_program(target=\"sim\", shots=1000)\n"
+        b"def main():\n"
+        b"    ry(0, theta=1.0)\n"
+    )
+
+    with pytest.raises(grpc.RpcError) as exc:
+        stub.CompileJob(
+            comp_pb.CompileJobRequest(
+                job_id="job-invalid-sandbox",
+                language="eigen-lang",
+                source=source,
+                options={},
+            ),
+            metadata=(("x-eigen-sandbox-profile", "host-network"),),
+        )
+
+    assert exc.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    bad_request = _extract_bad_request(exc.value)
+    assert any(v.field == "request_context.sandbox_profile" for v in bad_request.field_violations)
 
 
 def test_source_ref_is_resolved_from_qfs_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Implemented sandbox-profile propagation and validation for compiler request context, redacted secret lifecycle telemetry and secret-related initialization failures, and tightened provider-boundary regression coverage so isolation failures stay fail-closed.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: Internal API | Metrics | Trace context | Compatibility matrix | Migration docs
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Compiler sandbox-profile propagation in internal request context.
- Invalid compiler sandbox-profile rejection with canonical validation errors.
- Redacted secret lifecycle telemetry with stable digests.
- Redacted provider secret initialization failures.

### Changed
- Compiler metadata now includes the active sandbox profile.
- Driver-manager secret handling no longer echoes raw secret refs in audit telemetry.
- Provider initialization now returns generic configured-secret errors.

### Fixed
- Secrets no longer traverse raw telemetry labels or exception text.
- Sandbox-profile violations now fail closed with deterministic validation behavior.