### PR TITLE
Implemented tenant/project boundary

### DIFF
--- a/docs/architecture/components/neuro-symbolic-core.md
+++ b/docs/architecture/components/neuro-symbolic-core.md
@@ -417,7 +417,8 @@ All requests MUST support (as structured fields or standardized metadata):
 - `trace_id` (correlation, not as metric label),
 - policy context digest,
 - determinism mode + `seed` (required when deterministic=true),
-- tenant context (NOT as metric label; redacted/hashed where applicable),
+- tenant/project context (NOT as metric label; redacted/hashed where applicable),
+- internal request metadata MUST carry the same tenant/project binding used by the request context,
 - feature schema version,
 - timeout budget,
 - replay identifier (if present),
@@ -716,7 +717,7 @@ Every NSC request MUST carry a normalized security context with bounded, non-sec
 - `policy_snapshot_id`
 - `authz_decision_id`
 
-These values MUST be validated before inference, included in replay artifacts, and surfaced in audit events. Missing fields MUST fail closed. Raw bearer tokens, tenant-private secrets, and unredacted payload fragments MUST NOT be forwarded into NSC logs or model inputs.
+These values MUST be validated before inference, included in replay artifacts, and surfaced in audit events. Missing fields MUST fail closed. The inbound `x-eigen-tenant-id` and `x-eigen-project-id` request metadata MUST match the normalized request context exactly; any mismatch MUST fail closed with `PERMISSION_DENIED`. Raw bearer tokens, tenant-private secrets, and unredacted payload fragments MUST NOT be forwarded into NSC logs or model inputs.
 
 ---
 

--- a/docs/reference/api/grpc-internal.md
+++ b/docs/reference/api/grpc-internal.md
@@ -297,9 +297,12 @@ service NeuroSymbolicService {
 - Every edited field path MUST be emitted in audit/log metadata as redacted-only evidence.
 - `ScoreCompilationPlanRequest.context.tenant_id` is required.
 - `ScoreCompilationPlanRequest.context.project_id` is required.
+- Internal request metadata MUST also carry `x-eigen-tenant-id` and `x-eigen-project-id`, and those values MUST match the request context bound for scoring.
 - `ScoreCompilationPlanRequest.context.subject_id` is required.
 - `ScoreCompilationPlanRequest.context.workload_id` is required.
 - `ScoreCompilationPlanRequest.context.authz_decision_id` is required.
+- `x-eigen-tenant-id` and `x-eigen-project-id` gRPC metadata keys are required and MUST match the request context exactly.
+- Any tenant/project mismatch MUST fail closed with `PERMISSION_DENIED` before model scoring.
 - The normalized security context MUST be fully traceable in audit events and replay digests.
 - Raw bearer tokens and header values MUST be sanitized before normalization; only bounded, secret-free security context metadata may be forwarded into inference.
 - `ScoreCompilationPlanResponse.contract_version` MUST echo the accepted request contract version.

--- a/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
@@ -702,6 +702,28 @@ def _neuro_metadata(context: grpc.ServicerContext) -> dict[str, str]:
     return {k.lower(): v for k, v in (context.invocation_metadata() or [])}
 
 
+def _require_tenant_project_binding(
+    context: grpc.ServicerContext,
+    *,
+    method_name: str,
+    tenant_id: str,
+    project_id: str,
+) -> None:
+    md = _neuro_metadata(context)
+    md_tenant_id = md.get("x-eigen-tenant-id", "").strip()
+    md_project_id = md.get("x-eigen-project-id", "").strip()
+    if not md_tenant_id or not md_project_id:
+        context.abort(
+            grpc.StatusCode.PERMISSION_DENIED,
+            f"tenant/project binding required for {method_name}",
+        )
+    if md_tenant_id != tenant_id or md_project_id != project_id:
+        context.abort(
+            grpc.StatusCode.PERMISSION_DENIED,
+            f"tenant/project scope mismatch for {method_name}",
+        )
+
+
 def _require_internal_model_identity(context: grpc.ServicerContext, *, method_name: str) -> tuple[str, dict[str, object]]:
     cfg = _neuro_service_config()
     md = _neuro_metadata(context)
@@ -803,6 +825,12 @@ class NeuroSymbolicService:
             context.abort(grpc.StatusCode.INVALID_ARGUMENT, "context.workload_id is required")
         if not authz_decision_id:
             context.abort(grpc.StatusCode.INVALID_ARGUMENT, "context.authz_decision_id is required")
+        _require_tenant_project_binding(
+            context,
+            method_name="ScoreCompilationPlan",
+            tenant_id=tenant_id,
+            project_id=project_id,
+        )
         if not request.feature_vector:
             context.abort(grpc.StatusCode.INVALID_ARGUMENT, "feature_vector is required")
         redaction = _redact_feature_vector(request.feature_vector)

--- a/src/services/eigen-compiler/tests/test_compilation_rpc.py
+++ b/src/services/eigen-compiler/tests/test_compilation_rpc.py
@@ -302,6 +302,30 @@ def _nsc_request(
     )
 
 
+def _nsc_metadata(tenant_id: str = "tenant-a", project_id: str = "project-a") -> tuple[tuple[str, str], ...]:
+    return (
+        ("authorization", "Bearer unit-test-token"),
+        ("x-eigen-service-id", "eigen-kernel"),
+        ("x-eigen-tenant-id", tenant_id),
+        ("x-eigen-project-id", project_id),
+    )
+
+
+def _nsc_metadata(
+    *,
+    tenant_id: str = "tenant-a",
+    project_id: str = "project-a",
+    authorization: str = "Bearer unit-test-token",
+    service_id: str = "eigen-kernel",
+) -> tuple[tuple[str, str], ...]:
+    return (
+        ("authorization", authorization),
+        ("x-eigen-service-id", service_id),
+        ("x-eigen-tenant-id", tenant_id),
+        ("x-eigen-project-id", project_id),
+    )
+
+
 class _FakeServicerRpcError(grpc.RpcError):
     def __init__(self, code: grpc.StatusCode, details: str):
         super().__init__()
@@ -336,10 +360,7 @@ def test_neuro_symbolic_service_scores_internal_requests(grpc_addr: str, monkeyp
 
     resp = stub.ScoreCompilationPlan(
          _nsc_request(),
-        metadata=(
-            ("authorization", "Bearer unit-test-token"),
-            ("x-eigen-service-id", "eigen-kernel"),
-        ),
+        metadata=_nsc_metadata()
     )
 
     assert resp.contract_version == "1.0.0"
@@ -372,7 +393,14 @@ def test_neuro_symbolic_service_fails_closed_without_internal_identity(
     stub = nsc_pb_grpc.NeuroSymbolicServiceStub(channel)
 
     with pytest.raises(grpc.RpcError) as e:
-        stub.ScoreCompilationPlan(_nsc_request(), metadata=(("x-eigen-service-id", "eigen-kernel"),))
+        stub.ScoreCompilationPlan(
+            _nsc_request(),
+            metadata=(
+                ("x-eigen-service-id", "eigen-kernel"),
+                ("x-eigen-tenant-id", "tenant-a"),
+                ("x-eigen-project-id", "project-a"),
+            ),
+        )
 
     assert e.value.code() == grpc.StatusCode.UNAUTHENTICATED
 
@@ -390,13 +418,34 @@ def test_neuro_symbolic_service_rejects_unsupported_contract_version(
     with pytest.raises(grpc.RpcError) as e:
         stub.ScoreCompilationPlan(
             _nsc_request(contract_version="2.0.0"),
-            metadata=(
-                ("authorization", "Bearer unit-test-token"),
-                ("x-eigen-service-id", "eigen-kernel"),
-            ),
+            metadata=_nsc_metadata(),
         )
 
     assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+
+
+def test_neuro_symbolic_service_rejects_tenant_project_scope_mismatch(
+    grpc_addr: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_SERVICE_TOKEN", "unit-test-token")
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_ALLOWED_CALLERS", "eigen-kernel,eigen-compiler")
+
+    channel = grpc.insecure_channel(grpc_addr)
+    stub = nsc_pb_grpc.NeuroSymbolicServiceStub(channel)
+
+    with pytest.raises(grpc.RpcError) as e:
+        stub.ScoreCompilationPlan(
+            _nsc_request(),
+            metadata=(
+                ("authorization", "Bearer unit-test-token"),
+                ("x-eigen-service-id", "eigen-kernel"),
+                ("x-eigen-tenant-id", "tenant-b"),
+                ("x-eigen-project-id", "project-b"),
+            ),
+        )
+
+    assert e.value.code() == grpc.StatusCode.PERMISSION_DENIED
 
 
 def test_neuro_symbolic_feature_redaction_masks_sensitive_values() -> None:
@@ -530,10 +579,7 @@ def test_neuro_symbolic_service_redacts_sensitive_feature_payload(
             feature_vector=raw_feature_vector,
             feature_digest_sha256=hashlib.sha256(redacted.feature_vector).hexdigest(),
         ),
-        metadata=(
-            ("authorization", "Bearer unit-test-token"),
-            ("x-eigen-service-id", "eigen-kernel"),
-        ),
+        metadata=_nsc_metadata()
     )
 
     redacted = _redact_feature_vector(raw_feature_vector)
@@ -545,10 +591,7 @@ def test_neuro_symbolic_service_redacts_sensitive_feature_payload(
             feature_vector=raw_feature_vector,
             feature_digest_sha256=hashlib.sha256(redacted.feature_vector).hexdigest(),
         ),
-        metadata=(
-            ("authorization", "Bearer unit-test-token"),
-            ("x-eigen-service-id", "eigen-kernel"),
-        ),
+        metadata=_nsc_metadata()
     )
 
     assert repeat.replay_digest == resp.replay_digest
@@ -606,10 +649,7 @@ def test_neuro_symbolic_service_minimizes_payload_before_scoring(
             feature_vector=raw_feature_vector,
             feature_digest_sha256=hashlib.sha256(minimized.feature_vector).hexdigest(),
         ),
-        metadata=(
-            ("authorization", "Bearer unit-test-token"),
-            ("x-eigen-service-id", "eigen-kernel"),
-        ),
+        metadata=_nsc_metadata()
     )
 
     variant_feature_vector = json.dumps(
@@ -640,10 +680,7 @@ def test_neuro_symbolic_service_minimizes_payload_before_scoring(
             feature_vector=variant_feature_vector,
             feature_digest_sha256=hashlib.sha256(variant_minimized.feature_vector).hexdigest(),
         ),
-        metadata=(
-            ("authorization", "Bearer unit-test-token"),
-            ("x-eigen-service-id", "eigen-kernel"),
-        ),
+        metadata=_nsc_metadata(),
     )
 
     assert repeat.replay_digest == resp.replay_digest
@@ -688,10 +725,7 @@ def test_neuro_symbolic_service_enforces_policy_feature_payload_limit(
                 feature_vector=oversized,
                 feature_digest_sha256=hashlib.sha256(oversized_minimized.feature_vector).hexdigest(),
             ),
-            metadata=(
-                ("authorization", "Bearer unit-test-token"),
-                ("x-eigen-service-id", "eigen-kernel"),
-            ),
+            metadata=_nsc_metadata(),
         )
 
     assert e.value.code() == grpc.StatusCode.RESOURCE_EXHAUSTED
@@ -715,10 +749,7 @@ def test_neuro_symbolic_service_rejects_digest_mismatch(
     with pytest.raises(grpc.RpcError) as e:
         stub.ScoreCompilationPlan(
             bad,
-            metadata=(
-                ("authorization", "Bearer unit-test-token"),
-                ("x-eigen-service-id", "eigen-kernel"),
-            ),
+            metadata=_nsc_metadata(),
         )
 
     assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
@@ -737,10 +768,7 @@ def test_neuro_symbolic_service_uses_frozen_policy_snapshot_version(monkeypatch:
 
     resp = svc.ScoreCompilationPlan(
         _nsc_request(policy_snapshot_version="policy-locked-1"),
-        _FakeServicerContext((
-            ("authorization", "Bearer unit-test-token"),
-            ("x-eigen-service-id", "eigen-kernel"),
-        )),
+        _FakeServicerContext(_nsc_metadata()),
     )
 
     assert resp.policy_snapshot_version == "policy-locked-1"
@@ -748,10 +776,7 @@ def test_neuro_symbolic_service_uses_frozen_policy_snapshot_version(monkeypatch:
     with pytest.raises(_FakeServicerRpcError) as e:
         svc.ScoreCompilationPlan(
             _nsc_request(policy_snapshot_version="policy-locked-2"),
-            _FakeServicerContext((
-                ("authorization", "Bearer unit-test-token"),
-                ("x-eigen-service-id", "eigen-kernel"),
-            )),
+            _FakeServicerContext(_nsc_metadata()),
         )
 
     assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
@@ -786,10 +811,7 @@ def test_neuro_symbolic_service_rejects_missing_security_context_field(
     with pytest.raises(grpc.RpcError) as e:
         stub.ScoreCompilationPlan(
             request,
-            metadata=(
-                ("authorization", "Bearer unit-test-token"),
-                ("x-eigen-service-id", "eigen-kernel"),
-            ),
+            metadata=_nsc_metadata(),
         )
 
     assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
@@ -811,10 +833,7 @@ def test_neuro_symbolic_service_audits_security_context(
     with caplog.at_level("INFO", logger="eigen_compiler"):
         stub.ScoreCompilationPlan(
             _nsc_request(),
-            metadata=(
-                ("authorization", "Bearer unit-test-token"),
-                ("x-eigen-service-id", "eigen-kernel"),
-            ),
+            metadata=_nsc_metadata(),
         )
 
     records = [record for record in caplog.records if getattr(record, "rpc", "") == "ScoreCompilationPlan"]


### PR DESCRIPTION
## Summary

Implemented tenant/project boundary enforcement for NSC scoring.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: PATCH
- **Affected Interfaces**: API
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Tenant/project metadata binding enforcement for NSC scoring requests.
- Negative test coverage for tenant/project scope mismatch.

### Changed
- NSC requests now require x-eigen-tenant-id and x-eigen-project-id metadata to match the normalized request context.
- Internal docs now describe tenant/project-bound inference requests as a fail-closed security boundary.

### Fixed
- Cross-tenant inference access is now blocked at the service boundary.