### PR TITLE
Impl Policy Snapshot Enforcement

### DIFF
--- a/docs/architecture/components/neuro-symbolic-core.md
+++ b/docs/architecture/components/neuro-symbolic-core.md
@@ -164,6 +164,8 @@ Intelligent-adjacent behavior:
 - model registry + signed model lifecycle,
 - confidence-aware policy gating and deterministic rollback controller.
 
+The implemented NSC compiler path MUST still capture an immutable policy snapshot at service start and use that frozen snapshot for all inference requests. Live policy lookups MUST NOT be part of request-time scoring.
+
 **Production execution MUST NOT depend on NSC availability.**
 
 ---
@@ -222,6 +224,8 @@ Opaque decisions are prohibited.
 NSC MUST support deterministic mode.
 
 When `deterministic=true`, outputs MUST be a pure function of canonical inputs + seed and MUST be replayable byte-for-byte at the decision artifact level (canonical serialization).
+
+The active policy snapshot version used for scoring MUST be included in response metadata and audit logs so replay evidence is bound to the same immutable snapshot.
 
 ---
 

--- a/docs/reference/api/grpc-internal.md
+++ b/docs/reference/api/grpc-internal.md
@@ -286,6 +286,8 @@ service NeuroSymbolicService {
 - `ScoreCompilationPlanRequest.envelope.contract_version` is required.
 - `ScoreCompilationPlanRequest.context.feature_schema_version` is required.
 - `ScoreCompilationPlanRequest.context.policy_snapshot_version` is required.
+- The active policy snapshot MUST be frozen at service start and treated as immutable for the lifetime of the service process.
+- `ScoreCompilationPlanRequest.context.policy_snapshot_version` MUST match the active immutable snapshot version or the request MUST fail closed before scoring.
 - `ScoreCompilationPlanRequest.context.tenant_id` is required.
 - `ScoreCompilationPlanRequest.context.project_id` is required.
 - `ScoreCompilationPlanRequest.context.subject_id` is required.
@@ -293,12 +295,13 @@ service NeuroSymbolicService {
 - `ScoreCompilationPlanRequest.context.authz_decision_id` is required.
 - The normalized security context MUST be fully traceable in audit events and replay digests.
 - `ScoreCompilationPlanResponse.contract_version` MUST echo the accepted request contract version.
+- `ScoreCompilationPlanResponse.policy_snapshot_version` MUST echo the active immutable snapshot version used for scoring.
 - Responses SHOULD echo the normalized security context fields for bounded auditability.
 - Responses MUST remain bounded and MUST NOT return raw secrets, bearer tokens, or unredacted payload fragments.
 
 #### Determinism requirements
 
-- The service MUST be deterministic for the same feature vector, contract version, policy snapshot version, and deterministic seed.
+- The service MUST be deterministic for the same feature vector, contract version, active policy snapshot version, and deterministic seed.
 - The response MUST include a replay digest and a bounded confidence value.
 - The service output is advisory only and MUST NOT directly change security-relevant decisions.
 

--- a/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
@@ -422,6 +422,8 @@ _NEURO_ALLOWED_CALLERS_DEFAULT = "eigen-kernel,eigen-compiler,system-api"
 _NEURO_TOKEN_ENV = "EIGEN_NEURO_SYMBOLIC_SERVICE_TOKEN"
 _NEURO_CALLERS_ENV = "EIGEN_NEURO_SYMBOLIC_ALLOWED_CALLERS"
 _NEURO_MODEL_VERSION_ENV = "EIGEN_NEURO_SYMBOLIC_MODEL_VERSION"
+_NEURO_POLICY_SNAPSHOT_VERSION_ENV = "EIGEN_NEURO_SYMBOLIC_POLICY_SNAPSHOT_VERSION"
+_NEURO_POLICY_SNAPSHOT_DEFAULT = "policy-2026-06-15"
 
 
 def _neuro_service_config() -> dict[str, object]:
@@ -437,6 +439,11 @@ def _neuro_service_config() -> dict[str, object]:
         "token": token,
         "model_version": model_version,
     }
+
+
+def _active_policy_snapshot_version() -> str:
+    snapshot_version = os.getenv(_NEURO_POLICY_SNAPSHOT_VERSION_ENV, _NEURO_POLICY_SNAPSHOT_DEFAULT).strip()
+    return snapshot_version or _NEURO_POLICY_SNAPSHOT_DEFAULT
 
 
 def _neuro_metadata(context: grpc.ServicerContext) -> dict[str, str]:
@@ -499,8 +506,11 @@ def _decision_from_score(score: float):
 class NeuroSymbolicService:
     """Implementation of eigen.internal.v1.NeuroSymbolicService."""
 
-    def __init__(self, nsc_pb):
+    def __init__(self, nsc_pb, *, policy_snapshot_version: str | None = None):
         self._nsc_pb = nsc_pb
+        self._policy_snapshot_version = (policy_snapshot_version or _active_policy_snapshot_version()).strip()
+        if not self._policy_snapshot_version:
+            self._policy_snapshot_version = _NEURO_POLICY_SNAPSHOT_DEFAULT
 
     def ScoreCompilationPlan(self, request, context: grpc.ServicerContext):
         caller_id, cfg = _require_internal_model_identity(context, method_name="ScoreCompilationPlan")
@@ -543,6 +553,12 @@ class NeuroSymbolicService:
             context.abort(grpc.StatusCode.INVALID_ARGUMENT, "context.authz_decision_id is required")
         if not request.feature_vector:
             context.abort(grpc.StatusCode.INVALID_ARGUMENT, "feature_vector is required")
+        active_policy_snapshot_version = self._policy_snapshot_version
+        if req_context.policy_snapshot_version.strip() != active_policy_snapshot_version:
+            context.abort(
+                grpc.StatusCode.FAILED_PRECONDITION,
+                "context.policy_snapshot_version must match the active immutable policy snapshot",
+            )
         feature_digest = request.feature_digest_sha256.strip().lower()
         if not re.fullmatch(r"[0-9a-f]{64}", feature_digest):
             context.abort(grpc.StatusCode.INVALID_ARGUMENT, "feature_digest_sha256 must be a SHA-256 hex digest")
@@ -560,7 +576,7 @@ class NeuroSymbolicService:
                 workload_id.encode("utf-8"),
                 authz_decision_id.encode("utf-8"),
                 feature_schema_version.encode("utf-8"),
-                policy_snapshot_version.encode("utf-8"),
+                active_policy_snapshot_version.encode("utf-8"),
                 feature_digest.encode("utf-8"),
                 str(deterministic_seed).encode("utf-8"),
                 caller_id.encode("utf-8"),
@@ -581,7 +597,7 @@ class NeuroSymbolicService:
             tenant_id=tenant_id,
             project_id=project_id,
             feature_schema_version=feature_schema_version,
-            policy_snapshot_version=policy_snapshot_version,
+            policy_snapshot_version=active_policy_snapshot_version,
             model_version=str(cfg["model_version"]),
             decision=decision,
             score=score,
@@ -608,6 +624,7 @@ class NeuroSymbolicService:
                 "feature_schema_version": feature_schema_version,
                 "service_id": caller_id,
                 "model_version": str(cfg["model_version"]),
+                "policy_snapshot_version": active_policy_snapshot_version,
                 "decision": decision_name,
                 "replay_digest": replay_digest,
                 "trace_id": getattr(req_context, "trace_id", ""),

--- a/src/services/eigen-compiler/tests/test_compilation_rpc.py
+++ b/src/services/eigen-compiler/tests/test_compilation_rpc.py
@@ -298,6 +298,30 @@ def _nsc_request(
     )
 
 
+class _FakeServicerRpcError(grpc.RpcError):
+    def __init__(self, code: grpc.StatusCode, details: str):
+        super().__init__()
+        self._code = code
+        self._details = details
+
+    def code(self):
+        return self._code
+
+    def details(self):
+        return self._details
+
+
+class _FakeServicerContext:
+    def __init__(self, metadata: tuple[tuple[str, str], ...]):
+        self._metadata = metadata
+
+    def invocation_metadata(self):
+        return self._metadata
+
+    def abort(self, code, details):
+        raise _FakeServicerRpcError(code, details)
+
+
 def test_neuro_symbolic_service_scores_internal_requests(grpc_addr: str, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_SERVICE_TOKEN", "unit-test-token")
     monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_ALLOWED_CALLERS", "eigen-kernel,eigen-compiler")
@@ -397,6 +421,38 @@ def test_neuro_symbolic_service_rejects_digest_mismatch(
 
     assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
 
+
+def test_neuro_symbolic_service_uses_frozen_policy_snapshot_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_SERVICE_TOKEN", "unit-test-token")
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_ALLOWED_CALLERS", "eigen-kernel,eigen-compiler")
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_POLICY_SNAPSHOT_VERSION", "policy-locked-1")
+
+    # Instantiate the concrete implementation directly so the frozen snapshot can be verified in-process.
+    from eigen_compiler.grpc_impl import NeuroSymbolicService
+
+    svc = NeuroSymbolicService(nsc_pb=nsc_pb)
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_POLICY_SNAPSHOT_VERSION", "policy-locked-2")
+
+    resp = svc.ScoreCompilationPlan(
+        _nsc_request(policy_snapshot_version="policy-locked-1"),
+        _FakeServicerContext((
+            ("authorization", "Bearer unit-test-token"),
+            ("x-eigen-service-id", "eigen-kernel"),
+        )),
+    )
+
+    assert resp.policy_snapshot_version == "policy-locked-1"
+
+    with pytest.raises(_FakeServicerRpcError) as e:
+        svc.ScoreCompilationPlan(
+            _nsc_request(policy_snapshot_version="policy-locked-2"),
+            _FakeServicerContext((
+                ("authorization", "Bearer unit-test-token"),
+                ("x-eigen-service-id", "eigen-kernel"),
+            )),
+        )
+
+    assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Frozen the NSC policy snapshot at service start, made request-time scoring fail closed when the request snapshot version does not match that immutable snapshot, and propagated the active snapshot version into replay/audit metadata.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: API
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

```markdown
### Added
- 

### Changed
- 

### Fixed
- 
```