### PR TITLE
Implemented the canonical append-only security audit sink evidence

### DIFF
--- a/docs/architecture/components/observability.md
+++ b/docs/architecture/components/observability.md
@@ -601,6 +601,7 @@ Observability pipelines MUST:
 - enforce RBAC for any query/export endpoints,
 - support retention controls,
 - maintain an immutable audit trail for security-relevant events,
+- expose bounded audit-pipeline health counters for security sinks,
 - avoid multi-tenant leakage (no unsafe labels; redaction in logs).
 
 ---

--- a/docs/architecture/components/security-isolation.md
+++ b/docs/architecture/components/security-isolation.md
@@ -502,6 +502,7 @@ security_auth_attempts_total{mode,result}
 security_auth_failures_total{reason}
 security_policy_denials_total{action,resource_type,reason}
 security_policy_eval_duration_seconds_bucket
+security_audit_write_failures_total{sink}
 ```
 
 #### Validation
@@ -532,6 +533,8 @@ security_replay_verification_failures_total{reason}
 #### Implemented now
 
 - structured JSON logs with `trace_id`, `traceparent`, `method`, `request_id`, optional `job_id`
+- append-only security audit records with `decision`, `reason`, `policy_version`, `service_identity`, `sandbox_profile`, and `replay_marker`
+- bounded audit pipeline health counters for sink write failures
 
 #### Required target
 

--- a/docs/development/wave-9/product-1.0-wave-9-compatibility-report.md
+++ b/docs/development/wave-9/product-1.0-wave-9-compatibility-report.md
@@ -25,7 +25,7 @@ Wave 9 is a planning and execution package for security hardening. It does not c
 | W9-01 | Authentication, authorization, and normalized security context | Planned and documented |
 | W9-02 | Service identity, policy snapshots, and deterministic policy decisions | Planned and documented |
 | W9-03 | Sandbox isolation, secrets lifecycle, and provider boundary hardening | Planned and documented |
-| W9-04 | Audit store, security telemetry, and replayable security evidence | Planned and documented |
+| W9-04 | Audit store, security telemetry, and replayable security evidence | Implemented in current snapshot |
 | W9-05 | Security conformance, fail-closed gating, and release evidence bundle | Planned and documented |
 
 ## Migration notes

--- a/docs/development/wave-9/product-1.0-wave-9-release-readiness-checklist.md
+++ b/docs/development/wave-9/product-1.0-wave-9-release-readiness-checklist.md
@@ -15,7 +15,7 @@
 - [ ] Any manifest references that changed with the inventory are updated in the same change set.
 - [ ] No stale fixture-only wording remains where Wave 9 behavior becomes authoritative.
 - [ ] Security, identity, policy, and isolation evidence paths are linked to the wave package.
-- [ ] Security telemetry and auditability checks remain bounded and secret-free.
+- [ ] Security telemetry and auditability checks remain bounded, secret-free, and replayable.
 
 ## Release gating rule
 

--- a/docs/reference/security/authz.md
+++ b/docs/reference/security/authz.md
@@ -101,3 +101,11 @@ Wave 9 public ingress handlers MUST normalize and propagate a deterministic secu
 - request and trace correlation metadata where available
 
 The public ingress boundary MUST reject requests by default unless the configured identity and policy checks succeed. Allow-all behavior remains a local/dev compatibility mode only when explicitly configured.
+
+---
+
+### 7.1 Security audit trail and replay evidence
+
+Security decisions MUST be written to the canonical append-only audit sink with bounded, secret-free metadata. Each audit event MUST include the decision outcome, decision reason, policy version, service identity, sandbox profile, replay marker, and request trace correlation where available.
+
+Security telemetry for the audit path MUST remain bounded. Audit sink health is surfaced as counters rather than free-form labels, and audit records MUST NOT embed raw payloads, bearer tokens, or provider secrets.

--- a/src/services/system-api/src/system_api/observability.py
+++ b/src/services/system-api/src/system_api/observability.py
@@ -113,6 +113,7 @@ class _MetricsState:
     requests_total = 0
     request_duration_seconds_sum = 0.0
     authz_denied_total = 0
+    security_audit_write_failures_total = 0
     submit_job_outcomes_total: dict[str, int] = {
         "accepted": 0,
         "replayed": 0,
@@ -149,6 +150,7 @@ class _MetricsHandler(BaseHTTPRequestHandler):
             req_total = _MetricsState.requests_total
             req_sum = _MetricsState.request_duration_seconds_sum
             authz_denied = _MetricsState.authz_denied_total
+            security_audit_write_failures = _MetricsState.security_audit_write_failures_total
             submit_outcomes = dict(_MetricsState.submit_job_outcomes_total)
             public_contract_outcomes = dict(_MetricsState.public_api_contract_requests_total)
             kb_contract_info = dict(_MetricsState.kb_contract_info)
@@ -221,6 +223,8 @@ class _MetricsHandler(BaseHTTPRequestHandler):
             f"eigen_api_request_duration_seconds {req_sum:.6f}\n"
             "# TYPE eigen_api_authz_denied_total counter\n"
             f"eigen_api_authz_denied_total {authz_denied}\n"
+            "# TYPE eigen_security_audit_write_failures_total counter\n"
+            f"eigen_security_audit_write_failures_total{{sink=\"file\"}} {security_audit_write_failures}\n"
             "# TYPE eigen_api_submit_job_outcomes_total counter\n"
             f"{outcome_lines}"
             "# TYPE eigen_api_public_contract_requests_total counter\n"
@@ -279,12 +283,16 @@ def append_security_audit_event(event: dict[str, object]) -> None:
     record = json.dumps(event, sort_keys=True, separators=(",", ":"))
     line = record + "\n"
     sink_path = _audit_sink_path()
-    with _AUDIT_LOCK:
-        os.makedirs(os.path.dirname(sink_path), exist_ok=True)
-        with open(sink_path, "a", encoding="utf-8") as fh:
-            fh.write(line)
-            fh.flush()
-            os.fsync(fh.fileno())
+    try:
+        with _AUDIT_LOCK:
+            os.makedirs(os.path.dirname(sink_path), exist_ok=True)
+            with open(sink_path, "a", encoding="utf-8") as fh:
+                fh.write(line)
+                fh.flush()
+                os.fsync(fh.fileno())
+    except Exception:
+        record_security_audit_write_failure()
+        raise
     _AUDIT_LOG.info("security_audit", extra=event)
 
 
@@ -365,6 +373,11 @@ def log_authz_denied(*, method: str, subject: str, permission: str, job_id: str 
             "job_id": job_id,
         },
     )
+
+
+def record_security_audit_write_failure() -> None:
+    with _MetricsState.lock:
+        _MetricsState.security_audit_write_failures_total += 1
 
 
 def record_submit_job_outcome(outcome: str) -> None:

--- a/src/services/system-api/tests/test_observability_smoke.py
+++ b/src/services/system-api/tests/test_observability_smoke.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import socket
 import urllib.request
 
+import pytest
+
 from system_api.grpc_impl import JobService
 from system_api.observability import (
     _MetricsState,
+    append_security_audit_event,
     record_kb_contract_marker,
     record_kb_fallback,
     record_kb_learning_failure,
@@ -83,6 +86,10 @@ def _reset_kb_metrics() -> None:
     }
 
 
+def _reset_security_audit_metrics() -> None:
+    _MetricsState.security_audit_write_failures_total = 0
+
+
 def test_metrics_endpoint_exposes_prometheus_payload():
     port = _free_port()
     _MetricsState.requests_total = 3
@@ -106,6 +113,7 @@ def test_metrics_endpoint_exposes_prometheus_payload():
         ("unsupported", "error"): 0,
     }
     _reset_kb_metrics()
+    _reset_security_audit_metrics()
     record_kb_query("records", hit=True)
     record_kb_query("decision_logs", hit=False)
     record_kb_fallback("storage_unavailable")
@@ -113,6 +121,7 @@ def test_metrics_endpoint_exposes_prometheus_payload():
     record_kb_learning_failure("dataset_assembly")
     record_kb_replay_failure()
     record_kb_contract_marker("1.0.0", "accepted")
+    _MetricsState.security_audit_write_failures_total = 2
     server = start_metrics_server(port)
     try:
         body = urllib.request.urlopen(f"http://127.0.0.1:{port}/metrics", timeout=2).read().decode()
@@ -136,6 +145,36 @@ def test_metrics_endpoint_exposes_prometheus_payload():
     assert 'eigen_kb_learning_failures_total{reason="dataset_assembly"} 1' in body
     assert 'eigen_kb_replay_failures_total 1' in body
     assert 'eigen_kb_contract_requests_total{contract_version="1.0.0",outcome="accepted"} 1' in body
+    assert 'eigen_security_audit_write_failures_total{sink="file"} 2' in body
+
+
+def test_security_audit_write_failures_increment_bounded_metric(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reset_security_audit_metrics()
+
+    def failing_open(*args, **kwargs):
+        raise OSError("audit sink unavailable")
+
+    monkeypatch.setenv("SYSTEM_API_AUDIT_SINK_PATH", "/tmp/system-api/audit.jsonl")
+    monkeypatch.setattr("builtins.open", failing_open)
+
+    with pytest.raises(OSError):
+        append_security_audit_event(
+            {
+                "method": "authz",
+                "decision": "deny",
+                "reason": "POLICY_BACKEND_UNAVAILABLE",
+                "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+                "subject": "audit-user",
+                "roles": "readonly",
+                "auth_mode": "static_token",
+                "policy_version": "1.0.0",
+                "service_identity": "system-api",
+                "sandbox_profile": "restricted",
+                "replay_marker": "replay-marker-123",
+            }
+        )
+
+    assert _MetricsState.security_audit_write_failures_total == 1
 
 
 def test_public_contract_marker_uses_bounded_labels_and_contract_version():

--- a/src/services/system-api/tests/test_security_baseline.py
+++ b/src/services/system-api/tests/test_security_baseline.py
@@ -222,12 +222,32 @@ def test_expired_jwt_token_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_security_audit_sink_persists_and_sanitizes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     audit_path = tmp_path / "audit.jsonl"
+    policy_snapshot = {
+        "version": "1.0.0",
+        "issuer": "eigen-auth",
+        "audience": "eigen-api",
+        "role_permissions": {
+            "readonly": ["devices:list", "jobs:read"],
+            "user": ["devices:list", "jobs:read"],
+        },
+        "service_permissions": {
+            "system-api": ["public-ingress"],
+        },
+        "sandbox_profiles": ["default", "restricted"],
+    }
     monkeypatch.setenv("SYSTEM_API_AUDIT_SINK_PATH", str(audit_path))
     monkeypatch.setenv("SYSTEM_API_AUTH_MODE", "static_token")
     monkeypatch.setenv("SYSTEM_API_AUTH_TOKEN", "audit-token")
     monkeypatch.setenv("SYSTEM_API_AUTH_SUBJECT", "audit-user")
     monkeypatch.setenv("SYSTEM_API_AUTH_TENANT", "audit-tenant")
     monkeypatch.setenv("SYSTEM_API_AUTH_ROLES", "readonly")
+    monkeypatch.setenv("SYSTEM_API_SERVICE_IDENTITY", "system-api")
+    monkeypatch.setenv("SYSTEM_API_SERVICE_ROLE", "public-ingress")
+    monkeypatch.setenv("SYSTEM_API_SANDBOX_PROFILE", "restricted")
+    monkeypatch.setenv("SYSTEM_API_POLICY_SNAPSHOT_JSON", json.dumps(policy_snapshot))
+
+    traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+    replay_marker = "replay-marker-123"
 
     addr = f"127.0.0.1:{_free_port()}"
     server = serve(bind=addr)
@@ -235,16 +255,33 @@ def test_security_audit_sink_persists_and_sanitizes(monkeypatch: pytest.MonkeyPa
     try:
         channel = grpc.insecure_channel(addr)
         job_stub = job_pb_grpc.JobServiceStub(channel)
-        md = (("authorization", "Bearer audit-token"),)
+        dev_stub = dev_pb_grpc.DeviceServiceStub(channel)
+        md = (
+            ("authorization", "Bearer audit-token"),
+            ("traceparent", traceparent),
+            ("x-eigen-replay-marker", replay_marker),
+            ("x-eigen-service", "system-api"),
+            ("x-eigen-service-role", "public-ingress"),
+        )
+
+        dev_stub.ListDevices(dev_pb.ListDevicesRequest(), metadata=md)
         with pytest.raises(grpc.RpcError):
             job_stub.CancelJob(job_pb.CancelJobRequest(job_id="job_123"), metadata=md)
         assert audit_path.exists()
         body = audit_path.read_text(encoding="utf-8").strip().splitlines()
-        assert body
-        audit = json.loads(body[-1])
-        assert audit["decision"] == "deny"
-        assert audit["subject"] == "audit-user"
-        assert audit["trace_id"] == "" or "trace_id" in audit
+        assert len(body) >= 2
+        audits = [json.loads(line) for line in body[-2:]]
+
+        decisions = {entry["decision"] for entry in audits}
+        assert decisions == {"allow", "deny"}
+        for audit in audits:
+            assert audit["subject"] == "audit-user"
+            assert audit["policy_version"] == "1.0.0"
+            assert audit["service_identity"] == "system-api"
+            assert audit["sandbox_profile"] == "restricted"
+            assert audit["replay_marker"] == replay_marker
+            assert audit["trace_id"] == "4bf92f3577b34da6a3ce929d0e0e4736"
+            assert "Bearer audit-token" not in json.dumps(audit)
         assert "Bearer audit-token" not in audit_path.read_text(encoding="utf-8")
     finally:
         server.stop(grace=None)


### PR DESCRIPTION
## Summary

Implemented the canonical append-only security audit sink evidence path for Wave 9, including bounded audit-write-failure telemetry, replayable allow/deny audit records, and operator-facing documentation for the audit trail and telemetry contract.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: Security audit sink | Observability metrics | Trace context | Wave 9 docs and evidence package
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Bounded security audit write-failure telemetry.
- Replayable security audit evidence for allow/deny decisions.
- Wave 9 documentation updates describing the canonical audit sink and audit evidence path.

### Changed
- Security audit records now explicitly support replay review with policy version and trace correlation.
- Security telemetry documentation now includes the audit pipeline health counter.

### Fixed
- Audit sink write failures no longer disappear silently.
- Wave 9 audit evidence is now documented and test-backed end to end.