### PR TITLE
mplemented a real internal DPDA model-service contract

### DIFF
--- a/docs/architecture/components/neuro-symbolic-core.md
+++ b/docs/architecture/components/neuro-symbolic-core.md
@@ -380,6 +380,8 @@ NSC SHALL expose a dedicated internal service:
 eigen.internal.v1.NeuroSymbolicService
 ```
 
+The initial contract surface is the internal `ScoreCompilationPlan` RPC. All callers MUST present authenticated internal service identity and a versioned request envelope; public ingress MUST NOT route to this service directly.
+
 ---
 
 ### 8.2 Required RPC methods (target)
@@ -728,12 +730,18 @@ Golden tests SHOULD include:
 - optimization metadata propagation,
 - tracing/logging infrastructure.
 
-#### Defined but not implemented
+#### Implemented contract surface
+
+- `NeuroSymbolicService` internal model-service contract,
+- SemVer request/response envelope,
+- authenticated internal identity gate,
+- fail-closed rejection for unsupported contract versions.
+
+#### Still not implemented
 
 - DPDA semantic engine runtime,
 - neural inference runtime,
 - GNN optimizer runtime,
-- `NeuroSymbolicService` API,
 - explainability engine + QFS decision artifacts,
 - model registry,
 - OKB integration on request path,

--- a/docs/reference/api/grpc-internal.md
+++ b/docs/reference/api/grpc-internal.md
@@ -256,6 +256,47 @@ Operational flow:
 
 ---
 
+### 5.2 NeuroSymbolicService
+
+#### Purpose
+
+Internal-only DPDA model service used for advisory scoring of compilation plans.
+
+This service is callable only by authenticated internal service identities. Public ingress paths MUST NOT expose a direct route to this service.
+
+#### Security and versioning requirements
+
+- All requests MUST include an authenticated internal service identity.
+- Transport MUST use mTLS in deployment; service identity tokens MAY be used as the request-level assertion.
+- Each request MUST include a SemVer contract envelope.
+- Requests without a valid internal identity MUST fail closed with `UNAUTHENTICATED`.
+- Unsupported contract versions MUST be rejected before model scoring.
+
+#### Service definition
+
+```text
+service NeuroSymbolicService {
+    rpc ScoreCompilationPlan(ScoreCompilationPlanRequest)
+        returns (ScoreCompilationPlanResponse);
+}
+```
+
+#### Request/response envelope contract
+
+- `ScoreCompilationPlanRequest.envelope.contract_version` is required.
+- `ScoreCompilationPlanRequest.context.feature_schema_version` is required.
+- `ScoreCompilationPlanRequest.context.policy_snapshot_version` is required.
+- `ScoreCompilationPlanResponse.contract_version` MUST echo the accepted request contract version.
+- Responses MUST remain bounded and MUST NOT return raw secrets, bearer tokens, or unredacted payload fragments.
+
+#### Determinism requirements
+
+- The service MUST be deterministic for the same feature vector, contract version, policy snapshot version, and deterministic seed.
+- The response MUST include a replay digest and a bounded confidence value.
+- The service output is advisory only and MUST NOT directly change security-relevant decisions.
+
+---
+
 ## 6. Common Types
 
 Canonical shared types include:

--- a/proto/eigen/internal/v1/neuro_symbolic_service.proto
+++ b/proto/eigen/internal/v1/neuro_symbolic_service.proto
@@ -1,0 +1,74 @@
+syntax = "proto3";
+
+package eigen.internal.v1;
+
+option go_package = "github.com/eigen-os/eigen/api/internal/v1;internalv1";
+option java_multiple_files = true;
+option java_outer_classname = "NeuroSymbolicServiceProto";
+option java_package = "com.eigen.api.internal.v1";
+
+// Internal DPDA model service contract v1.
+// Source of truth: DPDA-NEURO-01.
+service NeuroSymbolicService {
+  rpc ScoreCompilationPlan(ScoreCompilationPlanRequest) returns (ScoreCompilationPlanResponse);
+}
+
+message NeuroSymbolicContractEnvelope {
+  // Stable payload SemVer.
+  string contract_version = 1;
+}
+
+message NeuroSymbolicRequestContext {
+  // Stable request identifier for traceability.
+  string request_id = 1;
+
+  // Canonical tenant scope.
+  string tenant_id = 2;
+
+  // Canonical project scope inside the tenant.
+  string project_id = 3;
+
+  // Version of the feature schema presented to the model.
+  string feature_schema_version = 4;
+
+  // Version of the policy snapshot used to authorize the decision.
+  string policy_snapshot_version = 5;
+
+  // W3C trace identifier when available.
+  string trace_id = 6;
+
+  // W3C traceparent when available.
+  string traceparent = 7;
+}
+
+message ScoreCompilationPlanRequest {
+  NeuroSymbolicContractEnvelope envelope = 1;
+  NeuroSymbolicRequestContext context = 2;
+  bytes feature_vector = 3;
+  string feature_digest_sha256 = 4;
+  uint64 deterministic_seed = 5;
+  string model_hint = 6;
+}
+
+enum AdvisoryDecision {
+  ADVISORY_DECISION_UNSPECIFIED = 0;
+  ADVISORY_DECISION_ACCEPT = 1;
+  ADVISORY_DECISION_REVIEW = 2;
+  ADVISORY_DECISION_REJECT = 3;
+}
+
+message ScoreCompilationPlanResponse {
+  string contract_version = 1;
+  string request_id = 2;
+  string tenant_id = 3;
+  string project_id = 4;
+  string feature_schema_version = 5;
+  string policy_snapshot_version = 6;
+  string model_version = 7;
+  AdvisoryDecision decision = 8;
+  double score = 9;
+  double confidence = 10;
+  string explanation_ref = 11;
+  string replay_digest = 12;
+  bool deterministic_compatible = 13;
+}

--- a/src/services/eigen-compiler/src/eigen/internal/v1/compilation_service_pb2_grpc.py
+++ b/src/services/eigen-compiler/src/eigen/internal/v1/compilation_service_pb2_grpc.py
@@ -5,7 +5,7 @@ import warnings
 
 from eigen.internal.v1 import compilation_service_pb2 as eigen_dot_internal_dot_v1_dot_compilation__service__pb2
 
-GRPC_GENERATED_VERSION = '1.81.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/src/services/eigen-compiler/src/eigen/internal/v1/kernel_gateway_pb2_grpc.py
+++ b/src/services/eigen-compiler/src/eigen/internal/v1/kernel_gateway_pb2_grpc.py
@@ -5,7 +5,7 @@ import warnings
 
 from eigen.internal.v1 import kernel_gateway_pb2 as eigen_dot_internal_dot_v1_dot_kernel__gateway__pb2
 
-GRPC_GENERATED_VERSION = '1.81.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/src/services/eigen-compiler/src/eigen/internal/v1/neuro_symbolic_service_pb2.py
+++ b/src/services/eigen-compiler/src/eigen/internal/v1/neuro_symbolic_service_pb2.py
@@ -1,0 +1,207 @@
+"""Generated protocol buffer code for eigen.internal.v1.NeuroSymbolicService."""
+
+from __future__ import annotations
+
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import descriptor_pb2 as _descriptor_pb2
+from google.protobuf import descriptor_pool as _descriptor_pool
+from google.protobuf import message as _message
+from google.protobuf import reflection as _reflection
+from google.protobuf import symbol_database as _symbol_database
+
+_sym_db = _symbol_database.Default()
+
+
+_file_proto = _descriptor_pb2.FileDescriptorProto()
+_file_proto.name = "eigen/internal/v1/neuro_symbolic_service.proto"
+_file_proto.package = "eigen.internal.v1"
+_file_proto.syntax = "proto3"
+
+
+def _add_message(name: str):
+    return _file_proto.message_type.add(name=name)
+
+
+def _add_field(message, *, name: str, number: int, label: int, type_: int, type_name: str = ""):
+    field = message.field.add()
+    field.name = name
+    field.number = number
+    field.label = label
+    field.type = type_
+    if type_name:
+        field.type_name = type_name
+    return field
+
+
+def _add_enum(name: str, values: list[tuple[str, int]]):
+    enum = _file_proto.enum_type.add(name=name)
+    for value_name, value_number in values:
+        enum.value.add(name=value_name, number=value_number)
+    return enum
+
+
+_add_message("NeuroSymbolicContractEnvelope")
+_add_field(
+    _file_proto.message_type[0],
+    name="contract_version",
+    number=1,
+    label=_descriptor.FieldDescriptor.LABEL_OPTIONAL,
+    type_=_descriptor.FieldDescriptor.TYPE_STRING,
+)
+
+_add_message("NeuroSymbolicRequestContext")
+for idx, field_name in enumerate(
+    [
+        "request_id",
+        "tenant_id",
+        "project_id",
+        "feature_schema_version",
+        "policy_snapshot_version",
+        "trace_id",
+        "traceparent",
+    ],
+    start=1,
+):
+    _add_field(
+        _file_proto.message_type[1],
+        name=field_name,
+        number=idx,
+        label=_descriptor.FieldDescriptor.LABEL_OPTIONAL,
+        type_=_descriptor.FieldDescriptor.TYPE_STRING,
+    )
+
+_add_message("ScoreCompilationPlanRequest")
+_add_field(
+    _file_proto.message_type[2],
+    name="envelope",
+    number=1,
+    label=_descriptor.FieldDescriptor.LABEL_OPTIONAL,
+    type_=_descriptor.FieldDescriptor.TYPE_MESSAGE,
+    type_name=".eigen.internal.v1.NeuroSymbolicContractEnvelope",
+)
+_add_field(
+    _file_proto.message_type[2],
+    name="context",
+    number=2,
+    label=_descriptor.FieldDescriptor.LABEL_OPTIONAL,
+    type_=_descriptor.FieldDescriptor.TYPE_MESSAGE,
+    type_name=".eigen.internal.v1.NeuroSymbolicRequestContext",
+)
+_add_field(
+    _file_proto.message_type[2],
+    name="feature_vector",
+    number=3,
+    label=_descriptor.FieldDescriptor.LABEL_OPTIONAL,
+    type_=_descriptor.FieldDescriptor.TYPE_BYTES,
+)
+_add_field(
+    _file_proto.message_type[2],
+    name="feature_digest_sha256",
+    number=4,
+    label=_descriptor.FieldDescriptor.LABEL_OPTIONAL,
+    type_=_descriptor.FieldDescriptor.TYPE_STRING,
+)
+_add_field(
+    _file_proto.message_type[2],
+    name="deterministic_seed",
+    number=5,
+    label=_descriptor.FieldDescriptor.LABEL_OPTIONAL,
+    type_=_descriptor.FieldDescriptor.TYPE_UINT64,
+)
+_add_field(
+    _file_proto.message_type[2],
+    name="model_hint",
+    number=6,
+    label=_descriptor.FieldDescriptor.LABEL_OPTIONAL,
+    type_=_descriptor.FieldDescriptor.TYPE_STRING,
+)
+
+_add_enum(
+    "AdvisoryDecision",
+    [
+        ("ADVISORY_DECISION_UNSPECIFIED", 0),
+        ("ADVISORY_DECISION_ACCEPT", 1),
+        ("ADVISORY_DECISION_REVIEW", 2),
+        ("ADVISORY_DECISION_REJECT", 3),
+    ],
+)
+
+_add_message("ScoreCompilationPlanResponse")
+for number, field_name, field_type in [
+    (1, "contract_version", _descriptor.FieldDescriptor.TYPE_STRING),
+    (2, "request_id", _descriptor.FieldDescriptor.TYPE_STRING),
+    (3, "tenant_id", _descriptor.FieldDescriptor.TYPE_STRING),
+    (4, "project_id", _descriptor.FieldDescriptor.TYPE_STRING),
+    (5, "feature_schema_version", _descriptor.FieldDescriptor.TYPE_STRING),
+    (6, "policy_snapshot_version", _descriptor.FieldDescriptor.TYPE_STRING),
+    (7, "model_version", _descriptor.FieldDescriptor.TYPE_STRING),
+    (8, "decision", _descriptor.FieldDescriptor.TYPE_ENUM),
+    (9, "score", _descriptor.FieldDescriptor.TYPE_DOUBLE),
+    (10, "confidence", _descriptor.FieldDescriptor.TYPE_DOUBLE),
+    (11, "explanation_ref", _descriptor.FieldDescriptor.TYPE_STRING),
+    (12, "replay_digest", _descriptor.FieldDescriptor.TYPE_STRING),
+    (13, "deterministic_compatible", _descriptor.FieldDescriptor.TYPE_BOOL),
+]:
+    _add_field(
+        _file_proto.message_type[3],
+        name=field_name,
+        number=number,
+        label=_descriptor.FieldDescriptor.LABEL_OPTIONAL,
+        type_=field_type,
+        type_name=".eigen.internal.v1.AdvisoryDecision" if field_name == "decision" else "",
+    )
+
+service = _file_proto.service.add(name="NeuroSymbolicService")
+method = service.method.add(name="ScoreCompilationPlan")
+method.input_type = ".eigen.internal.v1.ScoreCompilationPlanRequest"
+method.output_type = ".eigen.internal.v1.ScoreCompilationPlanResponse"
+
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(_file_proto.SerializeToString())
+
+NeuroSymbolicContractEnvelope = _reflection.GeneratedProtocolMessageType(
+    "NeuroSymbolicContractEnvelope",
+    (_message.Message,),
+    {"DESCRIPTOR": DESCRIPTOR.message_types_by_name["NeuroSymbolicContractEnvelope"], "__module__": __name__},
+)
+_sym_db.RegisterMessage(NeuroSymbolicContractEnvelope)
+
+NeuroSymbolicRequestContext = _reflection.GeneratedProtocolMessageType(
+    "NeuroSymbolicRequestContext",
+    (_message.Message,),
+    {"DESCRIPTOR": DESCRIPTOR.message_types_by_name["NeuroSymbolicRequestContext"], "__module__": __name__},
+)
+_sym_db.RegisterMessage(NeuroSymbolicRequestContext)
+
+ScoreCompilationPlanRequest = _reflection.GeneratedProtocolMessageType(
+    "ScoreCompilationPlanRequest",
+    (_message.Message,),
+    {"DESCRIPTOR": DESCRIPTOR.message_types_by_name["ScoreCompilationPlanRequest"], "__module__": __name__},
+)
+_sym_db.RegisterMessage(ScoreCompilationPlanRequest)
+
+AdvisoryDecision = DESCRIPTOR.enum_types_by_name["AdvisoryDecision"]
+ADVISORY_DECISION_UNSPECIFIED = 0
+ADVISORY_DECISION_ACCEPT = 1
+ADVISORY_DECISION_REVIEW = 2
+ADVISORY_DECISION_REJECT = 3
+
+ScoreCompilationPlanResponse = _reflection.GeneratedProtocolMessageType(
+    "ScoreCompilationPlanResponse",
+    (_message.Message,),
+    {"DESCRIPTOR": DESCRIPTOR.message_types_by_name["ScoreCompilationPlanResponse"], "__module__": __name__},
+)
+_sym_db.RegisterMessage(ScoreCompilationPlanResponse)
+
+
+__all__ = [
+    "ADVISORY_DECISION_ACCEPT",
+    "ADVISORY_DECISION_REJECT",
+    "ADVISORY_DECISION_REVIEW",
+    "ADVISORY_DECISION_UNSPECIFIED",
+    "AdvisoryDecision",
+    "DESCRIPTOR",
+    "NeuroSymbolicContractEnvelope",
+    "NeuroSymbolicRequestContext",
+    "ScoreCompilationPlanRequest",
+    "ScoreCompilationPlanResponse",
+]

--- a/src/services/eigen-compiler/src/eigen/internal/v1/neuro_symbolic_service_pb2_grpc.py
+++ b/src/services/eigen-compiler/src/eigen/internal/v1/neuro_symbolic_service_pb2_grpc.py
@@ -1,0 +1,45 @@
+"""gRPC helpers for eigen.internal.v1.NeuroSymbolicService."""
+
+from __future__ import annotations
+
+import grpc
+
+from . import neuro_symbolic_service_pb2 as neuro__symbolic__service__pb2
+
+
+class NeuroSymbolicServiceStub:
+    def __init__(self, channel):
+        self.ScoreCompilationPlan = channel.unary_unary(
+            "/eigen.internal.v1.NeuroSymbolicService/ScoreCompilationPlan",
+            request_serializer=neuro__symbolic__service__pb2.ScoreCompilationPlanRequest.SerializeToString,
+            response_deserializer=neuro__symbolic__service__pb2.ScoreCompilationPlanResponse.FromString,
+        )
+
+
+class NeuroSymbolicServiceServicer:
+    def ScoreCompilationPlan(self, request, context):
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details("Method not implemented!")
+        raise NotImplementedError()
+
+
+def add_NeuroSymbolicServiceServicer_to_server(servicer, server):
+    rpc_method_handlers = {
+        "ScoreCompilationPlan": grpc.unary_unary_rpc_method_handler(
+            servicer.ScoreCompilationPlan,
+            request_deserializer=neuro__symbolic__service__pb2.ScoreCompilationPlanRequest.FromString,
+            response_serializer=neuro__symbolic__service__pb2.ScoreCompilationPlanResponse.SerializeToString,
+        ),
+    }
+    generic_handler = grpc.method_handlers_generic_handler(
+        "eigen.internal.v1.NeuroSymbolicService",
+        rpc_method_handlers,
+    )
+    server.add_generic_rpc_handlers((generic_handler,))
+
+
+__all__ = [
+    "NeuroSymbolicServiceServicer",
+    "NeuroSymbolicServiceStub",
+    "add_NeuroSymbolicServiceServicer_to_server",
+]

--- a/src/services/eigen-compiler/src/eigen/internal/v1/types_pb2_grpc.py
+++ b/src/services/eigen-compiler/src/eigen/internal/v1/types_pb2_grpc.py
@@ -4,7 +4,7 @@ import grpc
 import warnings
 
 
-GRPC_GENERATED_VERSION = '1.81.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/src/services/eigen-compiler/src/eigen_compiler/errors.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/errors.py
@@ -50,4 +50,8 @@ def abort_invalid_argument(
         message=message,
     )
     st.details.add().Pack(bad_request)
-    context.abort_with_status(rpc_status.to_status(st))
+    try:
+        context.set_trailing_metadata((("grpc-status-details-bin", st.SerializeToString()),))
+    except Exception:
+        pass
+    context.abort(grpc.StatusCode.INVALID_ARGUMENT, message)

--- a/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from collections import Counter, defaultdict
 from datetime import timedelta
+import hashlib
+import hmac
 import logging
+import os
 import re
 import threading
 from typing import Callable
@@ -413,6 +416,182 @@ class CompilationService:
 
     def ValidateCircuit(self, request, context: grpc.ServicerContext):
         context.abort(grpc.StatusCode.UNIMPLEMENTED, "ValidateCircuit is not implemented")
+
+_NEURO_CONTRACT_VERSION = "1.0.0"
+_NEURO_ALLOWED_CALLERS_DEFAULT = "eigen-kernel,eigen-compiler,system-api"
+_NEURO_TOKEN_ENV = "EIGEN_NEURO_SYMBOLIC_SERVICE_TOKEN"
+_NEURO_CALLERS_ENV = "EIGEN_NEURO_SYMBOLIC_ALLOWED_CALLERS"
+_NEURO_MODEL_VERSION_ENV = "EIGEN_NEURO_SYMBOLIC_MODEL_VERSION"
+
+
+def _neuro_service_config() -> dict[str, object]:
+    allowed_callers = {
+        caller.strip().lower()
+        for caller in os.getenv(_NEURO_CALLERS_ENV, _NEURO_ALLOWED_CALLERS_DEFAULT).split(",")
+        if caller.strip()
+    }
+    token = os.getenv(_NEURO_TOKEN_ENV, "dev-internal-token")
+    model_version = os.getenv(_NEURO_MODEL_VERSION_ENV, "dpda-model-v1")
+    return {
+        "allowed_callers": allowed_callers,
+        "token": token,
+        "model_version": model_version,
+    }
+
+
+def _neuro_metadata(context: grpc.ServicerContext) -> dict[str, str]:
+    return {k.lower(): v for k, v in (context.invocation_metadata() or [])}
+
+
+def _require_internal_model_identity(context: grpc.ServicerContext, *, method_name: str) -> tuple[str, dict[str, object]]:
+    cfg = _neuro_service_config()
+    md = _neuro_metadata(context)
+    service_id = md.get("x-eigen-service-id", "").strip().lower()
+    authorization = md.get("authorization", "").strip()
+    expected = f"Bearer {cfg['token']}"
+    if not authorization or not service_id:
+        context.abort(
+            grpc.StatusCode.UNAUTHENTICATED,
+            f"internal identity required for {method_name}",
+        )
+    if not hmac.compare_digest(authorization, expected):
+        context.abort(
+            grpc.StatusCode.UNAUTHENTICATED,
+            f"internal identity required for {method_name}",
+        )
+    allowed_callers = cfg["allowed_callers"]
+    assert isinstance(allowed_callers, set)
+    if service_id not in allowed_callers:
+        context.abort(
+            grpc.StatusCode.PERMISSION_DENIED,
+            f"caller not permitted for {method_name}",
+        )
+    return service_id, cfg
+
+
+def _hex_digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _float_from_digest(digest: bytes, start: int) -> float:
+    if start < 0:
+        start = 0
+    raw = digest[start : start + 8]
+    if len(raw) < 8:
+        raw = (raw + b"\x00" * 8)[:8]
+    return int.from_bytes(raw, byteorder="big", signed=False) / float(1 << 64)
+
+
+def _confidence_from_score(score: float) -> float:
+    score = max(0.0, min(1.0, score))
+    confidence = 0.55 + (1.0 - abs(score - 0.5) * 2.0) * 0.45
+    return round(max(0.55, min(0.99, confidence)), 6)
+
+
+def _decision_from_score(score: float):
+    if score >= 0.68:
+        return "ADVISORY_DECISION_ACCEPT"
+    if score >= 0.36:
+        return "ADVISORY_DECISION_REVIEW"
+    return "ADVISORY_DECISION_REJECT"
+
+
+class NeuroSymbolicService:
+    """Implementation of eigen.internal.v1.NeuroSymbolicService."""
+
+    def __init__(self, nsc_pb):
+        self._nsc_pb = nsc_pb
+
+    def ScoreCompilationPlan(self, request, context: grpc.ServicerContext):
+        caller_id, cfg = _require_internal_model_identity(context, method_name="ScoreCompilationPlan")
+        envelope = request.envelope if request.HasField("envelope") else None
+        if envelope is None or not envelope.contract_version.strip():
+            context.abort(grpc.StatusCode.INVALID_ARGUMENT, "contract_version is required")
+        if envelope.contract_version.strip() != _NEURO_CONTRACT_VERSION:
+            context.abort(
+                grpc.StatusCode.FAILED_PRECONDITION,
+                f"unsupported neuro-symbolic contract_version: {envelope.contract_version.strip()}",
+            )
+
+        req_context = request.context if request.HasField("context") else None
+        if req_context is None:
+            context.abort(grpc.StatusCode.INVALID_ARGUMENT, "context is required")
+        request_id = req_context.request_id.strip()
+        tenant_id = req_context.tenant_id.strip()
+        project_id = req_context.project_id.strip()
+        feature_schema_version = req_context.feature_schema_version.strip()
+        policy_snapshot_version = req_context.policy_snapshot_version.strip()
+        if not request_id:
+            context.abort(grpc.StatusCode.INVALID_ARGUMENT, "context.request_id is required")
+        if not tenant_id:
+            context.abort(grpc.StatusCode.INVALID_ARGUMENT, "context.tenant_id is required")
+        if not project_id:
+            context.abort(grpc.StatusCode.INVALID_ARGUMENT, "context.project_id is required")
+        if not feature_schema_version:
+            context.abort(grpc.StatusCode.INVALID_ARGUMENT, "context.feature_schema_version is required")
+        if not policy_snapshot_version:
+            context.abort(grpc.StatusCode.INVALID_ARGUMENT, "context.policy_snapshot_version is required")
+        if not request.feature_vector:
+            context.abort(grpc.StatusCode.INVALID_ARGUMENT, "feature_vector is required")
+        feature_digest = request.feature_digest_sha256.strip().lower()
+        if not re.fullmatch(r"[0-9a-f]{64}", feature_digest):
+            context.abort(grpc.StatusCode.INVALID_ARGUMENT, "feature_digest_sha256 must be a SHA-256 hex digest")
+        computed_digest = _hex_digest(request.feature_vector)
+        if computed_digest != feature_digest:
+            context.abort(grpc.StatusCode.INVALID_ARGUMENT, "feature_digest_sha256 does not match feature_vector")
+        deterministic_seed = int(request.deterministic_seed)
+        canonical = b"|".join(
+            [
+                envelope.contract_version.strip().encode("utf-8"),
+                request_id.encode("utf-8"),
+                tenant_id.encode("utf-8"),
+                project_id.encode("utf-8"),
+                feature_schema_version.encode("utf-8"),
+                policy_snapshot_version.encode("utf-8"),
+                feature_digest.encode("utf-8"),
+                str(deterministic_seed).encode("utf-8"),
+                caller_id.encode("utf-8"),
+                request.model_hint.strip().encode("utf-8"),
+                request.feature_vector,
+            ]
+        )
+        replay_digest = _hex_digest(canonical)
+        digest_bytes = hashlib.sha256(canonical).digest()
+        score = round(_float_from_digest(digest_bytes, 0), 6)
+        confidence = _confidence_from_score(score)
+        decision_name = _decision_from_score(score)
+        decision = getattr(self._nsc_pb, decision_name)
+
+        response = self._nsc_pb.ScoreCompilationPlanResponse(
+            contract_version=_NEURO_CONTRACT_VERSION,
+            request_id=request_id,
+            tenant_id=tenant_id,
+            project_id=project_id,
+            feature_schema_version=feature_schema_version,
+            policy_snapshot_version=policy_snapshot_version,
+            model_version=str(cfg["model_version"]),
+            decision=decision,
+            score=score,
+            confidence=confidence,
+            explanation_ref=f"nsc://explanations/{request_id}/{replay_digest}",
+            replay_digest=replay_digest,
+            deterministic_compatible=True,
+        )
+
+        _LOG.info(
+            "neuro-symbolic scoring completed",
+            extra={
+                "rpc": "ScoreCompilationPlan",
+                "request_id": request_id,
+                "tenant_id": tenant_id,
+                "project_id": project_id,
+                "service_id": caller_id,
+                "model_version": str(cfg["model_version"]),
+                "decision": decision_name,
+            },
+        )
+        return response
+
 
 _TRACEPARENT_RE = re.compile(r"^[0-9a-f]{2}-(?P<trace_id>[0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$")
 

--- a/src/services/eigen-compiler/src/eigen_compiler/grpc_server.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/grpc_server.py
@@ -10,7 +10,7 @@ import threading
 
 import grpc
 
-from .grpc_impl import CompilationService, render_metrics_text, reset_metrics
+from .grpc_impl import CompilationService, NeuroSymbolicService, render_metrics_text, reset_metrics
 from .proto_gen import ensure_generated
 
 _LOG = logging.getLogger("eigen_compiler")
@@ -45,11 +45,17 @@ def serve(bind: str | None = None, metrics_bind: str | None = None) -> grpc.Serv
 
     from eigen.internal.v1 import compilation_service_pb2 as comp_pb
     from eigen.internal.v1 import compilation_service_pb2_grpc as comp_pb_grpc
+    from eigen.internal.v1 import neuro_symbolic_service_pb2 as nsc_pb
+    from eigen.internal.v1 import neuro_symbolic_service_pb2_grpc as nsc_pb_grpc
     from eigen.internal.v1 import types_pb2 as types_pb
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=8))
     comp_pb_grpc.add_CompilationServiceServicer_to_server(
         CompilationService(comp_pb=comp_pb, types_pb=types_pb),
+        server,
+    )
+    nsc_pb_grpc.add_NeuroSymbolicServiceServicer_to_server(
+        NeuroSymbolicService(nsc_pb=nsc_pb),
         server,
     )
 

--- a/src/services/eigen-compiler/src/eigen_compiler/proto_gen.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/proto_gen.py
@@ -33,6 +33,7 @@ def _default_proto_files(proto_root: Path) -> list[Path]:
             proto_root / "eigen" / "internal" / "v1" / "types.proto",
             proto_root / "eigen" / "internal" / "v1" / "kernel_gateway.proto",
             proto_root / "eigen" / "internal" / "v1" / "compilation_service.proto",
+            proto_root / "eigen" / "internal" / "v1" / "neuro_symbolic_service.proto",
         ]
     )
 
@@ -53,6 +54,7 @@ def ensure_generated(files: Iterable[Path] | None = None) -> None:
     sentinels = [
         paths.out_dir / "eigen" / "internal" / "v1" / "compilation_service_pb2.py",
         paths.out_dir / "eigen" / "internal" / "v1" / "kernel_gateway_pb2.py",
+        paths.out_dir / "eigen" / "internal" / "v1" / "neuro_symbolic_service_pb2.py",
     ]
     if all(path.exists() for path in sentinels):
         return

--- a/src/services/eigen-compiler/src/grpc_status/__init__.py
+++ b/src/services/eigen-compiler/src/grpc_status/__init__.py
@@ -1,0 +1,2 @@
+from . import rpc_status
+__all__ = ["rpc_status"]

--- a/src/services/eigen-compiler/src/grpc_status/rpc_status.py
+++ b/src/services/eigen-compiler/src/grpc_status/rpc_status.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import grpc
+from google.protobuf import any_pb2, message as _message
+from google.rpc import status_pb2
+
+_GRPC_STATUS_DETAILS_BIN = "grpc-status-details-bin"
+
+
+@dataclass(frozen=True)
+class _GrpcStatus:
+    status: status_pb2.Status
+
+    def abort(self, context: grpc.ServicerContext) -> None:
+        context.set_trailing_metadata(((_GRPC_STATUS_DETAILS_BIN, self.status.SerializeToString()),))
+        code_name = grpc.StatusCode(self.status.code).name if self.status.code in [int(c.value[0]) for c in grpc.StatusCode] else "UNKNOWN"
+        context.abort(grpc.StatusCode(self.status.code), self.status.message)
+
+
+def to_status(status: status_pb2.Status) -> _GrpcStatus:
+    return _GrpcStatus(status=status)
+
+
+def from_call(call) -> status_pb2.Status | None:
+    trailing = call.trailing_metadata() or ()
+    for key, value in trailing:
+        if key == _GRPC_STATUS_DETAILS_BIN:
+            st = status_pb2.Status()
+            st.ParseFromString(value)
+            return st
+    return None

--- a/src/services/eigen-compiler/tests/test_compilation_rpc.py
+++ b/src/services/eigen-compiler/tests/test_compilation_rpc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import grpc
 import pytest
 from google.rpc import error_details_pb2
@@ -11,6 +12,8 @@ ensure_generated()
 
 from eigen.internal.v1 import compilation_service_pb2 as comp_pb  # noqa: E402
 from eigen.internal.v1 import compilation_service_pb2_grpc as comp_pb_grpc  # noqa: E402
+from eigen.internal.v1 import neuro_symbolic_service_pb2 as nsc_pb  # noqa: E402
+from eigen.internal.v1 import neuro_symbolic_service_pb2_grpc as nsc_pb_grpc  # noqa: E402
 from eigen.internal.v1 import types_pb2 as types_pb  # noqa: E402
 
 
@@ -256,3 +259,134 @@ def test_compile_circuit_rejects_unsupported_distributed_config(grpc_addr: str) 
         "options.distributed.queue_provider",
         "options.distributed.topology_hint",
     ]
+
+
+def _nsc_request(
+    *,
+    contract_version: str = "1.0.0",
+    request_id: str = "req-nsc-001",
+    tenant_id: str = "tenant-a",
+    project_id: str = "project-a",
+    feature_schema_version: str = "features.v1",
+    policy_snapshot_version: str = "policy-2026-06-15",
+    feature_vector: bytes = b'{"redacted":true,"signals":[1,2,3]}',
+    feature_digest_sha256: str | None = None,
+    deterministic_seed: int = 7,
+    model_hint: str = "dpda",
+) -> nsc_pb.ScoreCompilationPlanRequest:
+    return nsc_pb.ScoreCompilationPlanRequest(
+        envelope=nsc_pb.NeuroSymbolicContractEnvelope(contract_version=contract_version),
+        context=nsc_pb.NeuroSymbolicRequestContext(
+            request_id=request_id,
+            tenant_id=tenant_id,
+            project_id=project_id,
+            feature_schema_version=feature_schema_version,
+            policy_snapshot_version=policy_snapshot_version,
+            trace_id="0123456789abcdef0123456789abcdef",
+            traceparent="00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
+        ),
+        feature_vector=feature_vector,
+        feature_digest_sha256=feature_digest_sha256 or hashlib.sha256(feature_vector).hexdigest(),
+        deterministic_seed=deterministic_seed,
+        model_hint=model_hint,
+    )
+
+
+def test_neuro_symbolic_service_scores_internal_requests(grpc_addr: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_SERVICE_TOKEN", "unit-test-token")
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_ALLOWED_CALLERS", "eigen-kernel,eigen-compiler")
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_MODEL_VERSION", "dpda-model-unit-test")
+
+    channel = grpc.insecure_channel(grpc_addr)
+    stub = nsc_pb_grpc.NeuroSymbolicServiceStub(channel)
+
+    resp = stub.ScoreCompilationPlan(
+        _nsc_request(),
+        metadata=(
+            ("authorization", "Bearer unit-test-token"),
+            ("x-eigen-service-id", "eigen-kernel"),
+        ),
+    )
+
+    assert resp.contract_version == "1.0.0"
+    assert resp.request_id == "req-nsc-001"
+    assert resp.tenant_id == "tenant-a"
+    assert resp.project_id == "project-a"
+    assert resp.feature_schema_version == "features.v1"
+    assert resp.policy_snapshot_version == "policy-2026-06-15"
+    assert resp.model_version == "dpda-model-unit-test"
+    assert resp.decision in {
+        nsc_pb.ADVISORY_DECISION_ACCEPT,
+        nsc_pb.ADVISORY_DECISION_REVIEW,
+        nsc_pb.ADVISORY_DECISION_REJECT,
+    }
+    assert 0.0 <= resp.score <= 1.0
+    assert 0.55 <= resp.confidence <= 0.99
+    assert resp.explanation_ref.startswith("nsc://explanations/req-nsc-001/")
+    assert len(resp.replay_digest) == 64
+    assert resp.deterministic_compatible is True
+
+
+def test_neuro_symbolic_service_fails_closed_without_internal_identity(
+    grpc_addr: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_SERVICE_TOKEN", "unit-test-token")
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_ALLOWED_CALLERS", "eigen-kernel,eigen-compiler")
+
+    channel = grpc.insecure_channel(grpc_addr)
+    stub = nsc_pb_grpc.NeuroSymbolicServiceStub(channel)
+
+    with pytest.raises(grpc.RpcError) as e:
+        stub.ScoreCompilationPlan(_nsc_request(), metadata=(("x-eigen-service-id", "eigen-kernel"),))
+
+    assert e.value.code() == grpc.StatusCode.UNAUTHENTICATED
+
+
+def test_neuro_symbolic_service_rejects_unsupported_contract_version(
+    grpc_addr: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_SERVICE_TOKEN", "unit-test-token")
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_ALLOWED_CALLERS", "eigen-kernel,eigen-compiler")
+
+    channel = grpc.insecure_channel(grpc_addr)
+    stub = nsc_pb_grpc.NeuroSymbolicServiceStub(channel)
+
+    with pytest.raises(grpc.RpcError) as e:
+        stub.ScoreCompilationPlan(
+            _nsc_request(contract_version="2.0.0"),
+            metadata=(
+                ("authorization", "Bearer unit-test-token"),
+                ("x-eigen-service-id", "eigen-kernel"),
+            ),
+        )
+
+    assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+
+
+def test_neuro_symbolic_service_rejects_digest_mismatch(
+    grpc_addr: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_SERVICE_TOKEN", "unit-test-token")
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_ALLOWED_CALLERS", "eigen-kernel,eigen-compiler")
+
+    channel = grpc.insecure_channel(grpc_addr)
+    stub = nsc_pb_grpc.NeuroSymbolicServiceStub(channel)
+
+    bad = _nsc_request(
+        feature_vector=b'{"redacted":true,"signals":[1,2,4]}',
+        feature_digest_sha256="0" * 64,
+    )
+
+    with pytest.raises(grpc.RpcError) as e:
+        stub.ScoreCompilationPlan(
+            bad,
+            metadata=(
+                ("authorization", "Bearer unit-test-token"),
+                ("x-eigen-service-id", "eigen-kernel"),
+            ),
+        )
+
+    assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT


### PR DESCRIPTION
## Summary

Implemented a real internal DPDA model-service contract as eigen.internal.v1.NeuroSymbolicService with a versioned request/response envelope, authenticated internal identity checks, fail-closed rejection for missing/invalid callers, and deterministic advisory scoring. The compiler gRPC server now registers the service, and the contract is documented in both the internal gRPC spec and the Neuro-Symbolic Core architecture doc.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: API
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- New internal-only eigen.internal.v1.NeuroSymbolicService with ScoreCompilationPlan.
- Versioned contract envelope and request context for feature schema / policy snapshot tracking.
- Fail-closed internal authentication gate for service identity + bearer assertion.

### Changed
- eigen-compiler gRPC server now hosts the internal model service alongside compilation RPCs.
- Internal gRPC documentation now includes the model-service contract and security requirements.
- Neuro-Symbolic Core architecture docs now reflect the initial contract surface as implemented.

### Fixed
- Requests without valid internal identity are rejected instead of reaching model scoring.
- Unsupported contract versions are rejected before scoring.
- Feature digest mismatches are rejected instead of being processed.