### PR TITLE
Implemented the audit-trail/compliance logging work for neuro-symbolic

### DIFF
--- a/docs/architecture/components/knowledge-base.md
+++ b/docs/architecture/components/knowledge-base.md
@@ -11,6 +11,8 @@ The Knowledge Base exposes two distinct behaviors:
 1. **Public record storage** — CRUD/query for KB records and decision logs.
 2. **Optimization Knowledge Base (OKB) retrieval** — deterministic reuse selection for compiler / AQO workflows.
 
+Runtime decision logs are append-only and MUST preserve the audit trail fields required by the neuro-symbolic compliance contract: caller identity, tenant, policy snapshot version, model version, retrieval sources, and final decision.
+
 This document defines the retrieval semantics for both candidate similarity search and canonical pattern lookup.
 
 ## 2. Retrieval primitives

--- a/docs/architecture/components/neuro-symbolic-core.md
+++ b/docs/architecture/components/neuro-symbolic-core.md
@@ -231,6 +231,8 @@ The active policy snapshot version used for scoring MUST be included in response
 
 The audit record MUST also retain the explainability envelope with model version, feature set summary, confidence, and retrieval references so the same inference can be replayed deterministically from immutable artifacts.
 
+The immutable audit trail MUST additionally capture caller identity, tenant, policy snapshot version, model version, retrieval sources, and final decision for every scoring operation.
+
 ---
 
 ## 7. Major Internal Subsystems (Target Architecture)

--- a/docs/reference/api/grpc-internal.md
+++ b/docs/reference/api/grpc-internal.md
@@ -315,6 +315,7 @@ service NeuroSymbolicService {
   - `feature_set`,
   - `confidence`,
   - `retrieval_references`.
+- Every scoring request MUST also emit an immutable audit record containing caller identity, tenant, active policy snapshot version, model version, retrieval sources, and final decision.
 - The explainability envelope MUST be derived from the minimized/redacted feature vector and the immutable policy snapshot, not from raw payloads.
 - Responses MUST remain bounded and MUST NOT return raw secrets, bearer tokens, or unredacted payload fragments.
 

--- a/docs/reference/api/grpc-public.md
+++ b/docs/reference/api/grpc-public.md
@@ -563,6 +563,8 @@ Returns canonical stored record, including persisted provenance and replay metad
 
 Appends immutable audit/event log entries. The public baseline records runtime decision lineage and benchmark decision traces through this RPC, preserving append order for each trace ID.
 
+Runtime decision logs MUST retain caller identity, tenant, policy snapshot version, model version, retrieval sources, and final decision so the same inference can be replayed from immutable evidence. The service MUST treat the log as append-only.
+
 Retention MUST follow audit policy.
 
 ---

--- a/src/services/system-api/src/system_api/knowledge_base.py
+++ b/src/services/system-api/src/system_api/knowledge_base.py
@@ -235,7 +235,7 @@ def _explainability_envelope_from_payload(payload: dict[str, Any], *, salt: str,
             "model_version": str(payload.get("model_version", "")).strip(),
             "feature_set": payload.get("feature_set") if isinstance(payload.get("feature_set"), dict) else {},
             "confidence": payload.get("confidence", 0.0),
-            "retrieval_references": payload.get("retrieval_references") or [],
+            "retrieval_references": payload.get("retrieval_references") or payload.get("retrieval_sources") or [],
             "replay_digest": str(payload.get("replay_digest", "")).strip(),
             "decision_digest": str(payload.get("decision_digest", "")).strip(),
             "policy_snapshot_version": str(payload.get("policy_snapshot_version", "")).strip(),
@@ -274,6 +274,29 @@ def _explainability_envelope_from_payload(payload: dict[str, Any], *, salt: str,
         "decision_digest": str(envelope.get("decision_digest") or envelope.get("replay_digest") or "").strip(),
         "policy_snapshot_version": str(envelope.get("policy_snapshot_version", "")).strip(),
     }
+
+
+def _audit_string_list(value: Any) -> list[str]:
+    if value in (None, ""):
+        return []
+    if isinstance(value, (list, tuple, set)):
+        raw_items = value
+    else:
+        raw_items = (value,)
+    items: list[str] = []
+    for raw in raw_items:
+        text = str(raw).strip()
+        if text and text not in items:
+            items.append(text)
+    return items
+
+
+def _caller_identity_from_payload(payload: dict[str, Any]) -> str:
+    for key in ("caller_identity", "caller_id", "service_identity", "subject", "requested_by"):
+        value = str(payload.get(key, "")).strip()
+        if value:
+            return value
+    return ""
 
 
 def _copy_timestamp(ts: Timestamp | None) -> Timestamp:
@@ -558,6 +581,43 @@ class KnowledgeBaseService:
         self._require_write(context, operation="append_decision_log")
         envelope = self._normalize_envelope(request.envelope, context)
         self._validate_decision_log(request.decision_log, context)
+        sec_ctx, policy_version = self._retrieval_security_context(context, operation="append_decision_log")
+        feature_snapshot = dict(getattr(request.decision_log, "feature_snapshot", {}) or {})
+        caller_identity = getattr(sec_ctx, "subject", "") or ""
+        retrieval_sources = _audit_string_list(
+            feature_snapshot.get("retrieval_sources")
+            or feature_snapshot.get("retrieval_references")
+            or feature_snapshot.get("retrieval_source")
+        )
+        policy_snapshot_version = str(
+            feature_snapshot.get("policy_snapshot_version")
+            or feature_snapshot.get("policy_version")
+            or policy_version
+        ).strip()
+        model_version = str(request.decision_log.model_version or feature_snapshot.get("model_version", "")).strip()
+        final_decision = str(request.decision_log.selected_action or feature_snapshot.get("final_decision", "")).strip()
+        confidence_value: float | None = None
+        raw_confidence = feature_snapshot.get("confidence", "")
+        if raw_confidence not in (None, ""):
+            try:
+                confidence_value = float(raw_confidence)
+            except (TypeError, ValueError):
+                confidence_value = None
+        self._audit_decision_event(
+            operation="append_decision_log",
+            decision_id=str(request.decision_log.decision_id).strip(),
+            final_decision=final_decision,
+            tenant_id=envelope["tenant_id"],
+            project_id=envelope["project_id"],
+            policy_snapshot_version=policy_snapshot_version,
+            model_version=model_version,
+            retrieval_sources=retrieval_sources,
+            caller_identity=caller_identity,
+            trace_id=str(request.decision_log.trace_id).strip(),
+            replay_digest=str(feature_snapshot.get("replay_digest", "")).strip(),
+            confidence=confidence_value,
+            sec_ctx=sec_ctx,
+        )
         with self._lock:
             self._gc_locked()
             stored = self._store_decision_log(decision_log=request.decision_log, envelope=envelope, context=context)
@@ -690,13 +750,20 @@ class KnowledgeBaseService:
             epoch=self._anon_epoch,
         )
         snapshot = _anonymize_mapping(dict(payload.get("feature_snapshot") or {}), salt=self._anon_salt, epoch=self._anon_epoch)
+        caller_identity = _caller_identity_from_payload(payload)
+        retrieval_sources = _audit_string_list(payload.get("retrieval_sources") or explainability_envelope["retrieval_references"])
+        snapshot["caller_identity"] = caller_identity
+        snapshot["tenant_id"] = str(payload.get("tenant_id") or self._payload_envelope(payload)["tenant_id"]).strip()
+        snapshot["project_id"] = str(payload.get("project_id") or self._payload_envelope(payload)["project_id"]).strip()
+        snapshot["policy_snapshot_version"] = explainability_envelope["policy_snapshot_version"]
+        snapshot["model_version"] = explainability_envelope["model_version"] or decision_log.model_version
+        snapshot["retrieval_sources"] = _stable_json(retrieval_sources)
+        snapshot["final_decision"] = decision_log.selected_action
         snapshot["explainability_envelope"] = _stable_json(explainability_envelope)
         snapshot["feature_set"] = _stable_json(explainability_envelope["feature_set"])
         snapshot["confidence"] = f"{explainability_envelope['confidence']:.6f}"
         snapshot["retrieval_references"] = _stable_json(explainability_envelope["retrieval_references"])
         snapshot["replay_digest"] = explainability_envelope["replay_digest"]
-        snapshot["policy_snapshot_version"] = explainability_envelope["policy_snapshot_version"]
-        snapshot["model_version"] = explainability_envelope["model_version"] or decision_log.model_version
         for key, value in snapshot.items():
             decision_log.feature_snapshot[key] = str(value)
         decided_at = payload.get("decided_at")
@@ -708,6 +775,20 @@ class KnowledgeBaseService:
             decision_log.decided_at.CopyFrom(_now_ts())
         envelope = self._payload_envelope(payload)
         capability_scope = _capability_scope_tokens(payload)
+        self._audit_decision_event(
+            operation="ingest_runtime_decision",
+            decision_id=decision_log.decision_id,
+            final_decision=decision_log.selected_action,
+            tenant_id=envelope["tenant_id"],
+            project_id=envelope["project_id"],
+            policy_snapshot_version=explainability_envelope["policy_snapshot_version"] or envelope["contract_version"],
+            model_version=decision_log.model_version,
+            retrieval_sources=retrieval_sources,
+            caller_identity=caller_identity,
+            trace_id=decision_log.trace_id,
+            replay_digest=explainability_envelope["replay_digest"],
+            confidence=explainability_envelope["confidence"],
+        )
         with self._lock:
             self._gc_locked()
             self._store_decision_log(
@@ -1247,6 +1328,75 @@ class KnowledgeBaseService:
                 ),
             }
         )
+
+
+    def _audit_decision_event(
+        self,
+        *,
+        operation: str,
+        decision_id: str,
+        final_decision: str,
+        tenant_id: str,
+        project_id: str,
+        policy_snapshot_version: str,
+        model_version: str,
+        retrieval_sources: Sequence[str],
+        caller_identity: str,
+        trace_id: str = "",
+        traceparent: str = "",
+        replay_digest: str = "",
+        confidence: float | None = None,
+        sec_ctx: Any | None = None,
+    ) -> None:
+        subject = ""
+        roles: tuple[str, ...] = ()
+        auth_mode = "allow_all"
+        service_identity = None
+        sandbox_profile = None
+        replay_marker = ""
+        if sec_ctx is not None:
+            subject = getattr(sec_ctx, "subject", "") or ""
+            roles = tuple(getattr(sec_ctx, "roles", ()) or ())
+            auth_mode = getattr(sec_ctx, "auth_mode", "allow_all") or "allow_all"
+            service_identity = getattr(sec_ctx, "service_identity", None)
+            sandbox_profile = getattr(sec_ctx, "sandbox_profile", None)
+            replay_marker = str(getattr(sec_ctx, "claims", {}).get("replay_marker", "") or "")
+        retrieval_sources_list = list(retrieval_sources)
+        audit_event: dict[str, object] = {
+            "audit_kind": "immutable_decision",
+            "operation": operation,
+            "decision": final_decision,
+            "final_decision": final_decision,
+            "decision_id": decision_id,
+            "caller_identity": caller_identity,
+            "tenant": tenant_id,
+            "tenant_id": tenant_id,
+            "project_id": project_id,
+            "policy_version": policy_snapshot_version,
+            "policy_snapshot_version": policy_snapshot_version,
+            "model_version": model_version,
+            "retrieval_sources": retrieval_sources_list,
+            "retrieval_references": retrieval_sources_list,
+            "retrieval_source_count": len(retrieval_sources_list),
+            "trace_id": trace_id,
+            "traceparent": traceparent,
+            "replay_digest": replay_digest,
+            "immutable": True,
+        }
+        if confidence is not None:
+            audit_event["confidence"] = round(float(confidence), 6)
+        audit_event.update(
+            sanitized_security_metadata(
+                subject=subject,
+                roles=roles,
+                auth_mode=auth_mode,
+                policy_version=policy_snapshot_version,
+                service_identity=service_identity,
+                sandbox_profile=sandbox_profile,
+                replay_marker=replay_marker,
+            )
+        )
+        append_security_audit_event(audit_event)
 
 
     def _normalize_okb_query(self, payload: dict[str, Any]) -> dict[str, Any]:

--- a/src/services/system-api/tests/test_knowledge_base_service.py
+++ b/src/services/system-api/tests/test_knowledge_base_service.py
@@ -230,7 +230,9 @@ def test_decision_log_lineage_validation_and_ordering(grpc_addr: str) -> None:
     assert [item.selected_action for item in query.decision_logs] == ["backend-alpha", "backend-beta"]
 
 
-def test_runtime_decision_ingest_persists_explainability_envelope() -> None:
+def test_runtime_decision_ingest_persists_explainability_envelope(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    audit_path = tmp_path / "audit.jsonl"
+    monkeypatch.setenv("SYSTEM_API_AUDIT_SINK_PATH", str(audit_path))
     service = KnowledgeBaseService(kb_pb=kb_pb, types_pb=types_pb)
 
     decision_id = service.ingest_runtime_decision(
@@ -238,6 +240,9 @@ def test_runtime_decision_ingest_persists_explainability_envelope() -> None:
             "record_id": "decision-runtime-1",
             "decision_id": "decision-runtime-1",
             "trace_id": "trace-runtime",
+            "tenant_id": "tenant-a",
+            "project_id": "project-a",
+            "caller_identity": "eigen-compiler",
             "model_version": "m1",
             "component": "runtime",
             "policy_branch": "baseline",
@@ -246,7 +251,7 @@ def test_runtime_decision_ingest_persists_explainability_envelope() -> None:
             "feature_snapshot": {"queue_depth": "2"},
             "feature_set": {"schema_version": "features.v1", "signature": "sig-1"},
             "confidence": 0.8125,
-            "retrieval_references": [
+            "retrieval_sources": [
                 "nsc://feature-set/tenant-a/project-a/request-1/feature-digest",
                 "nsc://policy-snapshot/policy-2026-06-15",
                 "nsc://model/dpda-model-unit-test",
@@ -266,11 +271,34 @@ def test_runtime_decision_ingest_persists_explainability_envelope() -> None:
     assert envelope["confidence"] == 0.8125
     assert envelope["retrieval_reference_count"] == 3
     assert envelope["retrieval_references"][1] == "nsc://policy-snapshot/policy-2026-06-15"
-
+    assert snapshot["caller_identity"] == "eigen-compiler"
+    assert snapshot["tenant_id"] == "tenant-a"
+    assert snapshot["project_id"] == "project-a"
+    assert snapshot["policy_snapshot_version"] == "policy-2026-06-15"
+    assert snapshot["final_decision"] == "backend-alpha"
+    assert json.loads(snapshot["retrieval_sources"]) == [
+        "nsc://feature-set/tenant-a/project-a/request-1/feature-digest",
+        "nsc://policy-snapshot/policy-2026-06-15",
+        "nsc://model/dpda-model-unit-test",
+    ]
+    
     evidence = service._learning_evidence[-1]
     assert evidence["payload"]["explainability_envelope"]["model_version"] == "m1"
     assert evidence["payload"]["explainability_envelope"]["confidence"] == 0.8125
     assert evidence["metadata"]["explainability_envelope_json"]
+
+    audit_lines = audit_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(audit_lines) == 1
+    audit = json.loads(audit_lines[0])
+    assert audit["audit_kind"] == "immutable_decision"
+    assert audit["operation"] == "ingest_runtime_decision"
+    assert audit["caller_identity"] == "eigen-compiler"
+    assert audit["tenant"] == "tenant-a"
+    assert audit["policy_snapshot_version"] == "policy-2026-06-15"
+    assert audit["model_version"] == "m1"
+    assert audit["retrieval_sources"][-1] == "nsc://model/dpda-model-unit-test"
+    assert audit["final_decision"] == "backend-alpha"
+    assert audit["immutable"] is True
 
 
 def test_kb_records_and_decision_logs_are_project_scoped(grpc_addr: str) -> None:


### PR DESCRIPTION
## Summary

Implemented the audit-trail/compliance logging work for neuro-symbolic decisions on top of the current tree. Runtime decision ingestion now writes an immutable audit record with caller identity, tenant, policy snapshot version, model version, retrieval sources, and final decision; AppendDecisionLog is audited the same way. The explainability payload also accepts retrieval_sources as an alias, and the docs now state the audit contract explicitly.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: API | Metrics
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft
### Added
- Immutable audit records for neuro-symbolic/runtime decision events.
- Caller identity, tenant, policy snapshot version, model version, retrieval sources, and final decision in the audit trail payload.

### Changed
- Runtime decision ingestion now emits append-only compliance audit events.
- Decision-log append operations now emit the same immutable audit trail.
- Explainability payload parsing now accepts retrieval_sources as an alias for retrieval_references.
- Documentation now specifies the neuro-symbolic audit-trail contract.

### Fixed
- Missing compliance logging for neural-network decisioning.
- Missing replay-relevant audit fields in stored runtime decision snapshots.