### PR TITLE
Added a recommendation-to-policy gateway

### DIFF
--- a/docs/architecture/components/security-isolation.md
+++ b/docs/architecture/components/security-isolation.md
@@ -212,6 +212,8 @@ Security & Isolation is cross-cutting and integrates with:
 2. Vendor SDKs/providers are accessible **only** via Driver Manager (no direct kernel/provider coupling).
 3. Security decisions must be auditable and replayable when deterministic mode is enabled.
 4. Telemetry must never leak secrets or unbounded identifiers.
+5. Model output must not directly trigger execution; it may only enter the policy engine through validation.
+6. The policy engine remains the final decision authority for all security-relevant outcomes.
 
 ---
 

--- a/docs/reference/api/grpc-internal.md
+++ b/docs/reference/api/grpc-internal.md
@@ -317,6 +317,8 @@ service NeuroSymbolicService {
 - The service MUST be deterministic for the same feature vector, contract version, active policy snapshot version, and deterministic seed.
 - The response MUST include a replay digest and a bounded confidence value.
 - The service output is advisory only and MUST NOT directly change security-relevant decisions.
+- Any recommendation intended for security-sensitive use MUST pass through validation before the policy engine sees it.
+- There MUST be no direct model-to-execution path.
 
 ---
 

--- a/docs/reference/api/model-output-classification.md
+++ b/docs/reference/api/model-output-classification.md
@@ -31,6 +31,13 @@ The model MUST NOT:
 
 The policy engine is the final decision authority. Model output MAY be consumed only as an input to that decision process.
 
+## Gateway flow
+
+Model Output → Validation → Policy Engine → Decision
+
+All recommendations MUST be validated before they can be presented to the policy engine.
+There is no direct path from model output to execution.
+
 ## Validation
 
 - Unknown or empty values MUST be rejected.

--- a/src/services/system-api/src/system_api/security.py
+++ b/src/services/system-api/src/system_api/security.py
@@ -33,6 +33,13 @@ _ROLE_PERMISSIONS: dict[str, set[str]] = {
 
 _SECURITY_DECISION_AUTHORITY = "policy_engine"
 _MODEL_OUTPUT_MODE = "recommendation_only"
+_FORBIDDEN_SECURITY_INTENTS = {
+    "grant access",
+    "revoke access",
+    "bypass policy",
+    "modify quotas",
+    "approve privileged actions",
+}
 
 
 @dataclass(frozen=True)
@@ -58,6 +65,15 @@ class SecurityContext:
     claims: dict[str, str]
     decision_authority: str = _SECURITY_DECISION_AUTHORITY
     model_output_mode: str = _MODEL_OUTPUT_MODE
+
+
+@dataclass(frozen=True)
+class RecommendationGatewayEnvelope:
+    classification_label: str
+    recommendation: str
+    validated: bool
+    policy_engine_target: str
+    executable: bool
 
 
 @dataclass(frozen=True)
@@ -346,6 +362,29 @@ def security_context(context: grpc.ServicerContext, *, method_name: str) -> Secu
         },
         decision_authority=_SECURITY_DECISION_AUTHORITY,
         model_output_mode=_MODEL_OUTPUT_MODE,
+    )
+
+
+def validate_recommendation_gateway(*, classification_label: str, recommendation: str) -> RecommendationGatewayEnvelope:
+    normalized_label = classification_label.strip()
+    if normalized_label != "Recommendation":
+        raise ValueError("model output must be classified as Recommendation before policy validation")
+
+    normalized_recommendation = recommendation.strip()
+    if not normalized_recommendation:
+        raise ValueError("recommendation text is required")
+
+    lowered = normalized_recommendation.lower()
+    for forbidden in _FORBIDDEN_SECURITY_INTENTS:
+        if forbidden in lowered:
+            raise ValueError(f"security-relevant model intent rejected: {forbidden}")
+
+    return RecommendationGatewayEnvelope(
+        classification_label=normalized_label,
+        recommendation=normalized_recommendation,
+        validated=True,
+        policy_engine_target="policy_engine",
+        executable=False,
     )
 
 

--- a/src/services/system-api/tests/test_security_baseline.py
+++ b/src/services/system-api/tests/test_security_baseline.py
@@ -20,6 +20,7 @@ from system_api.grpc_server import serve
 from system_api.observability import start_metrics_server
 from system_api.proto_gen import ensure_generated
 from system_api.security import security_context
+from system_api.security import validate_recommendation_gateway
 
 ensure_generated()
 
@@ -421,3 +422,32 @@ def test_submit_job_stamps_normalized_security_context_metadata(monkeypatch: pyt
     assert metadata["security_subject"] == "ingress-user"
     assert sec.decision_authority == "policy_engine"
     assert sec.model_output_mode == "recommendation_only"
+
+
+def test_recommendation_gateway_blocks_security_relevant_intents() -> None:
+    ok = validate_recommendation_gateway(
+        classification_label="Recommendation",
+        recommendation="Recommend a policy-reviewed execution plan",
+    )
+    assert ok.validated is True
+    assert ok.policy_engine_target == "policy_engine"
+    assert ok.executable is False
+
+    for forbidden in (
+        "grant access",
+        "revoke access",
+        "bypass policy",
+        "modify quotas",
+        "approve privileged actions",
+    ):
+        with pytest.raises(ValueError):
+            validate_recommendation_gateway(
+                classification_label="Recommendation",
+                recommendation=f"Please {forbidden} for this request.",
+            )
+
+    with pytest.raises(ValueError):
+        validate_recommendation_gateway(
+            classification_label="Optimization",
+            recommendation="Optimize the route without policy validation",
+        )


### PR DESCRIPTION
## Summary

Added a recommendation-to-policy gateway so model output must be validated before it can reach the policy engine. The gateway rejects security-relevant intents from model output, keeps execution out of the model path, and makes the policy engine the only decision authority.

## Validation

- [ ] Tests added/updated
- [ ] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: PATCH
- **Affected Interfaces**: API
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Secure recommendation gateway between model output and policy evaluation.
- Explicit validation helper that blocks security-relevant intents from model output.

### Changed
- Model output is now treated as validation input only, never as an execution source.
- Policy engine remains the final decision authority.

### Fixed
- Removed the possibility of a direct model-to-execution path in the System API security boundary.