### PR TITLE
Implemented scoped OKB candidate retrieval

### DIFF
--- a/docs/architecture/components/knowledge-base.md
+++ b/docs/architecture/components/knowledge-base.md
@@ -1,1 +1,135 @@
-PLACEHOLDER
+**Contract version:** 1.0.0  
+**Status:** Target architecture contract for deterministic OKB candidate retrieval  
+**Applies to:** `KnowledgeBaseService` similarity search, replay tooling, and optimizer reuse selection
+
+## 1. Scope
+
+The Knowledge Base exposes two distinct behaviors:
+
+1. **Public record storage** — CRUD/query for KB records and decision logs.
+2. **Optimization Knowledge Base (OKB) candidate retrieval** — deterministic reuse selection for optimizer/compiler workflows.
+
+This document defines the OKB retrieval semantics only.
+
+## 2. Similarity query definition
+
+A similarity query is a **deterministic ranking query over a scoped candidate pool**.
+
+Every query MUST be scoped by:
+
+- `tenant_id`
+- `project_id`
+
+The retrieval backend MUST NOT mix candidates across tenant or project boundaries.
+
+### Supported modes
+
+- `structural`: rank by structural compatibility.
+- `vector`: rank by deterministic vector-similarity surrogate.
+- `hybrid`: rank by a combined score derived from structural and vector scores.
+
+## 3. Candidate pool
+
+The candidate pool is bounded and deterministic.
+
+The backend MAY derive candidates from:
+
+- benchmark records,
+- runtime decision logs,
+- other replay-safe KB artifacts that are in the same tenant/project scope.
+
+The pool MUST be filtered before scoring. Cross-scope data MUST NOT be considered.
+
+## 4. Rank source of truth
+
+The final ranking score is `score_total`.
+
+Per mode:
+
+- `structural`: `score_total = structural_score`
+- `vector`: `score_total = vector_score`
+- `hybrid`: `score_total = round((structural_score * 0.6) + (vector_score * 0.4), 6)`
+
+The secondary ordering key is `confidence`.
+
+The final tiebreaker is `candidate_id` in ascending lexical order.
+
+### Score bounds
+
+- `structural_score`: `0.0..1.0`
+- `vector_score`: `0.0..1.0`
+- `confidence`: `0.0..1.0`
+- `score_total`: `0.0..1.0`
+
+## 5. Cardinality and replay
+
+The candidate budget is bounded.
+
+- `candidate_budget` is clamped to a maximum of `8`.
+- Returned candidates MUST be truncated to the final budget.
+- No pagination or streaming is used for this retrieval path.
+
+Deterministic replay requires that the same normalized query input returns the same ordered candidate list.
+
+## 6. Required deterministic inputs
+
+A normalized query MUST include:
+
+- `tenant_id`
+- `project_id`
+- `semantic_hash`
+- `aqo_hash`
+- `backend_profile_id`
+- `topology_snapshot_digest`
+- `policy_envelope_digest`
+- `kb_schema_version`
+- `compiler_version`
+- `optimizer_version`
+- `seed`
+- `deterministic`
+- `query_mode`
+- `candidate_budget`
+
+## 7. Contracted output fields
+
+Returned candidates MUST include:
+
+- `candidate_id`
+- `candidate_source`
+- `optimization_type`
+- `transformation_ref`
+- `provenance_ref`
+- `compatibility_window`
+- `deterministic_digest`
+- `explanation_ref`
+- `selection_reason`
+- `confidence`
+- `score_breakdown`
+- `score_total`
+- `selected`
+- `metadata`
+
+The output MUST also include:
+
+- `tenant_id`
+- `project_id`
+- `candidate_budget`
+- `selected_candidate_id`
+- `okb_selection_digest`
+
+## 8. Stable tie-breaking
+
+If two or more candidates share the same `score_total` and `confidence`, the backend MUST sort by `candidate_id` ascending.
+
+This guarantees replay-stable ordering when the normalized input is unchanged.
+
+## 9. Compatibility notes
+
+This contract is backward-compatible with the existing in-memory KB baseline because:
+
+- the candidate pool remains bounded,
+- the ranking remains deterministic,
+- the scope filter is stricter, not looser,
+- the output is additive.
+
+Any caller that does not provide tenant/project scope is invalid for similarity retrieval.

--- a/docs/reference/api/grpc-internal.md
+++ b/docs/reference/api/grpc-internal.md
@@ -507,6 +507,39 @@ service KnowledgeBaseService {
 
 ---
 
+#### SearchSimilar semantics
+
+`SearchSimilar` is a deterministic scoped similarity query.
+
+Required request semantics:
+
+- `tenant_id` and `project_id` MUST be present.
+- `query_mode` MUST be one of `structural`, `vector`, or `hybrid`.
+- `candidate_budget` MUST be clamped to the service maximum of `8`.
+- `deterministic=true` MUST replay to the same ordered results.
+
+Ranking semantics:
+
+- `structural`: final rank uses the structural score.
+- `vector`: final rank uses the vector score.
+- `hybrid`: final rank uses the combined score.
+- tie-breakers: `confidence` desc, then `candidate_id` asc.
+
+Scope semantics:
+
+- candidates MUST be filtered by tenant/project before scoring,
+- cross-tenant/project retrieval is forbidden.
+
+Returned responses MUST expose:
+
+- `tenant_id`
+- `project_id`
+- `candidate_budget`
+- `selected_candidate_id`
+- `okb_selection_digest`
+
+---
+
 ## 6. Common Types
 
 Canonical shared types include:

--- a/src/services/system-api/src/system_api/knowledge_base.py
+++ b/src/services/system-api/src/system_api/knowledge_base.py
@@ -124,6 +124,8 @@ class _OptimizationCandidate:
     explanation_ref: str
     selection_reason: str
     confidence: float
+    structural_score: float
+    vector_score: float
     score_total: float
     selected: bool
     metadata: dict[str, str]
@@ -361,7 +363,7 @@ class KnowledgeBaseService:
     # Ingestion helpers --------------------------------------------------
 
     def query_optimization_candidates(self, payload: dict[str, Any]) -> dict[str, Any]:
-        """Deterministic OKB query backend for structural/vector reuse selection."""
+        """Deterministic OKB query backend for scoped structural/vector/hybrid reuse selection."""
         if self._storage_mode == "disabled":
             raise KnowledgeBaseUnavailable("knowledge base storage unavailable")
 
@@ -388,6 +390,11 @@ class KnowledgeBaseService:
                 "explanation_ref": item.explanation_ref,
                 "selection_reason": item.selection_reason,
                 "confidence": item.confidence,
+                "score_breakdown": {
+                    "structural_score": item.structural_score,
+                    "vector_score": item.vector_score,
+                    "rank_source": item.metadata["rank_source"],
+                },
                 "score_total": item.score_total,
                 "selected": item.candidate_id == selected_candidate_id,
                 "metadata": item.metadata,
@@ -398,6 +405,8 @@ class KnowledgeBaseService:
         digest = _stable_hash(
             {
                 "query": {
+                    "tenant_id": query["tenant_id"],
+                    "project_id": query["project_id"],
                     "semantic_hash": query["semantic_hash"],
                     "aqo_hash": query["aqo_hash"],
                     "backend_profile_id": query["backend_profile_id"],
@@ -408,6 +417,8 @@ class KnowledgeBaseService:
                     "optimizer_version": query["optimizer_version"],
                     "seed": query["seed"],
                     "query_mode": query["query_mode"],
+                    "candidate_budget": query["candidate_budget"],
+                    "deterministic": query["deterministic"],
                 },
                 "selected_candidate_id": selected_candidate_id,
                 "candidate_ids": [item["candidate_id"] for item in selected_payload],
@@ -415,6 +426,8 @@ class KnowledgeBaseService:
         )
 
         return {
+            "tenant_id": query["tenant_id"],
+            "project_id": query["project_id"],
             "query_mode": query["query_mode"],
             "deterministic": query["deterministic"],
             "candidate_budget": query["candidate_budget"],
@@ -854,14 +867,21 @@ class KnowledgeBaseService:
 
 
     def _normalize_okb_query(self, payload: dict[str, Any]) -> dict[str, Any]:
+        tenant_id = str(payload.get("tenant_id", "")).strip()
+        project_id = str(payload.get("project_id", "")).strip()
+        if not tenant_id or not project_id:
+            raise ValueError("tenant_id and project_id are required")
+
         query_mode = str(payload.get("query_mode", "structural")).strip().lower() or "structural"
-        if query_mode not in _OKB_QUERY_MODES:
-            query_mode = "structural"
+        if query_mode not in {"structural", "vector", "hybrid"}:
+            raise ValueError("query_mode must be structural, vector, or hybrid")
 
         candidate_budget = max(1, min(int(payload.get("candidate_budget", 1) or 1), _OKB_MAX_CANDIDATES))
         seed = int(payload.get("seed", 0) or 0)
 
         return {
+            "tenant_id": tenant_id,
+            "project_id": project_id,
             "job_id": str(payload.get("job_id", "")).strip(),
             "semantic_hash": str(payload.get("semantic_hash", "")).strip(),
             "aqo_hash": str(payload.get("aqo_hash", "")).strip(),
@@ -881,9 +901,13 @@ class KnowledgeBaseService:
         pool: list[_OptimizationCandidate] = []
 
         for entry in self._records.values():
+            if entry.tenant_id != query["tenant_id"] or entry.project_id != query["project_id"]:
+                continue
             pool.append(self._candidate_from_record(entry, query))
 
         for entry in self._decision_logs:
+            if entry.tenant_id != query["tenant_id"] or entry.project_id != query["project_id"]:
+                continue
             pool.append(self._candidate_from_decision_log(entry, query))
 
         return [candidate for candidate in pool if candidate.score_total > 0.0]
@@ -898,12 +922,14 @@ class KnowledgeBaseService:
             "optimizer_version": entry.record.optimizer_version,
             "trace_id": entry.record.attributes.get("trace_id", ""),
             "lineage_model_version": getattr(getattr(entry.record, "lineage", None), "model_version", ""),
+            "artifact_ref": entry.record.artifact_ref,
+            "provenance_ref": entry.record.provenance.compiler_ref,
             "query": query,
         }
         return self._build_candidate(
             candidate_id=candidate_id,
             candidate_source="record",
-            optimization_type="structural-reuse" if query["query_mode"] == "structural" else "vector-reuse",
+            optimization_type="structural-reuse" if query["query_mode"] != "vector" else "vector-reuse",
             transformation_ref=entry.record.artifact_ref or entry.record.record_id,
             provenance_ref=entry.record.provenance.compiler_ref or entry.record.record_id,
             compatibility_window=compatibility_window,
@@ -955,11 +981,12 @@ class KnowledgeBaseService:
     ) -> _OptimizationCandidate:
         signature = _stable_hash(
             {
-                "candidate_id": candidate_id,
                 "candidate_source": candidate_source,
                 "optimization_type": optimization_type,
                 "basis": basis,
                 "query": {
+                    "tenant_id": query["tenant_id"],
+                    "project_id": query["project_id"],
                     "semantic_hash": query["semantic_hash"],
                     "aqo_hash": query["aqo_hash"],
                     "backend_profile_id": query["backend_profile_id"],
@@ -971,13 +998,53 @@ class KnowledgeBaseService:
                 },
             }
         )
-        score_total = self._score_from_signature(signature, query["query_mode"])
-        confidence = self._confidence_from_signature(signature, query["query_mode"])
+        score_basis = {
+            key: value
+            for key, value in basis.items()
+            if key not in {"record_id", "decision_id"}
+        }
+        score_signature = _stable_hash(
+            {
+                "candidate_source": candidate_source,
+                "optimization_type": optimization_type,
+                "basis": score_basis,
+                "query": {
+                    "tenant_id": query["tenant_id"],
+                    "project_id": query["project_id"],
+                    "semantic_hash": query["semantic_hash"],
+                    "aqo_hash": query["aqo_hash"],
+                    "backend_profile_id": query["backend_profile_id"],
+                    "topology_snapshot_digest": query["topology_snapshot_digest"],
+                    "policy_envelope_digest": query["policy_envelope_digest"],
+                    "seed": query["seed"],
+                    "query_mode": query["query_mode"],
+                    "deterministic": query["deterministic"],
+                },
+            }
+        )
+
+        structural_score = self._structural_score(basis, query, compatibility_window)
+        vector_score = self._vector_score(score_signature)
+        if query["query_mode"] == "vector":
+            score_total = vector_score
+            rank_source = "vector"
+        elif query["query_mode"] == "hybrid":
+            score_total = round((structural_score * 0.6) + (vector_score * 0.4), 6)
+            rank_source = "hybrid"
+        else:
+            score_total = structural_score
+            rank_source = "structural"
+
+        confidence = round((structural_score + vector_score) / 2.0, 6)
         metadata = {
             "query_mode": query["query_mode"],
+            "ranking_mode": rank_source,
+            "rank_source": rank_source,
             "kb_schema_version": query["kb_schema_version"],
             "compiler_version": query["compiler_version"],
             "optimizer_version": query["optimizer_version"],
+            "tenant_id": query["tenant_id"],
+            "project_id": query["project_id"],
         }
         return _OptimizationCandidate(
             candidate_id=candidate_id,
@@ -990,17 +1057,33 @@ class KnowledgeBaseService:
             explanation_ref=explanation_ref,
             selection_reason=selection_reason,
             confidence=confidence,
+            structural_score=structural_score,
+            vector_score=vector_score,
             score_total=score_total,
             selected=False,
             metadata=metadata,
         )
 
-    def _score_from_signature(self, signature: str, query_mode: str) -> float:
+    def _structural_score(self, basis: dict[str, Any], query: dict[str, Any], compatibility_window: str) -> float:
+        candidate_backend = str(
+            basis.get("backend_profile")
+            or basis.get("selected_action")
+            or ""
+        ).strip()
+        candidate_optimizer = str(
+            basis.get("optimizer_version")
+            or basis.get("model_version")
+            or ""
+        ).strip()
+        backend_match = 1.0 if candidate_backend and candidate_backend == query["backend_profile_id"] else 0.0
+        optimizer_match = 1.0 if candidate_optimizer and candidate_optimizer == query["optimizer_version"] else 0.0
+        compatibility_match = 1.0 if compatibility_window == f"{query['optimizer_version']}::{query['backend_profile_id']}" else 0.0
+        return round((backend_match * 0.45) + (optimizer_match * 0.35) + (compatibility_match * 0.20), 6)
+
+    def _vector_score(self, signature: str) -> float:
         raw = int(signature.removeprefix("sha256:")[:16], 16)
         base = raw / float(0xFFFFFFFFFFFFFFFF)
-        if query_mode == "structural":
-            return round(0.55 + (base * 0.4), 6)
-        return round(0.45 + (base * 0.5), 6)
+        return round(0.25 + (base * 0.75), 6)
 
     def _confidence_from_signature(self, signature: str, query_mode: str) -> float:
         raw = int(signature.removeprefix("sha256:")[16:32], 16)

--- a/src/services/system-api/tests/test_knowledge_base_service.py
+++ b/src/services/system-api/tests/test_knowledge_base_service.py
@@ -75,6 +75,48 @@ def _record(record_id: str, *, created_at: str, trace_id: str, user_id: str) -> 
     )
 
 
+def _okb_benchmark_payload(
+    record_id: str,
+    *,
+    tenant_id: str,
+    project_id: str,
+    trace_id: str,
+    backend_profile: str = "backend-alpha",
+    optimizer_version: str = "opt-1.0",
+) -> dict[str, object]:
+    return {
+        "record_id": record_id,
+        "run_id": f"run-{record_id}",
+        "job_id": f"job-{record_id}",
+        "trace_id": trace_id,
+        "tenant_id": tenant_id,
+        "project_id": project_id,
+        "request_hash": f"sha256:{record_id}",
+        "backend_profile": backend_profile,
+        "optimizer_version": optimizer_version,
+        "circuit_id": "circuit-shared",
+        "artifact_ref": "qfs://artifacts/shared-reuse",
+        "dataset_ref": "dataset-shared",
+        "qubit_count": 12,
+        "entanglement_score": 0.44,
+        "noise_profile_id": "noise-shared",
+        "backend_class": "simulator",
+        "provenance": {
+            "compiler_ref": "compiler://shared",
+            "optimizer_ref": "optimizer://shared",
+            "runtime_ref": "runtime://shared",
+            "checkpoint_ref": "checkpoint://shared",
+        },
+        "lineage": {
+            "model_version": "m1",
+            "training_set_hash": "train-hash",
+            "evaluation_bundle_hash": "eval-hash",
+            "promotion_policy_version": "policy-v1",
+            "promotion_outcome": "PROMOTED",
+        },
+    }
+
+
 def test_upsert_query_replay_and_provenance_are_deterministic(grpc_addr: str) -> None:
     channel = grpc.insecure_channel(grpc_addr)
     stub = kb_pb_grpc.KnowledgeBaseServiceStub(channel)
@@ -276,54 +318,30 @@ def test_kb_fallback_behavior_raises_when_storage_disabled() -> None:
 def test_okb_query_backend_is_deterministic_and_bounded() -> None:
     service = KnowledgeBaseService(kb_pb=kb_pb, types_pb=types_pb)
 
+    for i in range(10):
+        service.ingest_benchmark_run(
+            _okb_benchmark_payload(
+                f"candidate-{i:02d}",
+                tenant_id="tenant-a",
+                project_id="project-a",
+                trace_id="trace-okb",
+            )
+        )
+
     service.ingest_benchmark_run(
-        {
-            "record_id": "okb-record-1",
-            "run_id": "run-1",
-            "job_id": "job-1",
-            "trace_id": "trace-okb",
-            "tenant_id": "tenant-a",
-            "project_id": "project-a",
-            "request_hash": "sha256:record-1",
-            "backend_profile": "backend-alpha",
-            "optimizer_version": "opt-1.0",
-            "circuit_id": "circuit-1",
-            "artifact_ref": "qfs://artifacts/okb-record-1",
-            "dataset_ref": "dataset-v1",
-            "qubit_count": 12,
-            "entanglement_score": 0.44,
-            "noise_profile_id": "noise-1",
-            "backend_class": "simulator",
-            "provenance": {
-                "compiler_ref": "compiler://v1",
-                "optimizer_ref": "optimizer://v1",
-                "runtime_ref": "runtime://v1",
-                "checkpoint_ref": "checkpoint://v1",
-            },
-            "lineage": {
-                "model_version": "m1",
-                "training_set_hash": "train-hash",
-                "evaluation_bundle_hash": "eval-hash",
-                "promotion_policy_version": "policy-v1",
-                "promotion_outcome": "PROMOTED",
-            },
-        }
-    )
-    service.ingest_runtime_decision(
-        {
-            "decision_id": "okb-decision-1",
-            "trace_id": "trace-okb",
-            "model_version": "m1",
-            "component": "runtime",
-            "policy_branch": "baseline",
-            "selected_action": "backend-alpha",
-            "feature_snapshot": {"queue_depth": "2"},
-            "backend_profile_id": "backend-alpha",
-            "optimizer_version": "opt-1.0",
-        }
+        _okb_benchmark_payload(
+            "foreign-candidate",
+            tenant_id="tenant-b",
+            project_id="project-b",
+            trace_id="trace-foreign",
+            backend_profile="backend-foreign",
+            optimizer_version="opt-foreign",
+        )
     )
 
     query = {
+        "tenant_id": "tenant-a",
+        "project_id": "project-a",
         "job_id": "job-1",
         "semantic_hash": "sha256:semantic-1",
         "aqo_hash": "sha256:aqo-1",
@@ -336,26 +354,51 @@ def test_okb_query_backend_is_deterministic_and_bounded() -> None:
         "seed": 7,
         "deterministic": True,
         "query_mode": "structural",
-        "candidate_budget": 2,
+        "candidate_budget": 99,
     }
 
     first = service.query_optimization_candidates(query)
     second = service.query_optimization_candidates(query)
 
     assert first == second
+    assert first["tenant_id"] == "tenant-a"
+    assert first["project_id"] == "project-a"
     assert first["query_mode"] == "structural"
-    assert first["candidate_budget"] == 2
+    assert first["candidate_budget"] == 8
+    assert len(first["candidates"]) == 8
     assert first["selected_candidate_id"] == first["candidates"][0]["candidate_id"]
-    assert len(first["candidates"]) <= 2
-    assert 0.0 <= first["candidates"][0]["confidence"] <= 1.0
-    assert 0.0 <= first["candidates"][0]["score_total"] <= 1.0
+    assert [item["candidate_id"] for item in first["candidates"]] == [
+        "okb-record-candidate-00",
+        "okb-record-candidate-01",
+        "okb-record-candidate-02",
+        "okb-record-candidate-03",
+        "okb-record-candidate-04",
+        "okb-record-candidate-05",
+        "okb-record-candidate-06",
+        "okb-record-candidate-07",
+    ]
+    assert all(item["candidate_source"] == "record" for item in first["candidates"])
+    assert all(item["score_breakdown"]["rank_source"] == "structural" for item in first["candidates"])
+    assert all(item["score_breakdown"]["structural_score"] == 1.0 for item in first["candidates"])
+    assert len({item["score_breakdown"]["vector_score"] for item in first["candidates"]}) == 1
+    assert all("foreign-candidate" not in item["candidate_id"] for item in first["candidates"])
+    assert all(0.0 <= item["confidence"] <= 1.0 for item in first["candidates"])
+    assert all(0.0 <= item["score_total"] <= 1.0 for item in first["candidates"])
     assert first["candidates"][0]["deterministic_digest"].startswith("sha256:")
     assert first["okb_selection_digest"].startswith("sha256:")
     assert first["explanation_ref"] == "qfs://jobs/job-1/kb/explain.json"
 
-    vector = service.query_optimization_candidates({**query, "query_mode": "vector"})
+    vector = service.query_optimization_candidates({**query, "query_mode": "vector", "candidate_budget": 2})
     assert vector["query_mode"] == "vector"
+    assert vector["candidate_budget"] == 2
     assert vector["selected_candidate_id"] == vector["candidates"][0]["candidate_id"]
-    assert len(vector["candidates"]) <= 2
-    assert vector["okb_selection_digest"].startswith("sha256:")
+    assert vector["candidates"][0]["score_breakdown"]["rank_source"] == "vector"
+    assert len(vector["candidates"]) == 2
+
+    hybrid = service.query_optimization_candidates({**query, "query_mode": "hybrid", "candidate_budget": 3})
+    assert hybrid["query_mode"] == "hybrid"
+    assert hybrid["candidate_budget"] == 3
+    assert hybrid["selected_candidate_id"] == hybrid["candidates"][0]["candidate_id"]
+    assert hybrid["candidates"][0]["score_breakdown"]["rank_source"] == "hybrid"
+    assert len(hybrid["candidates"]) == 3
     


### PR DESCRIPTION
## Summary

- Implemented scoped OKB candidate retrieval in src/services/system-api/src/system_api/knowledge_base.py.
- Retrieval now requires tenant_id and project_id, filters candidates before scoring, supports structural, vector, and hybrid modes, and uses stable ordering: score_total → confidence → candidate_id.
- Added explicit score breakdown metadata and enforced the candidate budget cap.
- Updated tests to cover deterministic replay, tenant/project isolation, stable tie-breaking, and budget enforcement.
- Replaced the placeholder architecture doc and updated the internal gRPC reference contract with the new SearchSimilar semantics.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MAJOR
- **Affected Interfaces**: API
- **Compatibility**: Breaking
- **Breaking Marker**: true
- **Migration Notes**: SearchSimilar / OKB callers must provide tenant_id and project_id. Ranking is now explicit per mode (structural, vector, hybrid), with score_total as the primary rank source, confidence as the secondary key, and candidate_id as the final tiebreaker.

## Release Notes Draft

### Added
- Tenant/project-scoped deterministic OKB candidate retrieval.
- Explicit structural, vector, and hybrid ranking semantics.
- Candidate score breakdown metadata for replay and debugging.

### Changed
- Ranking order is now formally defined and stable.
- Candidate retrieval enforces tenant/project filtering before scoring.
- Candidate budget is clamped to the service maximum of 8.

### Fixed
- Cross-tenant/project leakage in similarity retrieval.
- Undocumented and unstable candidate ordering behavior.