### PR TITLE
Implemented the DPDA-NEURO sanitizer end to end.

### DIFF
--- a/docs/architecture/components/compiler.md
+++ b/docs/architecture/components/compiler.md
@@ -105,6 +105,7 @@ Inputs to compilation are carried via the internal `CompileJob` (or equivalent) 
 - `target` (string, e.g. `sim:local`, `cluster:auto`, `runtime:auto`),
 - `compiler_options` (bounded map of strings),
 - `request_context` (trace context, tenant/project scope via metadata).
+- Sensitive header values in request context metadata MUST be sanitized before normalization; raw bearer tokens MUST NOT reach compiler metadata or logs.
 
 **Source precedence** (when both provided):
 

--- a/docs/reference/api/grpc-internal.md
+++ b/docs/reference/api/grpc-internal.md
@@ -289,8 +289,8 @@ service NeuroSymbolicService {
 - The active policy snapshot MUST be frozen at service start and treated as immutable for the lifetime of the service process.
 - `ScoreCompilationPlanRequest.context.policy_snapshot_version` MUST match the active immutable snapshot version or the request MUST fail closed before scoring.
 - The service MUST run a mandatory feature-extraction redaction pass before scoring.
-- The service MUST minimize the inference payload before scoring by deleting raw payloads, full request bodies, unnecessary metadata, and large trace dumps.
-- The redaction pass MUST delete bearer tokens, API keys, tenant-private secrets, credentials, session cookies, and raw auth headers.
+- The service MUST minimize the inference payload before scoring by deleting raw payloads, full request bodies, unnecessary metadata, stack traces, and large trace dumps.
+- The redaction pass MUST delete bearer tokens, API keys, tenant-private secrets, credentials, session cookies, raw auth headers, internal endpoints, and secret-bearing paths.
 - The redaction pass MUST mask email addresses, phone numbers, and internal identifiers.
 - The minimized/redacted feature vector, not the raw payload, MUST be used for model scoring and replay digests.
 - The post-minimization feature payload MUST be bounded by policy, and oversized requests MUST fail closed with `RESOURCE_EXHAUSTED`.
@@ -301,6 +301,7 @@ service NeuroSymbolicService {
 - `ScoreCompilationPlanRequest.context.workload_id` is required.
 - `ScoreCompilationPlanRequest.context.authz_decision_id` is required.
 - The normalized security context MUST be fully traceable in audit events and replay digests.
+- Raw bearer tokens and header values MUST be sanitized before normalization; only bounded, secret-free security context metadata may be forwarded into inference.
 - `ScoreCompilationPlanResponse.contract_version` MUST echo the accepted request contract version.
 - `ScoreCompilationPlanResponse.policy_snapshot_version` MUST echo the active immutable snapshot version used for scoring.
 - Responses SHOULD echo the normalized security context fields for bounded auditability.

--- a/src/services/eigen-compiler/src/eigen_compiler/compiler.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/compiler.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import hashlib
 import json
+import re
 import os
 from math import isfinite
 from dataclasses import dataclass, asdict
@@ -30,6 +31,18 @@ _AQO_MEASUREMENT_BASIS = {"X", "Y", "Z"}
 _AQO_NON_PARAMETERIZED_OPS = {"CX", "CZ", "SWAP", "CCX", "CCZ", "X", "Y", "Z", "H", "S", "T", "RESET"}
 _AQO_ARITY = {"RX": 1, "RY": 1, "RZ": 1, "CX": 2, "CZ": 2, "SWAP": 2, "CCX": 3, "CCZ": 3, "X": 1, "Y": 1, "Z": 1, "H": 1, "S": 1, "T": 1, "MEASURE": 1, "RESET": 1}
 _ALLOWED_SANDBOX_PROFILES = {"default", "restricted", "strict"}
+_SENSITIVE_HEADER_RE = re.compile(
+    r"(?i)\b(?:authorization|proxy-authorization|x-api-key|x-auth-token|x-access-token|cookie|set-cookie)\s*:\s*.+"
+)
+_BEARER_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{8,}\b")
+
+
+def _sanitize_security_context(value: str) -> str:
+    if not value:
+        return ""
+    redacted = _SENSITIVE_HEADER_RE.sub("[REDACTED]", value)
+    redacted = _BEARER_RE.sub("[REDACTED]", redacted)
+    return redacted
 
 
 @dataclass(frozen=True)
@@ -231,7 +244,7 @@ def _normalize_request_context(request_context: dict[str, str] | None) -> Compil
         traceparent=str(context.get("traceparent", "")),
         deadline=str(context.get("deadline", "")),
         retry_policy=str(context.get("retry_policy", "")),
-        security_context=str(context.get("security_context", "")),
+        security_context=_sanitize_security_context(str(context.get("security_context", ""))),
         sandbox_profile=sandbox_profile,
         tenant_id=str(context.get("tenant_id", "")),
         project_id=str(context.get("project_id", "")),

--- a/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
@@ -107,9 +107,36 @@ _REDACT_MASK_IDENTIFIER_KEYS = {
 }
 
 _EMAIL_RE = re.compile(r"(?i)\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}\b")
-_PHONE_RE = re.compile(r"(?<!\d)(?:\+?\d{1,3}[-.\s]?)?(?:\(?\d{2,4}\)?[-.\s]?){1,3}\d{2,4}(?!\d)")
+_PHONE_RE = re.compile(r"(?i)(?<!\d)(?:\+?\d{1,3}[-.\s]?)?(?:\(?\d{2,4}\)?[-.\s]?){1,3}\d{2,4}(?!\d)")
 _BEARER_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{8,}\b")
 _UUID_RE = re.compile(r"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b")
+_SENSITIVE_HEADER_LINE_RE = re.compile(
+    r"(?im)^(?P<name>authorization|proxy-authorization|x-api-key|x-auth-token|x-access-token|cookie|set-cookie)\s*:\s*(?P<value>.+)$"
+)
+_INTERNAL_ENDPOINT_RE = re.compile(
+    r"(?i)\b(?:https?|grpc)://"
+    r"(?:"
+    r"localhost"
+    r"|127\.0\.0\.1"
+    r"|0\.0\.0\.0"
+    r"|10\.\d{1,3}\.\d{1,3}\.\d{1,3}"
+    r"|192\.168\.\d{1,3}\.\d{1,3}"
+    r"|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}"
+    r"|(?!-)(?:[a-z0-9-]+\.)*(?:internal|cluster\.local|svc\.cluster\.local|localdomain|corp|lan)"
+    r")(?::\d+)?(?:/[^\s\"'<>]*)?"
+)
+_SECRET_PATH_RE = re.compile(
+    r"(?i)(?P<path>(?:[A-Za-z]:\\|/)"
+    r"(?:[^\s\"'<>]*/)*"
+    r"(?:secrets?|secret|private|credentials?|tokens?|keys?)"
+    r"(?:/[^\s\"'<>]*)?)"
+)
+_STACK_TRACE_MARKERS = (
+    "Traceback (most recent call last):",
+    "java.lang.",
+    "Caused by:",
+)
+_STACK_TRACE_LINE_RE = re.compile(r"(?m)^\s*File \".+\", line \d+, in .+$|^\s*at [\w.$<>/]+\(.*\)$")
 
 
 @dataclass(frozen=True)
@@ -247,13 +274,17 @@ def _request_context_from_rpc(request, context: grpc.ServicerContext) -> dict[st
         if remaining is not None:
             deadline = f"{remaining:.6f}s"
 
+    security_context = pick("security_context", "authorization")
+    if security_context:
+        security_context = _redact_scalar_text(security_context, "$.security_context", set())
+
     return {
         "request_id": pick("request_id", "x-eigen-request-id"),
         "trace_id": pick("trace_id", "x-eigen-trace-id"),
         "traceparent": pick("traceparent", "traceparent"),
         "deadline": deadline,
         "retry_policy": pick("retry_policy", "x-eigen-retry-policy"),
-        "security_context": pick("security_context", "authorization"),
+        "security_context": security_context,
         "sandbox_profile": pick("sandbox_profile", "x-eigen-sandbox-profile"),
         "tenant_id": pick("tenant_id", "x-eigen-tenant-id"),
         "project_id": pick("project_id", "x-eigen-project-id"),
@@ -524,12 +555,38 @@ def _record_redaction(redactions: set[str], path: str, reason: str) -> None:
     redactions.add(f"{path}:{reason}")
 
 
+def _looks_like_stack_trace(value: str) -> bool:
+    if any(marker in value for marker in _STACK_TRACE_MARKERS):
+        return True
+    return _STACK_TRACE_LINE_RE.search(value) is not None
+
+
+def _redact_sensitive_text(value: str, path: str, redactions: set[str]) -> str:
+    redacted = value
+
+    if _SENSITIVE_HEADER_LINE_RE.search(redacted):
+        redacted = _SENSITIVE_HEADER_LINE_RE.sub(_REDACTED_VALUE, redacted)
+        _record_redaction(redactions, path, "masked_header")
+    if _INTERNAL_ENDPOINT_RE.search(redacted):
+        redacted = _INTERNAL_ENDPOINT_RE.sub(_REDACTED_VALUE, redacted)
+        _record_redaction(redactions, path, "masked_endpoint")
+    if _SECRET_PATH_RE.search(redacted):
+        redacted = _SECRET_PATH_RE.sub(_REDACTED_VALUE, redacted)
+        _record_redaction(redactions, path, "masked_path")
+
+    return redacted
+
 def _redact_scalar_text(value: str, path: str, redactions: set[str]) -> str:
     redacted = value
+
+    if _looks_like_stack_trace(redacted):
+        _record_redaction(redactions, path, "deleted")
+        return _REDACTED_VALUE
 
     if _BEARER_RE.search(redacted):
         redacted = _BEARER_RE.sub(_REDACTED_VALUE, redacted)
         _record_redaction(redactions, path, "deleted")
+    redacted = _redact_sensitive_text(redacted, path, redactions)
     if _EMAIL_RE.search(redacted):
         redacted = _EMAIL_RE.sub(_MASKED_EMAIL_VALUE, redacted)
         _record_redaction(redactions, path, "masked_email")

--- a/src/services/eigen-compiler/tests/test_compilation_rpc.py
+++ b/src/services/eigen-compiler/tests/test_compilation_rpc.py
@@ -8,6 +8,7 @@ import pytest
 from google.rpc import error_details_pb2
 from grpc_status import rpc_status
 
+from eigen_compiler.compiler import compile_eigen_lang
 from eigen_compiler.grpc_impl import _redact_feature_vector
 from eigen_compiler.proto_gen import ensure_generated
 
@@ -436,6 +437,63 @@ def test_neuro_symbolic_feature_redaction_masks_sensitive_values() -> None:
     assert any(field.endswith(":masked_email") for field in result.redacted_fields)
     assert any(field.endswith(":masked_phone") for field in result.redacted_fields)
     assert any(field.endswith(":masked_identifier") for field in result.redacted_fields)
+
+
+def test_neuro_symbolic_feature_redaction_removes_stack_traces_endpoints_paths_and_sensitive_headers() -> None:
+    raw_feature_vector = json.dumps(
+        {
+            "diagnostics": "Traceback (most recent call last):\n  File \"/app/main.py\", line 12, in run\n    raise RuntimeError('boom')",
+            "callback_url": "grpc://internal-api.svc.cluster.local:8443/v1/compile",
+            "artifact_path": "/var/lib/eigen/secret/pipelines/private/server.key",
+            "header_blob": "Authorization: Bearer sk-test-secret-token\nX-API-Key: sk-live-1234567890\nX-Auth-Token: token-abcdef123456",
+            "signals": [{"label": "ok"}],
+        },
+        sort_keys=True,
+    ).encode("utf-8")
+
+    result = _redact_feature_vector(raw_feature_vector)
+    decoded = json.loads(result.feature_vector.decode("utf-8"))
+
+    assert decoded["diagnostics"] == "[REDACTED]"
+    assert decoded["callback_url"] == "[REDACTED]"
+    assert decoded["artifact_path"] == "[REDACTED]"
+    assert all(line == "[REDACTED]" for line in decoded["header_blob"].splitlines())
+
+    rendered = result.feature_vector.decode("utf-8")
+    assert "Traceback (most recent call last):" not in rendered
+    assert "internal-api.svc.cluster.local" not in rendered
+    assert "server.key" not in rendered
+    assert "sk-test-secret-token" not in rendered
+    assert "sk-live-1234567890" not in rendered
+    assert any(field.endswith(":deleted") for field in result.redacted_fields)
+    assert any(field.endswith(":masked_endpoint") for field in result.redacted_fields)
+    assert any(field.endswith(":masked_path") for field in result.redacted_fields)
+    assert any(field.endswith(":masked_header") for field in result.redacted_fields)
+
+
+def test_compile_eigen_lang_redacts_security_context_in_metadata() -> None:
+    result = compile_eigen_lang(
+        source=(
+            b"from eigen_lang import hybrid_program\n\n"
+            b"@hybrid_program()\n"
+            b"def main():\n"
+            b"    ry(0, theta=1.0)\n"
+        ),
+        request_context={
+            "request_id": "req-1",
+            "trace_id": "0123456789abcdef0123456789abcdef",
+            "traceparent": "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
+            "deadline": "5s",
+            "retry_policy": "none",
+            "security_context": "authorization: Bearer sk-test-secret-token",
+            "sandbox_profile": "strict",
+            "tenant_id": "tenant-a",
+            "project_id": "project-a",
+        },
+    )
+
+    assert result.metadata["security_context"] == "[REDACTED]"
+    assert "sk-test-secret-token" not in result.metadata["request_context_json"]
 
 
 def test_neuro_symbolic_service_redacts_sensitive_feature_payload(


### PR DESCRIPTION
## Summary

The compiler-side feature redaction now removes:

- stack traces,
- internal endpoints,
- secret-bearing filesystem paths,
- sensitive header lines,
- raw bearer tokens in request metadata before normalization.

I also added unit coverage for these cases and updated the relevant architecture/reference docs to match the behavior.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: PATCH
- **Affected Interfaces**: API | Metrics
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Sanitization coverage for stack traces, internal endpoints, secret paths, and sensitive header lines.
- Unit tests for redaction of sensitive metadata and compiler request-context normalization.

### Changed
- Neuro-symbolic feature redaction now removes unsafe trace/metadata content before inference.
- Request context normalization now sanitizes sensitive security-context headers before they reach compiler metadata or logs.

### Fixed
- Sensitive header values no longer propagate into inference metadata.
- Internal endpoints and secret-bearing paths are redacted from text payloads before scoring.