### PR TITLE
Implemented tenant/project boundary enforcement for the KB

### DIFF
--- a/docs/architecture/components/knowledge-base.md
+++ b/docs/architecture/components/knowledge-base.md
@@ -55,6 +55,8 @@ The backend MAY derive candidates from:
 - other replay-safe KB artifacts that are in the same tenant/project scope.
 
 The pool MUST be filtered before scoring. Cross-scope data MUST NOT be considered.
+Mixed-tenant or mixed-project snapshots are invalid and MUST be rejected before retrieval.
+All explanation and replay outputs MUST stay within the same tenant/project boundary and MUST NOT echo foreign identifiers or payload fragments.
 
 ## 5. Rank source of truth
 
@@ -188,6 +190,7 @@ This contract is backward-compatible with the existing in-memory KB baseline bec
 - canonical lookup is separated from similarity lookup.
 
 Any caller that does not provide tenant/project scope is invalid for similarity retrieval.
+Snapshot ingest MUST preserve the snapshot's tenant/project scope, and retrieval helpers MUST fail closed when the request scope does not match that stored boundary.
 
 ## 11. Index synchronization, recovery, and backfill
 

--- a/docs/reference/api/grpc-internal.md
+++ b/docs/reference/api/grpc-internal.md
@@ -138,6 +138,7 @@ Required request semantics:
 - `schema_version`, `compiler_version`, `aqo_version`, `optimizer_version`, `policy_mode`, and `policy_digest` MUST be present.
 - compatibility metadata MUST be machine-verifiable by exact string equality.
 - incompatible patterns MUST remain visible only as candidates or diagnostics, never as the canonical result.
+- diagnostics, replay envelopes, and explanation payloads MUST remain scoped to the current tenant/project and MUST NOT echo foreign identifiers or payload fragments.
 
 Canonical selection semantics:
 
@@ -212,6 +213,8 @@ Scope semantics:
 
 - candidates MUST be filtered by tenant/project before scoring,
 - cross-tenant/project retrieval is forbidden.
+- cross-tenant/project retrieval is forbidden,
+- diagnostics, selection digests, and replay outputs MUST not expose third-party identifiers or payload fragments.
 
 Returned responses MUST expose:
 

--- a/src/services/system-api/src/system_api/pattern_miner.py
+++ b/src/services/system-api/src/system_api/pattern_miner.py
@@ -69,30 +69,47 @@ class PatternMinerService:
     def __init__(self) -> None:
         self._snapshots: dict[str, dict[str, Any]] = {}
 
-    def ingest_snapshot(self, *, snapshot_id: str, records: list[dict[str, Any]], config_digest: str) -> SnapshotIngestResult:
-        normalized_records = sorted(records, key=lambda row: _canonical_json(row))
+    def ingest_snapshot(
+        self,
+        *,
+        snapshot_id: str,
+        records: list[dict[str, Any]],
+        config_digest: str,
+        tenant_id: str = "",
+        project_id: str = "",
+    ) -> SnapshotIngestResult:
+        normalized_tenant_id, normalized_project_id, normalized_records = self._normalize_snapshot_records(
+            records,
+            tenant_id=tenant_id,
+            project_id=project_id,
+        )
         idempotency_key = sha256(
             _canonical_json(
                 {
                     "snapshot_id": snapshot_id,
                     "config_digest": config_digest,
+                    "tenant_id": normalized_tenant_id,
+                    "project_id": normalized_project_id,
                     "records": normalized_records,
                 }
             ).encode("utf-8")
         ).hexdigest()
         existing = self._snapshots.get(snapshot_id)
+        snapshot_payload = {
+            "config_digest": config_digest,
+            "tenant_id": normalized_tenant_id,
+            "project_id": normalized_project_id,
+            "records": normalized_records,
+            "idempotency_key": idempotency_key,
+        }
         if existing is None:
-            self._snapshots[snapshot_id] = {
-                "config_digest": config_digest,
-                "records": normalized_records,
-                "idempotency_key": idempotency_key,
-            }
+            self._snapshots[snapshot_id] = snapshot_payload
             return SnapshotIngestResult(snapshot_id, config_digest, idempotency_key, True)
         if existing["idempotency_key"] != idempotency_key:
             raise ValueError("snapshot_id already ingested with different payload")
         return SnapshotIngestResult(snapshot_id, config_digest, idempotency_key, False)
 
-    def mine_patterns(self, *, snapshot_id: str) -> dict[str, Any]:
+    def mine_patterns(self, *, snapshot_id: str, tenant_id: str, project_id: str) -> dict[str, Any]:
         snapshot = self._snapshots[snapshot_id]
         patterns = self._pattern_catalog(snapshot_id=snapshot_id)
         return {
@@ -124,6 +141,7 @@ class PatternMinerService:
         deterministic: bool = True,
     ) -> dict[str, Any]:
         snapshot = self._snapshots[snapshot_id]
+        self._require_snapshot_scope(snapshot, tenant_id=tenant_id, project_id=project_id)
         query = self._normalize_pattern_query(
             {
                 "snapshot_id": snapshot_id,
@@ -245,8 +263,17 @@ class PatternMinerService:
             "diagnostics": diagnostics,
         }
 
-    def get_recommendation(self, *, snapshot_id: str, circuit_id: str, backend_class: str, min_confidence: float = 0.0) -> dict[str, Any]:
-        mined = self.mine_patterns(snapshot_id=snapshot_id)
+    def get_recommendation(
+        self,
+        *,
+        snapshot_id: str,
+        tenant_id: str,
+        project_id: str,
+        circuit_id: str,
+        backend_class: str,
+        min_confidence: float = 0.0,
+    ) -> dict[str, Any]:
+        mined = self.mine_patterns(snapshot_id=snapshot_id, tenant_id=tenant_id, project_id=project_id)
         matching = [
             p
             for p in mined["patterns"]
@@ -258,10 +285,12 @@ class PatternMinerService:
         return {
             "contract": "pattern_miner.recommendation",
             "version": RECOMMENDATION_CONTRACT_VERSION,
+            "tenant_id": tenant_id,
+            "project_id": project_id,
             "snapshot_id": snapshot_id,
             "config_digest": mined["config_digest"],
             "cadence_seconds": mined["cadence_seconds"],
-            "query": {"circuit_id": circuit_id, "backend_class": backend_class},
+            "query": {"tenant_id": tenant_id, "project_id": project_id, "circuit_id": circuit_id, "backend_class": backend_class},
             "recommendation": {
                 "selected_pattern_id": matching[0]["pattern_id"] if matching else None,
                 "confidence": round(confidence, 6),
@@ -280,10 +309,71 @@ class PatternMinerService:
 
     GetPattern = get_pattern
 
+    def _normalize_snapshot_records(
+        self,
+        records: list[dict[str, Any]],
+        *,
+        tenant_id: str,
+        project_id: str,
+    ) -> tuple[str, str, list[dict[str, Any]]]:
+        normalized_tenant_id = _normalized_text(tenant_id)
+        normalized_project_id = _normalized_text(project_id)
+
+        record_tenants = sorted(
+            {
+                _normalized_text(record.get("tenant_id"))
+                for record in records
+                if _normalized_text(record.get("tenant_id"))
+            }
+        )
+        record_projects = sorted(
+            {
+                _normalized_text(record.get("project_id"))
+                for record in records
+                if _normalized_text(record.get("project_id"))
+            }
+        )
+
+        if not normalized_tenant_id:
+            normalized_tenant_id = record_tenants[0] if len(record_tenants) == 1 else "tenant-default"
+        if not normalized_project_id:
+            normalized_project_id = record_projects[0] if len(record_projects) == 1 else "project-default"
+
+        if len(record_tenants) > 1:
+            raise ValueError("snapshot records must share a single tenant_id")
+        if len(record_projects) > 1:
+            raise ValueError("snapshot records must share a single project_id")
+        if record_tenants and record_tenants[0] != normalized_tenant_id:
+            raise ValueError("snapshot tenant_id does not match record tenant_id")
+        if record_projects and record_projects[0] != normalized_project_id:
+            raise ValueError("snapshot project_id does not match record project_id")
+
+        normalized_records: list[dict[str, Any]] = []
+        for record in sorted(records, key=lambda row: _canonical_json(row)):
+            normalized_record = dict(record)
+            record_tenant_id = _normalized_text(normalized_record.get("tenant_id")) or normalized_tenant_id
+            record_project_id = _normalized_text(normalized_record.get("project_id")) or normalized_project_id
+            if record_tenant_id != normalized_tenant_id or record_project_id != normalized_project_id:
+                raise ValueError("snapshot records must share a single tenant/project scope")
+            normalized_record["tenant_id"] = normalized_tenant_id
+            normalized_record["project_id"] = normalized_project_id
+            normalized_records.append(normalized_record)
+
+        return normalized_tenant_id, normalized_project_id, normalized_records
+
+    def _require_snapshot_scope(self, snapshot: dict[str, Any], *, tenant_id: str, project_id: str) -> None:
+        if snapshot["tenant_id"] != _normalized_text(tenant_id) or snapshot["project_id"] != _normalized_text(project_id):
+            raise PermissionError("snapshot scope mismatch")
+
     def _pattern_catalog(self, *, snapshot_id: str) -> list[dict[str, Any]]:
         snapshot = self._snapshots[snapshot_id]
         grouped: dict[tuple[str, str, str, str], list[dict[str, Any]]] = {}
-        for record in snapshot["records"]:
+        for record in [
+            record
+            for record in snapshot["records"]
+            if _normalized_text(record.get("tenant_id")) == snapshot["tenant_id"]
+            and _normalized_text(record.get("project_id")) == snapshot["project_id"]
+        ]:
             circuit_id = _normalized_text(record.get("circuit_id"))
             backend_class = _normalized_text(record.get("backend_class"))
             pattern_family = _normalized_text(record.get("pattern_family") or f"{circuit_id}:{backend_class}") or f"{circuit_id}:{backend_class}"

--- a/src/services/system-api/tests/test_pattern_miner_service.py
+++ b/src/services/system-api/tests/test_pattern_miner_service.py
@@ -3,13 +3,22 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from system_api.pattern_miner import PatternMinerService
 
 
-def _dataset() -> list[dict[str, str]]:
+def _dataset(
+    *,
+    tenant_id: str = "tenant-a",
+    project_id: str = "project-a",
+    prefix: str = "",
+) -> list[dict[str, str]]:
     return [
         {
-            "record_id": "r-2",
+            "record_id": f"{prefix}r-2",
+            "tenant_id": tenant_id,
+            "project_id": project_id,
             "circuit_id": "c1",
             "backend_class": "sim",
             "pattern_family": "alpha",
@@ -23,7 +32,9 @@ def _dataset() -> list[dict[str, str]]:
             "aqo_hash": "aqo-alpha",
         },
         {
-            "record_id": "r-1",
+            "record_id": f"{prefix}r-1",
+            "tenant_id": tenant_id,
+            "project_id": project_id,
             "circuit_id": "c1",
             "backend_class": "sim",
             "pattern_family": "alpha",
@@ -37,7 +48,9 @@ def _dataset() -> list[dict[str, str]]:
             "aqo_hash": "aqo-alpha",
         },
         {
-            "record_id": "r-3",
+            "record_id": f"{prefix}r-3",
+            "tenant_id": tenant_id,
+            "project_id": project_id,
             "circuit_id": "c1",
             "backend_class": "sim",
             "pattern_family": "beta",
@@ -51,7 +64,9 @@ def _dataset() -> list[dict[str, str]]:
             "aqo_hash": "aqo-beta",
         },
         {
-            "record_id": "r-4",
+            "record_id": f"{prefix}r-4",
+            "tenant_id": tenant_id,
+            "project_id": project_id,
             "circuit_id": "c1",
             "backend_class": "sim",
             "pattern_family": "gamma",
@@ -65,7 +80,9 @@ def _dataset() -> list[dict[str, str]]:
             "aqo_hash": "aqo-gamma",
         },
         {
-            "record_id": "r-5",
+            "record_id": f"{prefix}r-5",
+            "tenant_id": tenant_id,
+            "project_id": project_id,
             "circuit_id": "c2",
             "backend_class": "qpu",
             "pattern_family": "delta",
@@ -83,23 +100,28 @@ def _dataset() -> list[dict[str, str]]:
 
 def test_pattern_miner_ingest_is_idempotent_and_deterministic() -> None:
     service = PatternMinerService()
-    first = service.ingest_snapshot(snapshot_id="s1", records=_dataset(), config_digest="cfg-a")
-    second = service.ingest_snapshot(snapshot_id="s1", records=list(reversed(_dataset())), config_digest="cfg-a")
+    first = service.ingest_snapshot(snapshot_id="s1", records=_dataset(tenant_id="tenant-a", project_id="project-a"), config_digest="cfg-a", tenant_id="tenant-a", project_id="project-a")
+    second = service.ingest_snapshot(snapshot_id="s1", records=list(reversed(_dataset(tenant_id="tenant-a", project_id="project-a"))), config_digest="cfg-a", tenant_id="tenant-a", project_id="project-a")
 
     assert first.created is True
     assert second.created is False
     assert first.idempotency_key == second.idempotency_key
 
-    mined_first = service.mine_patterns(snapshot_id="s1")
-    mined_second = service.mine_patterns(snapshot_id="s1")
+    mined_first = service.mine_patterns(snapshot_id="s1", tenant_id="tenant-a", project_id="project-a")
+    mined_second = service.mine_patterns(snapshot_id="s1", tenant_id="tenant-a", project_id="project-a")
     assert mined_first == mined_second
 
 
 def test_recommendation_payload_has_versioned_contract_and_provenance_links() -> None:
     service = PatternMinerService()
-    service.ingest_snapshot(snapshot_id="s1", records=_dataset(), config_digest="cfg-a")
+    service.ingest_snapshot(
+        snapshot_id="s1",
+        records=_dataset(tenant_id="tenant-a", project_id="project-a"),
+        config_digest="cfg-a",
+    )
+    recommendation = service.get_recommendation(snapshot_id="s1", tenant_id="tenant-a", project_id="project-a", circuit_id="c1", backend_class="sim", min_confidence=0.1)
 
-    recommendation = service.get_recommendation(snapshot_id="s1", circuit_id="c1", backend_class="sim", min_confidence=0.1)
+    recommendation = service.get_recommendation(snapshot_id="s1", tenant_id="tenant-a", project_id="project-a", circuit_id="c1", backend_class="sim", min_confidence=0.1)
     assert recommendation["contract"] == "pattern_miner.recommendation"
     assert recommendation["version"] == "1.0.0"
     assert recommendation["recommendation"]["fallback_used"] is False
@@ -109,7 +131,7 @@ def test_recommendation_payload_has_versioned_contract_and_provenance_links() ->
 
 def test_get_pattern_returns_canonical_template_and_separates_candidates() -> None:
     service = PatternMinerService()
-    service.ingest_snapshot(snapshot_id="s1", records=_dataset(), config_digest="cfg-a")
+    service.ingest_snapshot(snapshot_id="s1", records=_dataset(tenant_id="tenant-a", project_id="project-a"), config_digest="cfg-a", tenant_id="tenant-a", project_id="project-a")
 
     result = service.get_pattern(
         snapshot_id="s1",
@@ -156,7 +178,7 @@ def test_get_pattern_returns_canonical_template_and_separates_candidates() -> No
 
 def test_get_pattern_returns_diagnostics_when_no_canonical_pattern_exists() -> None:
     service = PatternMinerService()
-    service.ingest_snapshot(snapshot_id="s1", records=_dataset(), config_digest="cfg-a")
+    service.ingest_snapshot(snapshot_id="s1", records=_dataset(tenant_id="tenant-a", project_id="project-a"), config_digest="cfg-a")
 
     result = service.get_pattern(
         snapshot_id="s1",
@@ -185,6 +207,90 @@ def test_get_pattern_returns_diagnostics_when_no_canonical_pattern_exists() -> N
     assert all(candidate["selected"] is False for candidate in result["candidate_patterns"])
     assert result["explanation_pattern"]["canonical_pattern_id"] == ""
     assert result["candidate_patterns"][0]["pattern_kind"] == "candidate"
+
+
+def test_get_pattern_rejects_cross_scope_access_and_mixed_snapshot_ingest() -> None:
+    service = PatternMinerService()
+    service.ingest_snapshot(snapshot_id="s1", records=_dataset(tenant_id="tenant-a", project_id="project-a"), config_digest="cfg-a", tenant_id="tenant-a", project_id="project-a")
+
+    mixed_records = _dataset(tenant_id="tenant-a", project_id="project-a") + _dataset(
+        tenant_id="tenant-b",
+        project_id="project-b",
+        prefix="foreign-",
+    )
+    with pytest.raises(ValueError):
+        service.ingest_snapshot(
+            snapshot_id="mixed",
+            records=mixed_records,
+            config_digest="cfg-mixed",
+        )
+
+    with pytest.raises(PermissionError):
+        service.get_pattern(
+            snapshot_id="s1",
+            tenant_id="tenant-b",
+            project_id="project-b",
+            circuit_id="c1",
+            backend_class="sim",
+            semantic_hash="semantic-alpha",
+            aqo_hash="aqo-alpha",
+            schema_version="1.0.0",
+            compiler_version="compiler-1.0",
+            aqo_version="aqo-1.0",
+            optimizer_version="opt-1.0",
+            policy_mode="deterministic",
+            policy_digest="policy-1",
+            seed=7,
+            query_mode="structural",
+            candidate_budget=8,
+            deterministic=True,
+        )
+
+
+def test_pattern_retrieval_outputs_stay_within_tenant_project_scope() -> None:
+    service = PatternMinerService()
+    service.ingest_snapshot(snapshot_id="tenant-a-s1", records=_dataset(tenant_id="tenant-a", project_id="project-a"), config_digest="cfg-a", tenant_id="tenant-a", project_id="project-a")
+    service.ingest_snapshot(snapshot_id="tenant-b-s1", records=_dataset(tenant_id="tenant-b", project_id="project-b", prefix="foreign-"), config_digest="cfg-b", tenant_id="tenant-b", project_id="project-b")
+
+    result = service.get_pattern(
+        snapshot_id="tenant-a-s1",
+        tenant_id="tenant-a",
+        project_id="project-a",
+        circuit_id="c1",
+        backend_class="sim",
+        semantic_hash="semantic-alpha",
+        aqo_hash="aqo-alpha",
+        schema_version="1.0.0",
+        compiler_version="compiler-1.0",
+        aqo_version="aqo-1.0",
+        optimizer_version="opt-1.0",
+        policy_mode="deterministic",
+        policy_digest="policy-1",
+        seed=7,
+        query_mode="structural",
+        candidate_budget=8,
+        deterministic=True,
+    )
+
+    assert result["tenant_id"] == "tenant-a"
+    assert result["project_id"] == "project-a"
+    assert all(not record_id.startswith("foreign-") for candidate in result["candidate_patterns"] for record_id in candidate["source_record_ids"])
+    assert "tenant-b" not in json.dumps(result)
+    assert "project-b" not in json.dumps(result)
+
+    recommendation = service.get_recommendation(
+        snapshot_id="tenant-a-s1",
+        tenant_id="tenant-a",
+        project_id="project-a",
+        circuit_id="c1",
+        backend_class="sim",
+        min_confidence=0.1,
+    )
+    assert recommendation["tenant_id"] == "tenant-a"
+    assert recommendation["project_id"] == "project-a"
+    assert all(not rid.startswith("foreign-") for rid in recommendation["provenance"]["source_record_ids"])
+    assert "tenant-b" not in json.dumps(recommendation)
+    assert "project-b" not in json.dumps(recommendation)
 
 
 def test_pattern_miner_recommendation_contract_fixture_v1_0_0() -> None:


### PR DESCRIPTION
## Summary

Implemented tenant/project boundary enforcement for the KB pattern retrieval flow in PatternMinerService and closed the remaining cross-scope leakage paths.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: API
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Tenant/project scope enforcement for pattern snapshot ingest and retrieval.
- Negative tests covering mixed-scope ingest rejection and cross-scope access denial.
- Explicit boundary-policy documentation for candidate generation, explanation payloads, and replay/recommendation outputs.

### Changed
- Pattern catalog construction now filters to the snapshot’s stored tenant/project boundary before ranking.
mine_patterns and get_recommendation now require tenant/project scope inputs.
- Recommendation payloads now include the active tenant/project context.

### Fixed
- Cross-tenant / cross-project leakage through pattern retrieval paths.
- Mixed-scope snapshot ingest that could have produced ambiguous or unsafe candidate catalogs.