### PR TITLE
Implemented a dedicated GetPattern flow for the KB

### DIFF
--- a/docs/architecture/components/knowledge-base.md
+++ b/docs/architecture/components/knowledge-base.md
@@ -1,19 +1,35 @@
+# Knowledge Base: canonical patterns and candidate retrieval
+
 **Contract version:** 1.0.0  
-**Status:** Target architecture contract for deterministic OKB candidate retrieval  
-**Applies to:** `KnowledgeBaseService` similarity search, replay tooling, and optimizer reuse selection
+**Status:** Target architecture contract for deterministic KB reuse and canonical pattern selection  
+**Applies to:** `KnowledgeBaseService` similarity search, canonical pattern retrieval, replay tooling, and optimizer reuse selection
 
 ## 1. Scope
 
 The Knowledge Base exposes two distinct behaviors:
 
 1. **Public record storage** — CRUD/query for KB records and decision logs.
-2. **Optimization Knowledge Base (OKB) candidate retrieval** — deterministic reuse selection for optimizer/compiler workflows.
+2. **Optimization Knowledge Base (OKB) retrieval** — deterministic reuse selection for compiler / AQO workflows.
 
-This document defines the OKB retrieval semantics only.
+This document defines the retrieval semantics for both candidate similarity search and canonical pattern lookup.
 
-## 2. Similarity query definition
+## 2. Retrieval primitives
 
-A similarity query is a **deterministic ranking query over a scoped candidate pool**.
+### Candidate pattern
+
+A candidate pattern is a historical, replay-safe pattern extracted from KB artifacts. Candidate patterns may be similar to the current request, but they are not canonical by default.
+
+### Canonical pattern
+
+A canonical pattern is the single template selected by `GetPattern` when the request compatibility window matches exactly. The canonical pattern is deterministic and machine-verifiable.
+
+### Explanation pattern
+
+An explanation pattern is a bounded diagnostic envelope that explains why a canonical pattern was selected or why no canonical pattern was available.
+
+## 3. Similarity query definition
+
+A similarity query is a deterministic ranking query over a scoped candidate pool.
 
 Every query MUST be scoped by:
 
@@ -24,11 +40,11 @@ The retrieval backend MUST NOT mix candidates across tenant or project boundarie
 
 ### Supported modes
 
-- `structural`: rank by structural compatibility.
+- `structural`: rank by structural compatibility and support.
 - `vector`: rank by deterministic vector-similarity surrogate.
 - `hybrid`: rank by a combined score derived from structural and vector scores.
 
-## 3. Candidate pool
+## 4. Candidate pool
 
 The candidate pool is bounded and deterministic.
 
@@ -40,9 +56,9 @@ The backend MAY derive candidates from:
 
 The pool MUST be filtered before scoring. Cross-scope data MUST NOT be considered.
 
-## 4. Rank source of truth
+## 5. Rank source of truth
 
-The final ranking score is `score_total`.
+For candidate retrieval, the final ranking score is `score_total`.
 
 Per mode:
 
@@ -61,7 +77,42 @@ The final tiebreaker is `candidate_id` in ascending lexical order.
 - `confidence`: `0.0..1.0`
 - `score_total`: `0.0..1.0`
 
-## 5. Cardinality and replay
+## 6. Canonical pattern selection (`GetPattern`)
+
+`GetPattern` returns a canonical template, not just a similar historical object.
+
+The canonical pattern MUST satisfy the exact compatibility window for the request:
+
+- `schema_version`
+- `compiler_version`
+- `aqo_version`
+- `optimizer_version`
+- `policy_mode`
+- `policy_digest`
+
+Compatibility metadata MUST be machine-verifiable by exact string equality and a deterministic `compatibility_signature` hash over the normalized compatibility window.
+
+### Canonical selection rule
+
+Among compatible candidates, the canonical pattern is selected deterministically using:
+
+1. `support` descending,
+2. `pattern_family` ascending,
+3. `pattern_id` ascending.
+
+This rule is independent from candidate similarity scoring.
+
+### Incompatibility reason codes
+
+When a pattern is not canonical-eligible, the backend MUST report deterministic reason codes:
+
+- `SCHEMA_MISMATCH`
+- `COMPILER_MISMATCH`
+- `AQO_MISMATCH`
+- `OPTIMIZER_MISMATCH`
+- `POLICY_MISMATCH`
+
+## 7. Cardinality and replay
 
 The candidate budget is bounded.
 
@@ -69,67 +120,71 @@ The candidate budget is bounded.
 - Returned candidates MUST be truncated to the final budget.
 - No pagination or streaming is used for this retrieval path.
 
-Deterministic replay requires that the same normalized query input returns the same ordered candidate list.
+Deterministic replay requires that the same normalized query input returns the same ordered candidate list and the same canonical selection.
 
-## 6. Required deterministic inputs
+## 8. Required deterministic inputs
 
 A normalized query MUST include:
 
 - `tenant_id`
 - `project_id`
+- `snapshot_id`
+- `circuit_id`
+- `backend_class`
 - `semantic_hash`
 - `aqo_hash`
-- `backend_profile_id`
-- `topology_snapshot_digest`
-- `policy_envelope_digest`
-- `kb_schema_version`
+- `schema_version`
 - `compiler_version`
+- `aqo_version`
 - `optimizer_version`
+- `policy_mode`
+- `policy_digest`
 - `seed`
 - `deterministic`
 - `query_mode`
 - `candidate_budget`
 
-## 7. Contracted output fields
+## 9. Contracted output fields
 
-Returned candidates MUST include:
+Returned candidate patterns MUST include:
 
-- `candidate_id`
-- `candidate_source`
-- `optimization_type`
-- `transformation_ref`
-- `provenance_ref`
+- `pattern_id`
+- `pattern_family`
+- `pattern_kind`
+- `circuit_id`
+- `backend_class`
+- `source_record_ids`
+- `support`
 - `compatibility_window`
-- `deterministic_digest`
-- `explanation_ref`
-- `selection_reason`
-- `confidence`
+- `compatibility_signature`
+- `canonical_eligible`
+- `selected`
+- `rank`
 - `score_breakdown`
 - `score_total`
-- `selected`
+- `confidence`
+- `incompatibility_reasons
 - `metadata`
 
-The output MUST also include:
+The canonical response MUST also include:
 
 - `tenant_id`
 - `project_id`
 - `candidate_budget`
-- `selected_candidate_id`
-- `okb_selection_digest`
+- `canonical_pattern_id`
+- `canonical_pattern`
+- `candidate_patterns`
+- `explanation_pattern`
+- `diagnostics`
 
-## 8. Stable tie-breaking
-
-If two or more candidates share the same `score_total` and `confidence`, the backend MUST sort by `candidate_id` ascending.
-
-This guarantees replay-stable ordering when the normalized input is unchanged.
-
-## 9. Compatibility notes
+## 10. Compatibility notes
 
 This contract is backward-compatible with the existing in-memory KB baseline because:
 
 - the candidate pool remains bounded,
 - the ranking remains deterministic,
 - the scope filter is stricter, not looser,
-- the output is additive.
+- the output is additive,
+- canonical lookup is separated from similarity lookup.
 
 Any caller that does not provide tenant/project scope is invalid for similarity retrieval.

--- a/docs/reference/api/grpc-internal.md
+++ b/docs/reference/api/grpc-internal.md
@@ -125,366 +125,49 @@ Acts as the internal bridge between:
 
 #### Service Definition
 
-```text
-service KernelGatewayService {
-    rpc EnqueueJob(EnqueueJobRequest)
-        returns (EnqueueJobResponse);
 
-    rpc GetJobStatus(GetJobStatusRequest)
-        returns (GetJobStatusResponse);
 
-    rpc CancelJob(CancelJobRequest)
-        returns (CancelJobResponse);
+#### GetPattern semantics
 
-    rpc GetJobResults(GetJobResultsRequest)
-        returns (GetJobResultsResponse);
+`GetPattern` returns a canonical template, not just a similar historical object.
 
-    rpc PollJobUpdates(PollJobUpdatesRequest)
-        returns (stream JobUpdateEvent);
-}
-```
+Required request semantics:
 
----
+- `tenant_id` and `project_id` MUST be present.
+- `snapshot_id`, `circuit_id`, and `backend_class` MUST be present.
+- `schema_version`, `compiler_version`, `aqo_version`, `optimizer_version`, `policy_mode`, and `policy_digest` MUST be present.
+- compatibility metadata MUST be machine-verifiable by exact string equality.
+- incompatible patterns MUST remain visible only as candidates or diagnostics, never as the canonical result.
 
-#### Required Semantics
+Canonical selection semantics:
 
-#### EnqueueJob
+- exact compatibility is the canonical eligibility gate,
+- among compatible candidates the canonical template is selected by `support` desc, `pattern_family` asc, then `pattern_id` asc,
+- canonical selection is independent from similarity scoring,
+- `GetPattern` MUST return a fallback/diagnostics envelope when no canonical template is found.
 
-Creates a new execution workflow.
+Incompatibility reason codes:
 
-MUST:
-- validate authorization,
-- assign deterministic `job_id`,
-- persist JobSpec,
-- enqueue into QRTX.
+- `SCHEMA_MISMATCH`
+- `COMPILER_MISMATCH`
+- `AQO_MISMATCH`
+- `OPTIMIZER_MISMATCH`
+- `POLICY_MISMATCH`
 
-#### GetJobStatus
+Returned responses MUST expose:
 
-Returns lifecycle state.
+- `tenant_id`
+- `project_id`
+- `candidate_budget`
+- `canonical_pattern_id`
+- `canonical_pattern`
+- `candidate_patterns`
+- `explanation_pattern`
+- `diagnostics`
 
-Canonical states:
-```text
-PENDING
-COMPILING
-QUEUED
-RUNNING
-DONE
-ERROR
-CANCELLED
-TIMEOUT
-```
-
-#### CancelJob
-
-MUST:
-
-- propagate cancellation to all downstream services,
-- cancel queued/running backend executions,
-- release qubit reservations,
-- update observability traces.
-
-#### PollJobUpdates
-
-Streaming API for incremental updates.
-
-Replaces polling loops.
-
-MUST support:
-
-- server streaming,
-- heartbeat events,
-- cancellation propagation,
-- deadline handling.
+The canonical pattern MUST be distinct from the candidate pattern list and MUST not be recomputed from an arbitrary nearest neighbor.
 
 ---
-
-### 5.2 CompilationService
-
-#### Purpose
-
-Neuro-symbolic compilation interface.
-
-Transforms:
-```text
-Eigen-Lang → AST → AQO → Intermediate representations
-```
-
-**Service Definition**
-```text
-service CompilationService {
-    rpc CompileCircuit(CompileCircuitRequest)
-        returns (CompileCircuitResponse);
-
-    rpc CompileJob(CompileJobRequest)
-        returns (CompileJobResponse);
-
-    rpc OptimizeCircuit(OptimizeCircuitRequest)
-        returns (OptimizeCircuitResponse);
-
-    rpc ValidateCircuit(ValidateCircuitRequest)
-        returns (ValidateCircuitResponse);
-}
-```
-
-#### CompileCircuit
-
-Compiles a standalone circuit.
-
-#### Request metadata
-
-All internal compile requests MUST carry canonical metadata either in the request envelope or in the propagated gRPC metadata boundary.
-
-Required canonical request metadata:
-
-- request ID,
-- trace context,
-- deadline,
-- retry policy,
-- security context,
-- tenant/project scope.
-
-When both `source` and `source_ref` are present, `source` MUST take precedence.
-When `source_ref` is used, it MUST resolve deterministically against the QFS root.
-
-Outputs:
-
-- AQO,
-- IR,
-- diagnostics,
-- compiler trace.
-
-#### CompileJob
-
-Compiles a full hybrid workflow.
-
-The request follows the same canonical metadata and source-precedence rules as `CompileCircuit`.
-
-MUST support:
-
-- multiple circuits,
-- classical orchestration,
-- dataset references,
-- parameter binding.
-
-#### OptimizeCircuit
-
-Previously stubbed.
-
-MUST now be implemented.
-
-Responsibilities:
-
-- AQO optimization,
-- gate simplification,
-- SWAP reduction,
-- noise-aware rewriting,
-- topology-aware transformations.
-
-#### ValidateCircuit
-
-Previously stubbed.
-
-MUST now be implemented.
-
-Validation includes:
-
-- AST safety,
-- deterministic semantics,
-- unsupported gates,
-- recursion prevention,
-- bounded resources,
-- prohibited runtime constructs.
-
----
-
-### 5.3 DriverManagerService
-
-#### Purpose
-
-Hardware abstraction orchestration layer.
-
-Provides unified access to:
-
-- simulators,
-- local hardware,
-- cloud quantum devices.
-
-#### Service Definition
-
-```text
-service DriverManagerService {
-    rpc ListDevices(ListDevicesRequest)
-        returns (ListDevicesResponse);
-
-    rpc GetDeviceStatus(GetDeviceStatusRequest)
-        returns (GetDeviceStatusResponse);
-
-    rpc ExecuteCircuit(ExecuteCircuitRequest)
-        returns (ExecuteCircuitResponse);
-
-    rpc ExecuteCircuitAsync(ExecuteCircuitRequest)
-        returns (ExecutionHandle);
-
-    rpc StreamExecutionUpdates(ExecutionHandle)
-        returns (stream ExecutionEvent);
-
-    rpc CalibrateDevice(CalibrateDeviceRequest)
-        returns (CalibrateDeviceResponse);
-}
-```
-
-Driver Manager capability registry semantics are read-only and queryable through the same internal boundary:
-
-- device and capability snapshots MUST be deterministic,
-- live session state MUST remain separate from snapshot metadata,
-- versioned device profiles MUST be queryable for provider selection,
-- unsupported profile negotiation MUST fail closed unless the simulator fallback is explicitly available.
-
-The kernel-facing transport surface remains the implementation boundary; profile negotiation is a contract over registry behavior and metadata stability, not a new public wire surface.
-
-Canonical final-contract reference for this boundary:
-
-- `docs/reference/api/qdriver.md`
-
-`DriverManagerService` is the kernel-facing transport projection of the final QDriver v1 contract. The semantic mapping is intentionally stable:
-
-- `ExecuteCircuit` projects QDriver `Execute`
-- `GetDeviceStatus` projects QDriver `GetStatus`
-- `CalibrateDevice` projects QDriver `Calibrate`
-- cancellation is propagated through the kernel transport layer as the QDriver `Cancel` semantic
-
-Unsupported capability selection and version mismatch MUST remain deterministic and must use the canonical error model defined by the QDriver reference.
-
-#### ExecuteCircuit
-
-Synchronous unary execution.
-
-Recommended only for short-running jobs.
-
-#### ExecuteCircuitAsync
-
-Required for:
-
-- cloud devices,
-- queued systems,
-- long-running executions.
-
-Returns execution handle.
-
-#### StreamExecutionUpdates
-
-Streams:
-
-- queue status,
-- execution start,
-- execution completion,
-- telemetry,
-- cancellation,
-- failure events.
-
-#### CalibrateDevice
-
-Previously stubbed.
-
-MUST now be implemented.
-
-Calibration MAY include:
-
-- T1/T2 refresh,
-- gate recalibration,
-- readout recalibration,
-- topology refresh.
-
----
-
-### 5.4 OptimizerService
-
-#### Purpose
-
-GNN-based routing and placement optimization.
-
-Transforms:
-
-```text
-AQO → topology-aware executable QASM
-```
-
-#### Service Definition
-
-```text
-service OptimizerService {
-    rpc OptimizeCircuit(OptimizeCircuitRequest)
-        returns (OptimizeCircuitResponse);
-}
-```
-
-#### Required Semantics
-
-MUST support:
-
-- deterministic seed replay,
-- confidence scoring,
-- fallback algorithms,
-- topology-aware routing,
-- SWAP minimization,
-- noise prediction.
-
-#### Required Failure Codes
-
-| **Code** | **Meaning** |
-|----------------------|------|
-| `OPT_INVALID_AQO` | Invalid intermediate representation |
-| `OPT_TIMEOUT` | Optimization exceeded deadline |
-| `OPT_NO_FEASIBLE_MAPPING` | No routing solution |
-| `OPT_MODEL_FAILURE` | ML model failure |
-| `OPT_INTERNAL_ERROR` | Internal optimizer failure |
-
----
-
-### 5.5 QFSService
-
-#### Purpose
-
-Internal persistence interface for QFS.
-
-Previously undocumented in internal API contracts.
-
-Now mandatory.
-
-#### Service Definition
-
-```text
-service QFSService {
-    rpc StoreArtifact(StoreArtifactRequest)
-        returns (StoreArtifactResponse);
-
-    rpc GetArtifact(GetArtifactRequest)
-        returns (GetArtifactResponse);
-
-    rpc ListArtifacts(ListArtifactsRequest)
-        returns (ListArtifactsResponse);
-
-    rpc CheckpointState(CheckpointStateRequest)
-        returns (CheckpointStateResponse);
-
-    rpc RestoreState(RestoreStateRequest)
-        returns (RestoreStateResponse);
-}
-```
-
----
-
-### 5.6 KnowledgeBaseService
-
-#### Purpose
-
-Persistent memory and learning interface.
-
-Previously omitted from internal API spec.
-
-Now mandatory.
-
-#### Service Definition
 
 ```text
 service KnowledgeBaseService {

--- a/src/services/system-api/src/system_api/pattern_miner.py
+++ b/src/services/system-api/src/system_api/pattern_miner.py
@@ -7,11 +7,52 @@ import json
 from typing import Any
 
 RECOMMENDATION_CONTRACT_VERSION = "1.0.0"
+PATTERN_CONTRACT_VERSION = "1.0.0"
 PATTERN_MINER_CADENCE_SECONDS = 300
+PATTERN_MINER_MAX_CANDIDATES = 8
+
+_PATTERN_QUERY_MODES = {"structural", "vector", "hybrid"}
+_PATTERN_COMPATIBILITY_FIELDS = (
+    "schema_version",
+    "compiler_version",
+    "aqo_version",
+    "optimizer_version",
+    "policy_mode",
+    "policy_digest",
+)
+_PATTERN_INCOMPATIBILITY_REASON_MAP = {
+    "schema_version": "SCHEMA_MISMATCH",
+    "compiler_version": "COMPILER_MISMATCH",
+    "aqo_version": "AQO_MISMATCH",
+    "optimizer_version": "OPTIMIZER_MISMATCH",
+    "policy_mode": "POLICY_MISMATCH",
+    "policy_digest": "POLICY_MISMATCH",
+}
 
 
 def _canonical_json(payload: Any) -> str:
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _normalized_text(value: Any) -> str:
+    return str(value).strip()
+
+
+def _clamp_budget(value: Any) -> int:
+    try:
+        requested = int(value)
+    except Exception:
+        requested = 1
+    return max(1, min(requested, PATTERN_MINER_MAX_CANDIDATES))
+
+
+def _sha256_hex(payload: Any) -> str:
+    return sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def _digest_to_unit_interval(digest: str, *, start: int = 0, end: int = 16) -> float:
+    raw = int(digest[start:end], 16)
+    return raw / float(0xFFFFFFFFFFFFFFFF)
 
 
 @dataclass(frozen=True)
@@ -30,11 +71,15 @@ class PatternMinerService:
 
     def ingest_snapshot(self, *, snapshot_id: str, records: list[dict[str, Any]], config_digest: str) -> SnapshotIngestResult:
         normalized_records = sorted(records, key=lambda row: _canonical_json(row))
-        idempotency_key = sha256(_canonical_json({
-            "snapshot_id": snapshot_id,
-            "config_digest": config_digest,
-            "records": normalized_records,
-        }).encode("utf-8")).hexdigest()
+        idempotency_key = sha256(
+            _canonical_json(
+                {
+                    "snapshot_id": snapshot_id,
+                    "config_digest": config_digest,
+                    "records": normalized_records,
+                }
+            ).encode("utf-8")
+        ).hexdigest()
         existing = self._snapshots.get(snapshot_id)
         if existing is None:
             self._snapshots[snapshot_id] = {
@@ -49,31 +94,155 @@ class PatternMinerService:
 
     def mine_patterns(self, *, snapshot_id: str) -> dict[str, Any]:
         snapshot = self._snapshots[snapshot_id]
-        records = snapshot["records"]
-        grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
-        for record in records:
-            key = (str(record.get("circuit_id", "")), str(record.get("backend_class", "")))
-            grouped.setdefault(key, []).append(record)
-
-        patterns = []
-        for (circuit_id, backend_class), members in sorted(grouped.items()):
-            member_ids = sorted(str(m["record_id"]) for m in members)
-            pattern_id = sha256(f"{snapshot_id}:{circuit_id}:{backend_class}".encode("utf-8")).hexdigest()[:16]
-            patterns.append(
-                {
-                    "pattern_id": pattern_id,
-                    "circuit_id": circuit_id,
-                    "backend_class": backend_class,
-                    "source_record_ids": member_ids,
-                    "support": len(member_ids),
-                }
-            )
-
+        patterns = self._pattern_catalog(snapshot_id=snapshot_id)
         return {
             "snapshot_id": snapshot_id,
             "config_digest": snapshot["config_digest"],
             "cadence_seconds": PATTERN_MINER_CADENCE_SECONDS,
             "patterns": patterns,
+        }
+
+    def get_pattern(
+        self,
+        *,
+        snapshot_id: str,
+        tenant_id: str,
+        project_id: str,
+        circuit_id: str,
+        backend_class: str,
+        semantic_hash: str,
+        aqo_hash: str,
+        schema_version: str,
+        compiler_version: str,
+        aqo_version: str,
+        optimizer_version: str,
+        policy_mode: str = "deterministic",
+        policy_digest: str = "",
+        seed: int = 0,
+        query_mode: str = "structural",
+        candidate_budget: int = PATTERN_MINER_MAX_CANDIDATES,
+        deterministic: bool = True,
+    ) -> dict[str, Any]:
+        snapshot = self._snapshots[snapshot_id]
+        query = self._normalize_pattern_query(
+            {
+                "snapshot_id": snapshot_id,
+                "tenant_id": tenant_id,
+                "project_id": project_id,
+                "circuit_id": circuit_id,
+                "backend_class": backend_class,
+                "semantic_hash": semantic_hash,
+                "aqo_hash": aqo_hash,
+                "schema_version": schema_version,
+                "compiler_version": compiler_version,
+                "aqo_version": aqo_version,
+                "optimizer_version": optimizer_version,
+                "policy_mode": policy_mode,
+                "policy_digest": policy_digest,
+                "seed": seed,
+                "query_mode": query_mode,
+                "candidate_budget": candidate_budget,
+                "deterministic": deterministic,
+            }
+        )
+        catalog = self._pattern_catalog(snapshot_id=snapshot_id)
+        scoped = [pattern for pattern in catalog if pattern["circuit_id"] == query["circuit_id"] and pattern["backend_class"] == query["backend_class"]]
+        query_window = self._query_compatibility_window(query)
+        query_signature = _sha256_hex(query_window)
+        max_support = max((pattern["support"] for pattern in scoped), default=1)
+
+        scored_candidates = [
+            self._decorate_pattern_candidate(
+                pattern=pattern,
+                query=query,
+                query_signature=query_signature,
+                max_support=max_support,
+            )
+            for pattern in scoped
+        ]
+
+        compatible_candidates = [item for item in scored_candidates if item["compatible"]]
+        canonical_candidate = self._choose_canonical_pattern(compatible_candidates)
+        canonical_pattern_id = canonical_candidate["pattern_id"] if canonical_candidate else ""
+
+        ordered_candidates = self._order_pattern_candidates(
+            scored_candidates,
+            canonical_pattern_id=canonical_pattern_id,
+        )
+        selected_candidates = ordered_candidates[: query["candidate_budget"]]
+        if canonical_candidate and canonical_pattern_id not in {item["pattern_id"] for item in selected_candidates}:
+            selected_candidates = [canonical_candidate] + selected_candidates[: query["candidate_budget"] - 1]
+
+        selected_candidates = selected_candidates[: query["candidate_budget"]]
+        for rank, candidate in enumerate(selected_candidates, start=1):
+            candidate["rank"] = rank
+            candidate["selected"] = candidate["pattern_id"] == canonical_pattern_id if canonical_candidate else False
+
+        canonical_pattern = None
+        if canonical_candidate is not None:
+            canonical_pattern = dict(canonical_candidate)
+            canonical_pattern["pattern_kind"] = "canonical"
+            canonical_pattern["selected"] = True
+            canonical_pattern["canonical_template_ref"] = f"kb://patterns/{canonical_pattern['pattern_id']}"
+            canonical_pattern["explanation_ref"] = f"kb://patterns/{canonical_pattern['pattern_id']}/explanation"
+            canonical_pattern["rank"] = 1
+
+        incompatible_reasons = self._collect_incompatibility_reasons(scored_candidates)
+        fallback_used = canonical_pattern is None
+        diagnostics = {
+            "fallback_used": fallback_used,
+            "fallback_reason": "NO_CANONICAL_PATTERN" if fallback_used else None,
+            "compatibility_signature": query_signature,
+            "canonical_selection_rule": [
+                "exact compatibility window",
+                "support desc",
+                "pattern_family asc",
+                "pattern_id asc",
+            ],
+            "compatible_candidate_count": len(compatible_candidates),
+            "incompatible_candidate_count": len(scored_candidates) - len(compatible_candidates),
+            "incompatibility_reason_codes": incompatible_reasons,
+        }
+
+        explanation_pattern = {
+            "explanation_id": _sha256_hex(
+                {
+                    "snapshot_id": snapshot_id,
+                    "query_signature": query_signature,
+                    "canonical_pattern_id": canonical_pattern_id,
+                    "candidate_pattern_ids": [item["pattern_id"] for item in selected_candidates],
+                    "reason_codes": incompatible_reasons,
+                }
+            ),
+            "pattern_kind": "explanation",
+            "snapshot_id": snapshot_id,
+            "query_signature": query_signature,
+            "canonical_pattern_id": canonical_pattern_id,
+            "candidate_pattern_ids": [item["pattern_id"] for item in selected_candidates],
+            "reason_codes": incompatible_reasons,
+            "summary": (
+                "Exact compatibility window matched a canonical template."
+                if canonical_candidate is not None
+                else "No canonical template matched the requested compatibility window."
+            ),
+        }
+
+        return {
+            "contract": "pattern_miner.pattern",
+            "version": PATTERN_CONTRACT_VERSION,
+            "tenant_id": query["tenant_id"],
+            "project_id": query["project_id"],
+            "snapshot_id": snapshot_id,
+            "config_digest": snapshot["config_digest"],
+            "candidate_budget": query["candidate_budget"],
+            "canonical_pattern_id": canonical_pattern_id,
+            "selected_candidate_id": canonical_pattern_id,
+            "cadence_seconds": PATTERN_MINER_CADENCE_SECONDS,
+            "query": query,
+            "canonical_pattern": canonical_pattern,
+            "candidate_patterns": selected_candidates,
+            "explanation_pattern": explanation_pattern,
+            "diagnostics": diagnostics,
         }
 
     def get_recommendation(self, *, snapshot_id: str, circuit_id: str, backend_class: str, min_confidence: float = 0.0) -> dict[str, Any]:
@@ -108,3 +277,233 @@ class PatternMinerService:
                 "expires_at": (now + timedelta(seconds=PATTERN_MINER_CADENCE_SECONDS)).isoformat(),
             },
         }
+
+    GetPattern = get_pattern
+
+    def _pattern_catalog(self, *, snapshot_id: str) -> list[dict[str, Any]]:
+        snapshot = self._snapshots[snapshot_id]
+        grouped: dict[tuple[str, str, str, str], list[dict[str, Any]]] = {}
+        for record in snapshot["records"]:
+            circuit_id = _normalized_text(record.get("circuit_id"))
+            backend_class = _normalized_text(record.get("backend_class"))
+            pattern_family = _normalized_text(record.get("pattern_family") or f"{circuit_id}:{backend_class}") or f"{circuit_id}:{backend_class}"
+            compatibility_window = self._record_compatibility_window(record)
+            compatibility_signature = _sha256_hex(compatibility_window)
+            grouped.setdefault((circuit_id, backend_class, pattern_family, compatibility_signature), []).append(record)
+
+        patterns: list[dict[str, Any]] = []
+        for (circuit_id, backend_class, pattern_family, compatibility_signature), members in sorted(grouped.items()):
+            ordered_members = sorted(members, key=_canonical_json)
+            source_record_ids = sorted(
+                {
+                    _normalized_text(member.get("record_id"))
+                    for member in ordered_members
+                    if _normalized_text(member.get("record_id"))
+                }
+            )
+            representative = ordered_members[0] if ordered_members else {}
+            compatibility_window = self._record_compatibility_window(representative)
+            pattern_id = sha256(
+                _canonical_json(
+                    {
+                        "snapshot_id": snapshot_id,
+                        "circuit_id": circuit_id,
+                        "backend_class": backend_class,
+                        "pattern_family": pattern_family,
+                        "compatibility_signature": compatibility_signature,
+                        "source_record_ids": source_record_ids,
+                    }
+                ).encode("utf-8")
+            ).hexdigest()[:16]
+            patterns.append(
+                {
+                    "candidate_id": f"candidate-{pattern_id}",
+                    "pattern_id": pattern_id,
+                    "pattern_family": pattern_family,
+                    "pattern_kind": "candidate",
+                    "circuit_id": circuit_id,
+                    "backend_class": backend_class,
+                    "source_record_ids": source_record_ids,
+                    "support": len(source_record_ids),
+                    "compatibility_window": compatibility_window,
+                    "compatibility_signature": compatibility_signature,
+                    "canonical_eligible": True,
+                    "selected": False,
+                    "rank": 0,
+                    "score_breakdown": {
+                        "structural_score": 0.0,
+                        "vector_score": 0.0,
+                        "hybrid_score": 0.0,
+                    },
+                    "score_total": 0.0,
+                    "confidence": 0.0,
+                    "canonical_template_ref": f"kb://patterns/{pattern_id}",
+                    "explanation_ref": f"kb://patterns/{pattern_id}/explanation",
+                    "metadata": {
+                        "snapshot_id": snapshot_id,
+                        "config_digest": snapshot["config_digest"],
+                        "source_record_count": len(source_record_ids),
+                    },
+                }
+            )
+
+        return patterns
+
+    def _record_compatibility_window(self, record: dict[str, Any]) -> dict[str, str]:
+        return {field: _normalized_text(record.get(field, "")) for field in _PATTERN_COMPATIBILITY_FIELDS}
+
+    def _query_compatibility_window(self, query: dict[str, Any]) -> dict[str, str]:
+        return {field: _normalized_text(query.get(field, "")) for field in _PATTERN_COMPATIBILITY_FIELDS}
+
+    def _normalize_pattern_query(self, payload: dict[str, Any]) -> dict[str, Any]:
+        required_fields = (
+            "tenant_id",
+            "project_id",
+            "snapshot_id",
+            "circuit_id",
+            "backend_class",
+            "semantic_hash",
+            "aqo_hash",
+            "schema_version",
+            "compiler_version",
+            "aqo_version",
+            "optimizer_version",
+        )
+        missing = [field for field in required_fields if not _normalized_text(payload.get(field, ""))]
+        if missing:
+            raise ValueError(f"missing required fields: {', '.join(missing)}")
+
+        query_mode = _normalized_text(payload.get("query_mode", "structural")).lower() or "structural"
+        if query_mode not in _PATTERN_QUERY_MODES:
+            query_mode = "structural"
+
+        return {
+            "tenant_id": _normalized_text(payload.get("tenant_id")),
+            "project_id": _normalized_text(payload.get("project_id")),
+            "snapshot_id": _normalized_text(payload.get("snapshot_id")),
+            "circuit_id": _normalized_text(payload.get("circuit_id")),
+            "backend_class": _normalized_text(payload.get("backend_class")),
+            "semantic_hash": _normalized_text(payload.get("semantic_hash")),
+            "aqo_hash": _normalized_text(payload.get("aqo_hash")),
+            "schema_version": _normalized_text(payload.get("schema_version")),
+            "compiler_version": _normalized_text(payload.get("compiler_version")),
+            "aqo_version": _normalized_text(payload.get("aqo_version")),
+            "optimizer_version": _normalized_text(payload.get("optimizer_version")),
+            "policy_mode": _normalized_text(payload.get("policy_mode", "deterministic")) or "deterministic",
+            "policy_digest": _normalized_text(payload.get("policy_digest")),
+            "seed": int(payload.get("seed", 0) or 0),
+            "deterministic": bool(payload.get("deterministic", True)),
+            "query_mode": query_mode,
+            "candidate_budget": _clamp_budget(payload.get("candidate_budget", PATTERN_MINER_MAX_CANDIDATES)),
+        }
+
+    def _decorate_pattern_candidate(
+        self,
+        *,
+        pattern: dict[str, Any],
+        query: dict[str, Any],
+        query_signature: str,
+        max_support: int,
+    ) -> dict[str, Any]:
+        compatibility_checks = self._compatibility_checks(pattern["compatibility_window"], query)
+        compatible = not compatibility_checks["incompatibility_reasons"]
+        compatibility_ratio = compatibility_checks["compatibility_ratio"]
+        support_ratio = pattern["support"] / float(max_support or 1)
+        structural_score = round((support_ratio * 0.6) + (compatibility_ratio * 0.4), 6)
+
+        vector_digest = _sha256_hex(
+            {
+                "pattern_id": pattern["pattern_id"],
+                "pattern_family": pattern["pattern_family"],
+                "query_signature": query_signature,
+                "semantic_hash": query["semantic_hash"],
+                "aqo_hash": query["aqo_hash"],
+                "seed": query["seed"],
+            }
+        )
+        vector_score = round(_digest_to_unit_interval(vector_digest), 6)
+        hybrid_score = round((structural_score * 0.6) + (vector_score * 0.4), 6)
+
+        if query["query_mode"] == "vector":
+            selected_score = vector_score
+        elif query["query_mode"] == "hybrid":
+            selected_score = hybrid_score
+        else:
+            selected_score = structural_score
+
+        confidence = round(min(1.0, (support_ratio * 0.5) + (compatibility_ratio * 0.5)), 6)
+
+        candidate = dict(pattern)
+        candidate.update(
+            {
+                "compatible": compatible,
+                "incompatibility_reasons": compatibility_checks["incompatibility_reasons"],
+                "canonical_eligible": compatible,
+                "score_breakdown": {
+                    "structural_score": structural_score,
+                    "vector_score": vector_score,
+                    "hybrid_score": hybrid_score,
+                },
+                "score_total": selected_score,
+                "confidence": confidence,
+                "metadata": {
+                    **pattern["metadata"],
+                    "query_mode": query["query_mode"],
+                    "query_signature": query_signature,
+                    "compatibility_ratio": compatibility_ratio,
+                    "support_ratio": round(support_ratio, 6),
+                },
+            }
+        )
+        return candidate
+
+    def _compatibility_checks(self, compatibility_window: dict[str, str], query: dict[str, Any]) -> dict[str, Any]:
+        reasons: list[str] = []
+        matched_fields = 0
+        for field in _PATTERN_COMPATIBILITY_FIELDS:
+            expected = compatibility_window.get(field, "")
+            actual = _normalized_text(query.get(field, ""))
+            if expected and expected == actual:
+                matched_fields += 1
+                continue
+            if expected or actual:
+                reason_code = _PATTERN_INCOMPATIBILITY_REASON_MAP[field]
+                if reason_code not in reasons:
+                    reasons.append(reason_code)
+        compatibility_ratio = matched_fields / float(len(_PATTERN_COMPATIBILITY_FIELDS))
+        return {
+            "compatible": not reasons,
+            "incompatibility_reasons": reasons,
+            "compatibility_ratio": round(compatibility_ratio, 6),
+        }
+
+    def _choose_canonical_pattern(self, candidates: list[dict[str, Any]]) -> dict[str, Any] | None:
+        if not candidates:
+            return None
+        return sorted(
+            candidates,
+            key=lambda item: (
+                -item["support"],
+                item["pattern_family"],
+                item["pattern_id"],
+            ),
+        )[0]
+
+    def _order_pattern_candidates(self, candidates: list[dict[str, Any]], *, canonical_pattern_id: str) -> list[dict[str, Any]]:
+        return sorted(
+            candidates,
+            key=lambda item: (
+                0 if canonical_pattern_id and item["pattern_id"] == canonical_pattern_id else 1,
+                -item["score_total"],
+                -item["confidence"],
+                item["candidate_id"],
+            ),
+        )
+
+    def _collect_incompatibility_reasons(self, candidates: list[dict[str, Any]]) -> list[str]:
+        reasons: list[str] = []
+        for candidate in candidates:
+            for reason in candidate["incompatibility_reasons"]:
+                if reason not in reasons:
+                    reasons.append(reason)
+        return reasons

--- a/src/services/system-api/tests/test_pattern_miner_service.py
+++ b/src/services/system-api/tests/test_pattern_miner_service.py
@@ -8,9 +8,76 @@ from system_api.pattern_miner import PatternMinerService
 
 def _dataset() -> list[dict[str, str]]:
     return [
-        {"record_id": "r-2", "circuit_id": "c1", "backend_class": "sim"},
-        {"record_id": "r-1", "circuit_id": "c1", "backend_class": "sim"},
-        {"record_id": "r-3", "circuit_id": "c2", "backend_class": "qpu"},
+        {
+            "record_id": "r-2",
+            "circuit_id": "c1",
+            "backend_class": "sim",
+            "pattern_family": "alpha",
+            "schema_version": "1.0.0",
+            "compiler_version": "compiler-1.0",
+            "aqo_version": "aqo-1.0",
+            "optimizer_version": "opt-1.0",
+            "policy_mode": "deterministic",
+            "policy_digest": "policy-1",
+            "semantic_hash": "semantic-alpha",
+            "aqo_hash": "aqo-alpha",
+        },
+        {
+            "record_id": "r-1",
+            "circuit_id": "c1",
+            "backend_class": "sim",
+            "pattern_family": "alpha",
+            "schema_version": "1.0.0",
+            "compiler_version": "compiler-1.0",
+            "aqo_version": "aqo-1.0",
+            "optimizer_version": "opt-1.0",
+            "policy_mode": "deterministic",
+            "policy_digest": "policy-1",
+            "semantic_hash": "semantic-alpha",
+            "aqo_hash": "aqo-alpha",
+        },
+        {
+            "record_id": "r-3",
+            "circuit_id": "c1",
+            "backend_class": "sim",
+            "pattern_family": "beta",
+            "schema_version": "1.0.0",
+            "compiler_version": "compiler-1.0",
+            "aqo_version": "aqo-1.0",
+            "optimizer_version": "opt-1.0",
+            "policy_mode": "deterministic",
+            "policy_digest": "policy-1",
+            "semantic_hash": "semantic-beta",
+            "aqo_hash": "aqo-beta",
+        },
+        {
+            "record_id": "r-4",
+            "circuit_id": "c1",
+            "backend_class": "sim",
+            "pattern_family": "gamma",
+            "schema_version": "1.0.0",
+            "compiler_version": "compiler-2.0",
+            "aqo_version": "aqo-1.0",
+            "optimizer_version": "opt-1.0",
+            "policy_mode": "deterministic",
+            "policy_digest": "policy-1",
+            "semantic_hash": "semantic-gamma",
+            "aqo_hash": "aqo-gamma",
+        },
+        {
+            "record_id": "r-5",
+            "circuit_id": "c2",
+            "backend_class": "qpu",
+            "pattern_family": "delta",
+            "schema_version": "1.0.0",
+            "compiler_version": "compiler-1.0",
+            "aqo_version": "aqo-1.0",
+            "optimizer_version": "opt-1.0",
+            "policy_mode": "deterministic",
+            "policy_digest": "policy-1",
+            "semantic_hash": "semantic-delta",
+            "aqo_hash": "aqo-delta",
+        },
     ]
 
 
@@ -38,6 +105,86 @@ def test_recommendation_payload_has_versioned_contract_and_provenance_links() ->
     assert recommendation["recommendation"]["fallback_used"] is False
     assert recommendation["provenance"]["source_record_ids"] == ["r-1", "r-2"]
     assert recommendation["provenance"]["queryable_links"] == ["kb://records/r-1", "kb://records/r-2"]
+
+
+def test_get_pattern_returns_canonical_template_and_separates_candidates() -> None:
+    service = PatternMinerService()
+    service.ingest_snapshot(snapshot_id="s1", records=_dataset(), config_digest="cfg-a")
+
+    result = service.get_pattern(
+        snapshot_id="s1",
+        tenant_id="tenant-a",
+        project_id="project-a",
+        circuit_id="c1",
+        backend_class="sim",
+        semantic_hash="semantic-alpha",
+        aqo_hash="aqo-alpha",
+        schema_version="1.0.0",
+        compiler_version="compiler-1.0",
+        aqo_version="aqo-1.0",
+        optimizer_version="opt-1.0",
+        policy_mode="deterministic",
+        policy_digest="policy-1",
+        seed=7,
+        query_mode="structural",
+        candidate_budget=8,
+        deterministic=True,
+    )
+
+    assert result["contract"] == "pattern_miner.pattern"
+    assert result["version"] == "1.0.0"
+    assert result["diagnostics"]["fallback_used"] is False
+    assert result["diagnostics"]["compatibility_signature"] == result["canonical_pattern"]["compatibility_signature"]
+    assert result["canonical_pattern"]["pattern_kind"] == "canonical"
+    assert result["canonical_pattern"]["pattern_family"] == "alpha"
+    assert result["canonical_pattern"]["selected"] is True
+    assert result["candidate_patterns"][0]["selected"] is True
+    assert result["candidate_patterns"][0]["pattern_family"] == "alpha"
+    assert result["candidate_patterns"][0]["rank"] == 1
+    assert len(result["candidate_patterns"]) <= 8
+    assert any(
+        candidate["pattern_family"] == "beta"
+        for candidate in result["candidate_patterns"]
+    )
+    assert any(
+        candidate["pattern_family"] == "gamma" and "COMPILER_MISMATCH" in candidate["incompatibility_reasons"]
+        for candidate in result["candidate_patterns"]
+    )
+    assert result["explanation_pattern"]["canonical_pattern_id"] == result["canonical_pattern"]["pattern_id"]
+    assert result["explanation_pattern"]["pattern_kind"] == "explanation"
+
+
+def test_get_pattern_returns_diagnostics_when_no_canonical_pattern_exists() -> None:
+    service = PatternMinerService()
+    service.ingest_snapshot(snapshot_id="s1", records=_dataset(), config_digest="cfg-a")
+
+    result = service.get_pattern(
+        snapshot_id="s1",
+        tenant_id="tenant-a",
+        project_id="project-a",
+        circuit_id="c1",
+        backend_class="sim",
+        semantic_hash="semantic-alpha",
+        aqo_hash="aqo-alpha",
+        schema_version="1.0.0",
+        compiler_version="compiler-9.9",
+        aqo_version="aqo-1.0",
+        optimizer_version="opt-1.0",
+        policy_mode="deterministic",
+        policy_digest="policy-1",
+        seed=7,
+        query_mode="structural",
+        candidate_budget=8,
+        deterministic=True,
+    )
+
+    assert result["canonical_pattern"] is None
+    assert result["diagnostics"]["fallback_used"] is True
+    assert result["diagnostics"]["fallback_reason"] == "NO_CANONICAL_PATTERN"
+    assert "COMPILER_MISMATCH" in result["diagnostics"]["incompatibility_reason_codes"]
+    assert all(candidate["selected"] is False for candidate in result["candidate_patterns"])
+    assert result["explanation_pattern"]["canonical_pattern_id"] == ""
+    assert result["candidate_patterns"][0]["pattern_kind"] == "candidate"
 
 
 def test_pattern_miner_recommendation_contract_fixture_v1_0_0() -> None:


### PR DESCRIPTION
## Summary

Implemented a dedicated GetPattern flow for the KB pattern miner so canonical templates are selected separately from similarity candidates. The new contract is deterministic, scope-safe, and machine-verifiable: it requires exact compatibility windows, exposes explicit incompatibility reason codes, and returns a diagnostics envelope when no canonical pattern is available.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MAJOR
- **Affected Interfaces**: API
- **Compatibility**: Breaking
- **Breaking Marker**: true
- **Migration Notes**: GetPattern callers must supply the canonical compatibility inputs (tenant_id, project_id, snapshot_id, circuit_id, backend_class, schema_version, compiler_version, aqo_version, optimizer_version, policy_mode, policy_digest). Canonical selection is no longer inferred from nearest-neighbor similarity; incompatible patterns are diagnostics-only and cannot be returned as canonical.

## Release Notes Draft

### Added
- Explicit GetPattern contract for canonical pattern retrieval.
- Machine-verifiable compatibility windows and compatibility signatures.
- Deterministic incompatibility reason codes for schema, compiler, AQO, optimizer, and policy mismatches.
- Canonical-pattern diagnostics and fallback output when no canonical template is found.

### Changed
- Pattern retrieval now separates canonical templates from similarity candidates.
- Candidate ordering remains deterministic, but canonical selection uses exact compatibility plus a stable canonical precedence rule.
- Docs now distinguish canonical patterns, candidate patterns, and explanation patterns.

### Fixed
- Canonical selection no longer returns an arbitrary nearest neighbor when a stable template is required.
- Incompatible patterns are excluded from canonical results.