### PR TITLE
Implemented a bounded explainability envelope end-to-end for neuro-sy…

### DIFF
--- a/docs/architecture/components/neuro-symbolic-core.md
+++ b/docs/architecture/components/neuro-symbolic-core.md
@@ -210,6 +210,8 @@ Every accepted NSC recommendation MUST include:
 - provenance,
 - model version (or “heuristic/symbolic-only”),
 - confidence score (bounded numeric),
+- feature set summary (bounded and reproducible),
+- retrieval references for the scored evidence,
 - reasoning metadata (bounded),
 - fallback eligibility,
 - reproducibility hash (digest),
@@ -226,6 +228,8 @@ NSC MUST support deterministic mode.
 When `deterministic=true`, outputs MUST be a pure function of canonical inputs + seed and MUST be replayable byte-for-byte at the decision artifact level (canonical serialization).
 
 The active policy snapshot version used for scoring MUST be included in response metadata and audit logs so replay evidence is bound to the same immutable snapshot.
+
+The audit record MUST also retain the explainability envelope with model version, feature set summary, confidence, and retrieval references so the same inference can be replayed deterministically from immutable artifacts.
 
 ---
 
@@ -435,6 +439,8 @@ All responses MUST include:
 - `confidence` (bounded numeric),
 - `provenance` (stable reference or “symbolic-only”),
 - `model_version` (or “none”),
+- `feature_set` (bounded summary),
+- `retrieval_references` (bounded list),
 - `deterministic_compatible` (bool),
 - `fallback_eligible` (bool),
 - explainability payload or reference,

--- a/docs/reference/api/grpc-internal.md
+++ b/docs/reference/api/grpc-internal.md
@@ -310,6 +310,12 @@ service NeuroSymbolicService {
 - `ScoreCompilationPlanResponse.contract_version` MUST echo the accepted request contract version.
 - `ScoreCompilationPlanResponse.policy_snapshot_version` MUST echo the active immutable snapshot version used for scoring.
 - Responses SHOULD echo the normalized security context fields for bounded auditability.
+- Responses MUST carry a bounded explainability envelope in audit/log form that includes:
+  - `model_version`,
+  - `feature_set`,
+  - `confidence`,
+  - `retrieval_references`.
+- The explainability envelope MUST be derived from the minimized/redacted feature vector and the immutable policy snapshot, not from raw payloads.
 - Responses MUST remain bounded and MUST NOT return raw secrets, bearer tokens, or unredacted payload fragments.
 
 #### Determinism requirements

--- a/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
@@ -172,6 +172,10 @@ def _bump(counter: Counter[tuple[tuple[str, str], ...]], **labels: str) -> None:
         counter[_label_tuple(**labels)] += 1
 
 
+def _stable_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+
+
 def _bump_stage(stage: str, elapsed_seconds: float, outcome: str) -> None:
     if stage not in _STAGE_LABELS:
         stage = "emit"
@@ -777,6 +781,69 @@ def _decision_from_score(score: float):
     return "ADVISORY_DECISION_REJECT"
 
 
+def _explainability_feature_set(
+    *,
+    feature_schema_version: str,
+    model_hint: str,
+    feature_digest_sha256: str,
+    minimized_feature_vector: bytes,
+    redacted_fields: tuple[str, ...],
+) -> dict[str, object]:
+    return {
+        "schema_version": feature_schema_version,
+        "model_hint": model_hint.strip(),
+        "feature_digest_sha256": feature_digest_sha256,
+        "minimized_feature_vector_sha256": _hex_digest(minimized_feature_vector),
+        "minimized_feature_vector_bytes": len(minimized_feature_vector),
+        "redacted_fields": list(redacted_fields),
+    }
+
+
+def _build_explainability_envelope(
+    *,
+    contract_version: str,
+    request_id: str,
+    tenant_id: str,
+    project_id: str,
+    feature_schema_version: str,
+    policy_snapshot_version: str,
+    model_version: str,
+    confidence: float,
+    feature_digest_sha256: str,
+    replay_digest: str,
+    minimized_feature_vector: bytes,
+    redacted_fields: tuple[str, ...],
+    model_hint: str,
+) -> dict[str, object]:
+    feature_set = _explainability_feature_set(
+        feature_schema_version=feature_schema_version,
+        model_hint=model_hint,
+        feature_digest_sha256=feature_digest_sha256,
+        minimized_feature_vector=minimized_feature_vector,
+        redacted_fields=redacted_fields,
+    )
+    retrieval_references = [
+        f"nsc://feature-set/{tenant_id}/{project_id}/{request_id}/{feature_digest_sha256}",
+        f"nsc://policy-snapshot/{policy_snapshot_version}",
+        f"nsc://model/{model_version}",
+    ]
+    return {
+        "contract_version": contract_version,
+        "request_id": request_id,
+        "tenant_id": tenant_id,
+        "project_id": project_id,
+        "policy_snapshot_version": policy_snapshot_version,
+        "model_version": model_version,
+        "confidence": round(float(confidence), 6),
+        "feature_set": feature_set,
+        "retrieval_references": retrieval_references,
+        "retrieval_reference_count": len(retrieval_references),
+        "replay_digest": replay_digest,
+        "decision_digest": replay_digest,
+        "explanation_ref": f"nsc://explanations/{request_id}/{replay_digest}",
+    }
+
+
 class NeuroSymbolicService:
     """Implementation of eigen.internal.v1.NeuroSymbolicService."""
 
@@ -878,6 +945,22 @@ class NeuroSymbolicService:
         confidence = _confidence_from_score(score)
         decision_name = _decision_from_score(score)
         decision = getattr(self._nsc_pb, decision_name)
+        model_version = str(cfg["model_version"])
+        explainability_envelope = _build_explainability_envelope(
+            contract_version=contract_version,
+            request_id=request_id,
+            tenant_id=tenant_id,
+            project_id=project_id,
+            feature_schema_version=feature_schema_version,
+            policy_snapshot_version=active_policy_snapshot_version,
+            model_version=model_version,
+            confidence=confidence,
+            feature_digest_sha256=feature_digest,
+            replay_digest=replay_digest,
+            minimized_feature_vector=feature_vector,
+            redacted_fields=redaction.redacted_fields,
+            model_hint=request.model_hint.strip(),
+        )
 
         response = self._nsc_pb.ScoreCompilationPlanResponse(
             contract_version=contract_version,
@@ -886,11 +969,11 @@ class NeuroSymbolicService:
             project_id=project_id,
             feature_schema_version=feature_schema_version,
             policy_snapshot_version=active_policy_snapshot_version,
-            model_version=str(cfg["model_version"]),
+            model_version=model_version,
             decision=decision,
             score=score,
             confidence=confidence,
-            explanation_ref=f"nsc://explanations/{request_id}/{replay_digest}",
+            explanation_ref=explainability_envelope["explanation_ref"],
             replay_digest=replay_digest,
             deterministic_compatible=True,
             subject_id=subject_id,
@@ -911,8 +994,7 @@ class NeuroSymbolicService:
                 "policy_snapshot_version": policy_snapshot_version,
                 "feature_schema_version": feature_schema_version,
                 "service_id": caller_id,
-                "model_version": str(cfg["model_version"]),
-                "policy_snapshot_version": active_policy_snapshot_version,
+                "model_version": model_version,
                 "decision": decision_name,
                 "feature_payload_bytes": len(request.feature_vector),
                 "feature_payload_minimized_bytes": len(feature_vector),
@@ -920,6 +1002,8 @@ class NeuroSymbolicService:
                 "feature_redaction_fields": redaction.redacted_fields,
                 "feature_redaction_count": len(redaction.redacted_fields),
                 "replay_digest": replay_digest,
+                "explainability_envelope": explainability_envelope,
+                "explainability_envelope_json": _stable_json(explainability_envelope),
                 "trace_id": getattr(req_context, "trace_id", ""),
                 "traceparent": getattr(req_context, "traceparent", ""),
             },

--- a/src/services/eigen-compiler/tests/test_compilation_rpc.py
+++ b/src/services/eigen-compiler/tests/test_compilation_rpc.py
@@ -831,7 +831,7 @@ def test_neuro_symbolic_service_audits_security_context(
     stub = nsc_pb_grpc.NeuroSymbolicServiceStub(channel)
 
     with caplog.at_level("INFO", logger="eigen_compiler"):
-        stub.ScoreCompilationPlan(
+        resp = stub.ScoreCompilationPlan(
             _nsc_request(),
             metadata=_nsc_metadata(),
         )
@@ -845,3 +845,17 @@ def test_neuro_symbolic_service_audits_security_context(
     assert getattr(record, "tenant_id") == "tenant-a"
     assert getattr(record, "project_id") == "project-a"
     assert getattr(record, "policy_snapshot_version") == "policy-2026-06-15"
+
+    envelope = getattr(record, "explainability_envelope")
+    assert envelope["model_version"] == "dpda-model-unit-test"
+    assert envelope["feature_set"]["schema_version"] == "features.v1"
+    assert envelope["feature_set"]["feature_digest_sha256"] == hashlib.sha256(b'{"redacted":true,"signals":[1,2,3]}').hexdigest()
+    assert envelope["confidence"] == resp.confidence
+    assert envelope["explanation_ref"] == resp.explanation_ref
+    assert envelope["retrieval_reference_count"] == 3
+    assert envelope["retrieval_references"] == [
+        "nsc://feature-set/tenant-a/project-a/req-nsc-001/" + hashlib.sha256(b'{"redacted":true,"signals":[1,2,3]}').hexdigest(),
+        "nsc://policy-snapshot/policy-2026-06-15",
+        "nsc://model/dpda-model-unit-test",
+    ]
+    assert getattr(record, "explainability_envelope_json")

--- a/src/services/system-api/src/system_api/knowledge_base.py
+++ b/src/services/system-api/src/system_api/knowledge_base.py
@@ -225,6 +225,57 @@ def _anonymize_mapping(payload: dict[str, Any], *, salt: str, epoch: str) -> dic
     return {key: _anonymize_value(key, value, salt=salt, epoch=epoch) for key, value in payload.items()}
 
 
+def _explainability_envelope_from_payload(payload: dict[str, Any], *, salt: str, epoch: str) -> dict[str, Any]:
+    raw_envelope = payload.get("explainability_envelope")
+    if isinstance(raw_envelope, dict) and raw_envelope:
+        envelope = dict(raw_envelope)
+    else:
+        envelope = {
+            "contract_version": str(payload.get("contract_version", "")).strip() or _KB_CONTRACT_VERSION,
+            "model_version": str(payload.get("model_version", "")).strip(),
+            "feature_set": payload.get("feature_set") if isinstance(payload.get("feature_set"), dict) else {},
+            "confidence": payload.get("confidence", 0.0),
+            "retrieval_references": payload.get("retrieval_references") or [],
+            "replay_digest": str(payload.get("replay_digest", "")).strip(),
+            "decision_digest": str(payload.get("decision_digest", "")).strip(),
+            "policy_snapshot_version": str(payload.get("policy_snapshot_version", "")).strip(),
+        }
+
+    feature_set = envelope.get("feature_set")
+    if isinstance(feature_set, dict):
+        normalized_feature_set = _anonymize_mapping(dict(feature_set), salt=salt, epoch=epoch)
+    elif feature_set:
+        normalized_feature_set = {"value": str(feature_set)}
+    else:
+        normalized_feature_set = {}
+
+    retrieval_references = envelope.get("retrieval_references")
+    if isinstance(retrieval_references, (list, tuple, set)):
+        normalized_retrieval_references = [str(ref).strip() for ref in retrieval_references if str(ref).strip()]
+    elif retrieval_references:
+        normalized_retrieval_references = [str(retrieval_references).strip()]
+    else:
+        normalized_retrieval_references = []
+
+    confidence = envelope.get("confidence", 0.0)
+    try:
+        confidence_value = round(float(confidence), 6)
+    except (TypeError, ValueError):
+        confidence_value = 0.0
+
+    return {
+        "contract_version": str(envelope.get("contract_version", "")).strip() or _KB_CONTRACT_VERSION,
+        "model_version": str(envelope.get("model_version", "")).strip(),
+        "feature_set": normalized_feature_set,
+        "confidence": confidence_value,
+        "retrieval_references": normalized_retrieval_references,
+        "retrieval_reference_count": len(normalized_retrieval_references),
+        "replay_digest": str(envelope.get("replay_digest", "")).strip(),
+        "decision_digest": str(envelope.get("decision_digest") or envelope.get("replay_digest") or "").strip(),
+        "policy_snapshot_version": str(envelope.get("policy_snapshot_version", "")).strip(),
+    }
+
+
 def _copy_timestamp(ts: Timestamp | None) -> Timestamp:
     if ts is None:
         return _now_ts()
@@ -633,7 +684,19 @@ class KnowledgeBaseService:
         decision_log.policy_branch = str(payload.get("policy_branch", "")).strip()
         decision_log.selected_action = str(payload.get("selected_action", "")).strip()
         decision_log.fallback_used = bool(payload.get("fallback_used", False))
+        explainability_envelope = _explainability_envelope_from_payload(
+            payload,
+            salt=self._anon_salt,
+            epoch=self._anon_epoch,
+        )
         snapshot = _anonymize_mapping(dict(payload.get("feature_snapshot") or {}), salt=self._anon_salt, epoch=self._anon_epoch)
+        snapshot["explainability_envelope"] = _stable_json(explainability_envelope)
+        snapshot["feature_set"] = _stable_json(explainability_envelope["feature_set"])
+        snapshot["confidence"] = f"{explainability_envelope['confidence']:.6f}"
+        snapshot["retrieval_references"] = _stable_json(explainability_envelope["retrieval_references"])
+        snapshot["replay_digest"] = explainability_envelope["replay_digest"]
+        snapshot["policy_snapshot_version"] = explainability_envelope["policy_snapshot_version"]
+        snapshot["model_version"] = explainability_envelope["model_version"] or decision_log.model_version
         for key, value in snapshot.items():
             decision_log.feature_snapshot[key] = str(value)
         decided_at = payload.get("decided_at")
@@ -671,6 +734,7 @@ class KnowledgeBaseService:
                     "training_set_hash": str(payload.get("training_set_hash", "")).strip(),
                     "evaluation_bundle_hash": str(payload.get("evaluation_bundle_hash", "")).strip(),
                     "promotion_policy_version": str(payload.get("promotion_policy_version", "")).strip(),
+                    "explainability_envelope": explainability_envelope,
                 },
                 model_version=decision_log.model_version,
                 training_set_hash=str(payload.get("training_set_hash", "")).strip(),
@@ -685,6 +749,7 @@ class KnowledgeBaseService:
                 metadata={
                     "component": decision_log.component,
                     "policy_branch": decision_log.policy_branch,
+                    "explainability_envelope_json": _stable_json(explainability_envelope),
                 },
                 command="runtime_decision",
                 decision=decision_log.selected_action,

--- a/src/services/system-api/tests/test_knowledge_base_service.py
+++ b/src/services/system-api/tests/test_knowledge_base_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 
 import grpc
@@ -227,6 +228,49 @@ def test_decision_log_lineage_validation_and_ordering(grpc_addr: str) -> None:
     )
     assert [item.decision_id for item in query.decision_logs] == ["decision-a", "decision-b"]
     assert [item.selected_action for item in query.decision_logs] == ["backend-alpha", "backend-beta"]
+
+
+def test_runtime_decision_ingest_persists_explainability_envelope() -> None:
+    service = KnowledgeBaseService(kb_pb=kb_pb, types_pb=types_pb)
+
+    decision_id = service.ingest_runtime_decision(
+        {
+            "record_id": "decision-runtime-1",
+            "decision_id": "decision-runtime-1",
+            "trace_id": "trace-runtime",
+            "model_version": "m1",
+            "component": "runtime",
+            "policy_branch": "baseline",
+            "selected_action": "backend-alpha",
+            "fallback_used": False,
+            "feature_snapshot": {"queue_depth": "2"},
+            "feature_set": {"schema_version": "features.v1", "signature": "sig-1"},
+            "confidence": 0.8125,
+            "retrieval_references": [
+                "nsc://feature-set/tenant-a/project-a/request-1/feature-digest",
+                "nsc://policy-snapshot/policy-2026-06-15",
+                "nsc://model/dpda-model-unit-test",
+            ],
+            "replay_digest": "sha256:replay-1",
+            "policy_snapshot_version": "policy-2026-06-15",
+            "decided_at": _ts("2026-06-11T10:05:00+00:00"),
+        }
+    )
+
+    assert decision_id == "decision-runtime-1"
+    stored = service._decision_logs[-1]
+    snapshot = dict(stored.decision_log.feature_snapshot)
+    envelope = json.loads(snapshot["explainability_envelope"])
+    assert envelope["model_version"] == "m1"
+    assert envelope["feature_set"]["schema_version"] == "features.v1"
+    assert envelope["confidence"] == 0.8125
+    assert envelope["retrieval_reference_count"] == 3
+    assert envelope["retrieval_references"][1] == "nsc://policy-snapshot/policy-2026-06-15"
+
+    evidence = service._learning_evidence[-1]
+    assert evidence["payload"]["explainability_envelope"]["model_version"] == "m1"
+    assert evidence["payload"]["explainability_envelope"]["confidence"] == 0.8125
+    assert evidence["metadata"]["explainability_envelope_json"]
 
 
 def test_kb_records_and_decision_logs_are_project_scoped(grpc_addr: str) -> None:


### PR DESCRIPTION
## Summary

Implemented a bounded explainability envelope end-to-end for neuro-symbolic inference and audit persistence. The scoring path now builds and logs a deterministic envelope containing model version, feature set, confidence, and retrieval references; the system API persists the same envelope into runtime decision evidence; and the architecture/reference docs now describe the contract explicitly.

## Validation

- [ ] Tests added/updated
- [ ] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: API, Plugin envelopes, Metrics
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Explainability envelope generation for inference auditability.
- Persisted explainability envelope in runtime decision evidence.
- Deterministic retrieval references and feature-set summary in audit/log payloads.

### Changed
- Neuro-symbolic scoring now records a structured explainability envelope alongside existing audit fields.
- Knowledge base ingestion now stores explainability metadata in the decision log feature snapshot and learning evidence.
- Internal docs now require explainability envelope contents for reproducible inference.

### Fixed
- Audit data now contains the minimum structured inputs needed to reproduce an inference deterministically without raw payload leakage.