### PR TITLE
Implemented the mandatory NSC feature-extraction

### DIFF
--- a/docs/architecture/components/neuro-symbolic-core.md
+++ b/docs/architecture/components/neuro-symbolic-core.md
@@ -420,7 +420,10 @@ All requests MUST support (as structured fields or standardized metadata):
 - tenant context (NOT as metric label; redacted/hashed where applicable),
 - feature schema version,
 - timeout budget,
-- replay identifier (if present).
+- replay identifier (if present),
+- a mandatory preprocessing redaction layer that removes bearer tokens, API keys, tenant-private secrets, credentials, session cookies, and raw auth headers before scoring,
+- masking of email addresses, phone numbers, and internal identifiers before model input,
+- redacted field paths recorded in audit/log metadata only.
 
 ---
 
@@ -755,6 +758,7 @@ Golden tests SHOULD include:
 - `NeuroSymbolicService` internal model-service contract,
 - SemVer request/response envelope,
 - authenticated internal identity gate,
+- mandatory feature-extraction redaction layer for model input,
 - fail-closed rejection for unsupported contract versions.
 
 #### Still not implemented

--- a/docs/reference/api/grpc-internal.md
+++ b/docs/reference/api/grpc-internal.md
@@ -288,6 +288,11 @@ service NeuroSymbolicService {
 - `ScoreCompilationPlanRequest.context.policy_snapshot_version` is required.
 - The active policy snapshot MUST be frozen at service start and treated as immutable for the lifetime of the service process.
 - `ScoreCompilationPlanRequest.context.policy_snapshot_version` MUST match the active immutable snapshot version or the request MUST fail closed before scoring.
+- The service MUST run a mandatory feature-extraction redaction pass before scoring.
+- The redaction pass MUST delete bearer tokens, API keys, tenant-private secrets, credentials, session cookies, and raw auth headers.
+- The redaction pass MUST mask email addresses, phone numbers, and internal identifiers.
+- The redacted feature vector, not the raw payload, MUST be used for model scoring and replay digests.
+- Every edited field path MUST be emitted in audit/log metadata as redacted-only evidence.
 - `ScoreCompilationPlanRequest.context.tenant_id` is required.
 - `ScoreCompilationPlanRequest.context.project_id` is required.
 - `ScoreCompilationPlanRequest.context.subject_id` is required.

--- a/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from collections import Counter, defaultdict
+from dataclasses import dataclass
 from datetime import timedelta
 import hashlib
 import hmac
+import json
 import logging
 import os
 import re
@@ -30,6 +32,77 @@ _AQO_DIGEST_TOTALS: Counter[tuple[tuple[str, str], ...]] = Counter()
 _REPLAY_TOTALS: Counter[tuple[tuple[str, str], ...]] = Counter()
 _SEEN_AQO_DIGESTS: set[str] = set()
 _OBSERVABILITY_CONTRACT_VERSION = "1.0.0"
+
+_REDACTED_VALUE = "[REDACTED]"
+_MASKED_EMAIL_VALUE = "[REDACTED_EMAIL]"
+_MASKED_PHONE_VALUE = "[REDACTED_PHONE]"
+_MASKED_IDENTIFIER_VALUE = "[REDACTED_ID]"
+
+_REDACT_DELETE_KEYS = {
+    "authorization",
+    "auth_header",
+    "auth-token",
+    "bearer",
+    "cookie",
+    "credentials",
+    "credential",
+    "password",
+    "passwd",
+    "pwd",
+    "private_secret",
+    "secret",
+    "session_cookie",
+    "sessionid",
+    "session_token",
+    "token",
+    "api_key",
+    "apikey",
+    "access_token",
+    "refresh_token",
+    "id_token",
+    "raw_auth_header",
+    "raw_authorization",
+}
+_REDACT_MASK_EMAIL_KEYS = {
+    "email",
+    "email_address",
+    "contact_email",
+    "e_mail",
+}
+_REDACT_MASK_PHONE_KEYS = {
+    "phone",
+    "phone_number",
+    "mobile",
+    "msisdn",
+    "contact_phone",
+}
+_REDACT_MASK_IDENTIFIER_KEYS = {
+    "id",
+    "identifier",
+    "internal_id",
+    "internal_identifier",
+    "subject_id",
+    "user_id",
+    "tenant_id",
+    "project_id",
+    "request_id",
+    "trace_id",
+    "session_id",
+    "correlation_id",
+    "device_id",
+    "account_id",
+}
+
+_EMAIL_RE = re.compile(r"(?i)\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}\b")
+_PHONE_RE = re.compile(r"(?<!\d)(?:\+?\d{1,3}[-.\s]?)?(?:\(?\d{2,4}\)?[-.\s]?){1,3}\d{2,4}(?!\d)")
+_BEARER_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{8,}\b")
+_UUID_RE = re.compile(r"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b")
+
+
+@dataclass(frozen=True)
+class FeatureRedactionResult:
+    feature_vector: bytes
+    redacted_fields: tuple[str, ...]
 
 _STAGE_LABELS = {
     "request_validation",
@@ -426,6 +499,100 @@ _NEURO_POLICY_SNAPSHOT_VERSION_ENV = "EIGEN_NEURO_SYMBOLIC_POLICY_SNAPSHOT_VERSI
 _NEURO_POLICY_SNAPSHOT_DEFAULT = "policy-2026-06-15"
 
 
+def _redaction_path(parent: str, key: str) -> str:
+    if not parent or parent == "$":
+        return f"$.{key}"
+    return f"{parent}.{key}"
+
+
+def _record_redaction(redactions: set[str], path: str, reason: str) -> None:
+    redactions.add(f"{path}:{reason}")
+
+
+def _redact_scalar_text(value: str, path: str, redactions: set[str]) -> str:
+    redacted = value
+
+    if _BEARER_RE.search(redacted):
+        redacted = _BEARER_RE.sub(_REDACTED_VALUE, redacted)
+        _record_redaction(redactions, path, "deleted")
+    if _EMAIL_RE.search(redacted):
+        redacted = _EMAIL_RE.sub(_MASKED_EMAIL_VALUE, redacted)
+        _record_redaction(redactions, path, "masked_email")
+    if _PHONE_RE.search(redacted):
+        redacted = _PHONE_RE.sub(_MASKED_PHONE_VALUE, redacted)
+        _record_redaction(redactions, path, "masked_phone")
+    if _UUID_RE.search(redacted):
+        redacted = _UUID_RE.sub(_MASKED_IDENTIFIER_VALUE, redacted)
+        _record_redaction(redactions, path, "masked_identifier")
+    return redacted
+
+
+def _redact_json_value(value, path: str, redactions: set[str]):
+    if isinstance(value, dict):
+        redacted: dict[str, object] = {}
+        for key, nested in value.items():
+            nested_path = _redaction_path(path, str(key))
+            key_lower = str(key).strip().lower()
+
+            if key_lower in _REDACT_DELETE_KEYS:
+                redacted[key] = _REDACTED_VALUE
+                _record_redaction(redactions, nested_path, "deleted")
+                continue
+            if key_lower in _REDACT_MASK_EMAIL_KEYS:
+                redacted[key] = _MASKED_EMAIL_VALUE
+                _record_redaction(redactions, nested_path, "masked_email")
+                continue
+            if key_lower in _REDACT_MASK_PHONE_KEYS:
+                redacted[key] = _MASKED_PHONE_VALUE
+                _record_redaction(redactions, nested_path, "masked_phone")
+                continue
+            if key_lower in _REDACT_MASK_IDENTIFIER_KEYS or key_lower.endswith("_id"):
+                if isinstance(nested, (dict, list)):
+                    redacted[key] = _redact_json_value(nested, nested_path, redactions)
+                else:
+                    redacted[key] = _MASKED_IDENTIFIER_VALUE
+                    _record_redaction(redactions, nested_path, "masked_identifier")
+                continue
+
+            redacted[key] = _redact_json_value(nested, nested_path, redactions)
+        return redacted
+
+    if isinstance(value, list):
+        return [
+            _redact_json_value(item, f"{path}[{index}]", redactions)
+            for index, item in enumerate(value)
+        ]
+
+    if isinstance(value, str):
+        return _redact_scalar_text(value, path, redactions)
+
+    return value
+
+
+def _redact_feature_vector(feature_vector: bytes) -> FeatureRedactionResult:
+    if not feature_vector:
+        return FeatureRedactionResult(feature_vector=b"", redacted_fields=())
+
+    redactions: set[str] = set()
+    raw_text = feature_vector.decode("utf-8", errors="replace")
+
+    try:
+        parsed = json.loads(raw_text)
+    except json.JSONDecodeError:
+        sanitized = _redact_scalar_text(raw_text, "$", redactions)
+        return FeatureRedactionResult(
+            feature_vector=sanitized.encode("utf-8"),
+            redacted_fields=tuple(sorted(redactions)),
+        )
+
+    redacted = _redact_json_value(parsed, "$", redactions)
+    sanitized_text = json.dumps(redacted, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return FeatureRedactionResult(
+        feature_vector=sanitized_text.encode("utf-8"),
+        redacted_fields=tuple(sorted(redactions)),
+    )
+
+
 def _neuro_service_config() -> dict[str, object]:
     allowed_callers = {
         caller.strip().lower()
@@ -553,6 +720,7 @@ class NeuroSymbolicService:
             context.abort(grpc.StatusCode.INVALID_ARGUMENT, "context.authz_decision_id is required")
         if not request.feature_vector:
             context.abort(grpc.StatusCode.INVALID_ARGUMENT, "feature_vector is required")
+        redaction = _redact_feature_vector(request.feature_vector)
         active_policy_snapshot_version = self._policy_snapshot_version
         if req_context.policy_snapshot_version.strip() != active_policy_snapshot_version:
             context.abort(
@@ -581,7 +749,7 @@ class NeuroSymbolicService:
                 str(deterministic_seed).encode("utf-8"),
                 caller_id.encode("utf-8"),
                 request.model_hint.strip().encode("utf-8"),
-                request.feature_vector,
+                redaction.feature_vector,
             ]
         )
         replay_digest = _hex_digest(canonical)
@@ -626,6 +794,8 @@ class NeuroSymbolicService:
                 "model_version": str(cfg["model_version"]),
                 "policy_snapshot_version": active_policy_snapshot_version,
                 "decision": decision_name,
+                "feature_redaction_fields": redaction.redacted_fields,
+                "feature_redaction_count": len(redaction.redacted_fields),
                 "replay_digest": replay_digest,
                 "trace_id": getattr(req_context, "trace_id", ""),
                 "traceparent": getattr(req_context, "traceparent", ""),

--- a/src/services/eigen-compiler/tests/test_compilation_rpc.py
+++ b/src/services/eigen-compiler/tests/test_compilation_rpc.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import hashlib
+import json
+import logging
 import grpc
 import pytest
 from google.rpc import error_details_pb2
 from grpc_status import rpc_status
 
+from eigen_compiler.grpc_impl import _redact_feature_vector
 from eigen_compiler.proto_gen import ensure_generated
 
 ensure_generated()
@@ -393,6 +396,108 @@ def test_neuro_symbolic_service_rejects_unsupported_contract_version(
         )
 
     assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+
+
+def test_neuro_symbolic_feature_redaction_masks_sensitive_values() -> None:
+    raw_feature_vector = json.dumps(
+        {
+            "authorization": "Bearer sk-test-secret-token",
+            "api_key": "sk-live-1234567890",
+            "credentials": {
+                "session_cookie": "sessionid=abc123",
+                "password": "super-secret-password",
+            },
+            "contact": {
+                "email": "alice@example.com",
+                "phone": "+1 (555) 123-4567",
+            },
+            "internal_id": "7e3b7e77-4b2d-4c85-a8f5-0d9307cc0a11",
+            "signals": [{"label": "ok"}],
+        },
+        sort_keys=True,
+    ).encode("utf-8")
+
+    result = _redact_feature_vector(raw_feature_vector)
+    decoded = json.loads(result.feature_vector.decode("utf-8"))
+
+    assert decoded["authorization"] == "[REDACTED]"
+    assert decoded["api_key"] == "[REDACTED]"
+    assert decoded["credentials"] == "[REDACTED]"
+    assert decoded["contact"]["email"] == "[REDACTED_EMAIL]"
+    assert decoded["contact"]["phone"] == "[REDACTED_PHONE]"
+    assert decoded["internal_id"] == "[REDACTED_ID]"
+    assert all(secret not in result.feature_vector.decode("utf-8") for secret in [
+        "sk-test-secret-token",
+        "alice@example.com",
+        "+1 (555) 123-4567",
+        "7e3b7e77-4b2d-4c85-a8f5-0d9307cc0a11",
+    ])
+    assert any(field.endswith(":deleted") for field in result.redacted_fields)
+    assert any(field.endswith(":masked_email") for field in result.redacted_fields)
+    assert any(field.endswith(":masked_phone") for field in result.redacted_fields)
+    assert any(field.endswith(":masked_identifier") for field in result.redacted_fields)
+
+
+def test_neuro_symbolic_service_redacts_sensitive_feature_payload(
+    grpc_addr: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_SERVICE_TOKEN", "unit-test-token")
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_ALLOWED_CALLERS", "eigen-kernel,eigen-compiler")
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_MODEL_VERSION", "dpda-model-unit-test")
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_POLICY_SNAPSHOT_VERSION", "policy-2026-06-15")
+    caplog.set_level(logging.INFO, logger="eigen_compiler")
+
+    raw_feature_vector = json.dumps(
+        {
+            "authorization": "Bearer sk-test-secret-token",
+            "api_key": "sk-live-1234567890",
+            "contact": {
+                "email": "alice@example.com",
+                "phone": "+1 (555) 123-4567",
+            },
+            "internal_id": "7e3b7e77-4b2d-4c85-a8f5-0d9307cc0a11",
+            "signals": [{"label": "ok"}],
+        },
+        sort_keys=True,
+    ).encode("utf-8")
+
+    channel = grpc.insecure_channel(grpc_addr)
+    stub = nsc_pb_grpc.NeuroSymbolicServiceStub(channel)
+    resp = stub.ScoreCompilationPlan(
+        _nsc_request(feature_vector=raw_feature_vector),
+        metadata=(
+            ("authorization", "Bearer unit-test-token"),
+            ("x-eigen-service-id", "eigen-kernel"),
+        ),
+    )
+
+    redacted = _redact_feature_vector(raw_feature_vector)
+    assert len(resp.replay_digest) == 64
+    int(resp.replay_digest, 16)
+
+    repeat = stub.ScoreCompilationPlan(
+        _nsc_request(feature_vector=raw_feature_vector),
+        metadata=(
+            ("authorization", "Bearer unit-test-token"),
+            ("x-eigen-service-id", "eigen-kernel"),
+        ),
+    )
+
+    assert repeat.replay_digest == resp.replay_digest
+    assert resp.policy_snapshot_version == "policy-2026-06-15"
+    assert resp.model_version == "dpda-model-unit-test"
+
+    scoring_logs = [record for record in caplog.records if record.getMessage() == "neuro-symbolic scoring completed"]
+    assert scoring_logs, "expected a scoring log record"
+    record = scoring_logs[-1]
+    assert "feature_redaction_fields" in record.__dict__
+    assert record.feature_redaction_count == len(redacted.redacted_fields)
+    assert any(field.endswith(":deleted") for field in record.feature_redaction_fields)
+    assert any(field.endswith(":masked_email") for field in record.feature_redaction_fields)
+    assert any(field.endswith(":masked_phone") for field in record.feature_redaction_fields)
+    assert any(field.endswith(":masked_identifier") for field in record.feature_redaction_fields)
 
 
 def test_neuro_symbolic_service_rejects_digest_mismatch(


### PR DESCRIPTION
## Summary

Implemented the mandatory NSC feature-extraction redaction layer for DPDA-NEURO-04:

- bearer tokens, API keys, credentials, session cookies, and raw auth headers are removed before scoring
- email addresses, phone numbers, and internal identifiers are masked
- the model receives only the redacted feature vector
- edited field paths are emitted in log metadata as redacted-only evidence

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: API
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Mandatory feature-extraction redaction layer for internal NSC scoring.
- Audit/log metadata for redacted field paths.

### Changed
- ScoreCompilationPlan now scores redacted feature vectors instead of raw payloads.
- Internal NSC documentation now states the redaction contract and audit requirements.

### Fixed
- Sensitive payload fragments can no longer reach the model input path.
- Logs now record only redacted field evidence for edited fields.