### PR TITLE
Implemented fail-closed enforcement for the system-api knowledge

### DIFF
--- a/docs/architecture/components/security-isolation.md
+++ b/docs/architecture/components/security-isolation.md
@@ -88,6 +88,8 @@ System API enforces auth modes:
 - `SYSTEM_API_AUTH_MODE=allow_all`
 - `SYSTEM_API_AUTH_MODE=static_token`
 
+`allow_all` remains a local/dev bootstrap mode for ingress-only flows; knowledge-base retrieval and runtime audit helpers MUST still fail closed when security context or policy evidence is missing.
+
 Static token mode uses:
 
 `SYSTEM_API_AUTH_TOKEN=<token>`

--- a/docs/architecture/components/system-api.md
+++ b/docs/architecture/components/system-api.md
@@ -318,6 +318,8 @@ Auth modes:
 - `SYSTEM_API_AUTH_MODE=static_token`
 - `SYSTEM_API_AUTH_TOKEN=<token>`
 
+`allow_all` is only acceptable for local/dev ingress bootstrap. Internal KB audit and retrieval helpers do not accept permissive fallback; missing security context or policy evidence MUST deny.
+
 Coarse RBAC permissions:
 
 - `jobs:submit`

--- a/docs/reference/security/authz.md
+++ b/docs/reference/security/authz.md
@@ -59,6 +59,7 @@ Product 1.0 authorization decisions are evaluated for these principal classes:
 - Replay-sensitive security decisions MUST preserve deterministic replay markers.
 - Policy backend unavailability MUST result in deny behavior.
 - Missing policy snapshots MUST NOT fall back to allow behavior.
+- Knowledge Base retrieval and runtime decision logging MUST fail closed when security context, policy evidence, or redaction cannot be completed.
 
 ---
 

--- a/src/services/system-api/src/system_api/knowledge_base.py
+++ b/src/services/system-api/src/system_api/knowledge_base.py
@@ -432,6 +432,13 @@ def _okb_filter_scope_tokens(
 
     return tuple(sorted(dict.fromkeys(normalized)))
 
+def _policy_snapshot_configured() -> bool:
+    return bool(
+        os.getenv("SYSTEM_API_POLICY_SNAPSHOT_JSON", "").strip()
+        or os.getenv("SYSTEM_API_POLICY_SNAPSHOT_PATH", "").strip()
+    )
+
+
 class KnowledgeBaseService:
     """Deterministic in-memory KnowledgeBaseService implementation."""
 
@@ -736,6 +743,23 @@ class KnowledgeBaseService:
     def ingest_runtime_decision(self, payload: dict[str, Any]) -> str:
         if self._storage_mode == "disabled":
             raise KnowledgeBaseUnavailable("knowledge base storage unavailable")
+        
+        security_payload = payload.get("security_context") if isinstance(payload.get("security_context"), dict) else {}
+        security_payload = dict(security_payload or {})
+        subject = str(security_payload.get("subject") or payload.get("caller_identity") or payload.get("subject") or "").strip()
+        tenant_id = str(security_payload.get("tenant") or security_payload.get("tenant_id") or payload.get("tenant_id") or "").strip()
+        project_id = str(security_payload.get("project_id") or payload.get("project_id") or "").strip()
+        policy_snapshot_version = str(security_payload.get("policy_version") or payload.get("policy_snapshot_version") or payload.get("policy_version") or "").strip()
+        auth_mode = str(security_payload.get("auth_mode") or payload.get("auth_mode") or "").strip().lower()
+        service_identity = str(security_payload.get("service_identity") or payload.get("service_identity") or "").strip()
+        retrieval_sources = _audit_string_list(
+            payload.get("retrieval_sources")
+            or security_payload.get("retrieval_sources")
+            or payload.get("retrieval_references")
+        )
+        if not subject or not tenant_id or not project_id or not policy_snapshot_version or not service_identity or not auth_mode or auth_mode == "allow_all" or not retrieval_sources:
+            raise KnowledgeBaseUnavailable("security context unavailable")
+
         decision_log = self._kb_pb.DecisionLog()
         decision_log.decision_id = str(payload.get("decision_id") or self._decision_id(payload))
         decision_log.trace_id = str(payload.get("trace_id", "")).strip()
@@ -744,97 +768,104 @@ class KnowledgeBaseService:
         decision_log.policy_branch = str(payload.get("policy_branch", "")).strip()
         decision_log.selected_action = str(payload.get("selected_action", "")).strip()
         decision_log.fallback_used = bool(payload.get("fallback_used", False))
-        explainability_envelope = _explainability_envelope_from_payload(
-            payload,
-            salt=self._anon_salt,
-            epoch=self._anon_epoch,
-        )
-        snapshot = _anonymize_mapping(dict(payload.get("feature_snapshot") or {}), salt=self._anon_salt, epoch=self._anon_epoch)
-        caller_identity = _caller_identity_from_payload(payload)
-        retrieval_sources = _audit_string_list(payload.get("retrieval_sources") or explainability_envelope["retrieval_references"])
-        snapshot["caller_identity"] = caller_identity
-        snapshot["tenant_id"] = str(payload.get("tenant_id") or self._payload_envelope(payload)["tenant_id"]).strip()
-        snapshot["project_id"] = str(payload.get("project_id") or self._payload_envelope(payload)["project_id"]).strip()
-        snapshot["policy_snapshot_version"] = explainability_envelope["policy_snapshot_version"]
-        snapshot["model_version"] = explainability_envelope["model_version"] or decision_log.model_version
-        snapshot["retrieval_sources"] = _stable_json(retrieval_sources)
-        snapshot["final_decision"] = decision_log.selected_action
-        snapshot["explainability_envelope"] = _stable_json(explainability_envelope)
-        snapshot["feature_set"] = _stable_json(explainability_envelope["feature_set"])
-        snapshot["confidence"] = f"{explainability_envelope['confidence']:.6f}"
-        snapshot["retrieval_references"] = _stable_json(explainability_envelope["retrieval_references"])
-        snapshot["replay_digest"] = explainability_envelope["replay_digest"]
-        for key, value in snapshot.items():
-            decision_log.feature_snapshot[key] = str(value)
-        decided_at = payload.get("decided_at")
-        if isinstance(decided_at, Timestamp):
-            decision_log.decided_at.CopyFrom(decided_at)
-        elif isinstance(decided_at, datetime):
-            decision_log.decided_at.FromDatetime(decided_at.astimezone(timezone.utc))
-        else:
-            decision_log.decided_at.CopyFrom(_now_ts())
-        envelope = self._payload_envelope(payload)
-        capability_scope = _capability_scope_tokens(payload)
-        self._audit_decision_event(
-            operation="ingest_runtime_decision",
-            decision_id=decision_log.decision_id,
-            final_decision=decision_log.selected_action,
-            tenant_id=envelope["tenant_id"],
-            project_id=envelope["project_id"],
-            policy_snapshot_version=explainability_envelope["policy_snapshot_version"] or envelope["contract_version"],
-            model_version=decision_log.model_version,
-            retrieval_sources=retrieval_sources,
-            caller_identity=caller_identity,
-            trace_id=decision_log.trace_id,
-            replay_digest=explainability_envelope["replay_digest"],
-            confidence=explainability_envelope["confidence"],
-        )
-        with self._lock:
-            self._gc_locked()
-            self._store_decision_log(
-                decision_log=decision_log,
-                envelope=envelope,
-                context=None,
-                capability_scope=self._capability_scope_tokens(payload),
+        
+        try:
+            explainability_envelope = _explainability_envelope_from_payload(
+                payload,
+                salt=self._anon_salt,
+                epoch=self._anon_epoch,
             )
-            self._learning_store_evidence(
-                source="runtime",
-                evidence_kind="runtime",
-                envelope=envelope,
-                evidence_payload={
-                    "decision_id": decision_log.decision_id,
-                    "trace_id": decision_log.trace_id,
-                    "model_version": decision_log.model_version,
-                    "component": decision_log.component,
-                    "policy_branch": decision_log.policy_branch,
-                    "selected_action": decision_log.selected_action,
-                    "fallback_used": decision_log.fallback_used,
-                    "feature_snapshot": dict(decision_log.feature_snapshot),
-                    "capability_scope": list(capability_scope),
-                    "decided_at": decision_log.decided_at,
-                    "training_set_hash": str(payload.get("training_set_hash", "")).strip(),
-                    "evaluation_bundle_hash": str(payload.get("evaluation_bundle_hash", "")).strip(),
-                    "promotion_policy_version": str(payload.get("promotion_policy_version", "")).strip(),
-                    "explainability_envelope": explainability_envelope,
-                },
+            if not explainability_envelope["policy_snapshot_version"]:
+                raise KnowledgeBaseUnavailable("policy snapshot unavailable")
+            snapshot = _anonymize_mapping(dict(payload.get("feature_snapshot") or {}), salt=self._anon_salt, epoch=self._anon_epoch)
+            caller_identity = subject
+            snapshot["caller_identity"] = caller_identity
+            snapshot["tenant_id"] = tenant_id
+            snapshot["project_id"] = project_id
+            snapshot["policy_snapshot_version"] = policy_snapshot_version or explainability_envelope["policy_snapshot_version"]
+            snapshot["model_version"] = explainability_envelope["model_version"] or decision_log.model_version
+            snapshot["retrieval_sources"] = _stable_json(retrieval_sources)
+            snapshot["final_decision"] = decision_log.selected_action
+            snapshot["explainability_envelope"] = _stable_json(explainability_envelope)
+            snapshot["feature_set"] = _stable_json(explainability_envelope["feature_set"])
+            snapshot["confidence"] = f"{explainability_envelope['confidence']:.6f}"
+            snapshot["retrieval_references"] = _stable_json(explainability_envelope["retrieval_references"])
+            snapshot["replay_digest"] = explainability_envelope["replay_digest"]
+            for key, value in snapshot.items():
+                decision_log.feature_snapshot[key] = str(value)
+            decided_at = payload.get("decided_at")
+            if isinstance(decided_at, Timestamp):
+                decision_log.decided_at.CopyFrom(decided_at)
+            elif isinstance(decided_at, datetime):
+                decision_log.decided_at.FromDatetime(decided_at.astimezone(timezone.utc))
+            else:
+                decision_log.decided_at.CopyFrom(_now_ts())
+            envelope = self._payload_envelope({**payload, "tenant_id": tenant_id, "project_id": project_id})
+            capability_scope = _capability_scope_tokens(payload)
+            self._audit_decision_event(
+                operation="ingest_runtime_decision",
+                decision_id=decision_log.decision_id,
+                final_decision=decision_log.selected_action,
+                tenant_id=envelope["tenant_id"],
+                project_id=envelope["project_id"],
+                policy_snapshot_version=explainability_envelope["policy_snapshot_version"] or policy_snapshot_version or envelope["contract_version"],
                 model_version=decision_log.model_version,
-                training_set_hash=str(payload.get("training_set_hash", "")).strip(),
-                evaluation_bundle_hash=str(payload.get("evaluation_bundle_hash", "")).strip(),
-                promotion_policy_version=str(payload.get("promotion_policy_version", "")).strip(),
-                lifecycle_state="VALIDATED",
-                quarantine_state="quarantine" if self._learning_payload_contains_quarantine_fields(payload) else "none",
-                gate_results={
-                    "fallback_used": bool(decision_log.fallback_used),
-                    "trace_id": decision_log.trace_id,
-                },
-                metadata={
-                    "component": decision_log.component,
-                    "policy_branch": decision_log.policy_branch,
-                    "explainability_envelope_json": _stable_json(explainability_envelope),
-                },
-                command="runtime_decision",
-                decision=decision_log.selected_action,
-            )
+                retrieval_sources=retrieval_sources,
+                caller_identity=caller_identity,
+                trace_id=decision_log.trace_id,
+                replay_digest=explainability_envelope["replay_digest"],
+                confidence=explainability_envelope["confidence"],
+            )    
+            with self._lock:
+                self._gc_locked()
+                self._store_decision_log(
+                    decision_log=decision_log,
+                    envelope=envelope,
+                    context=None,
+                    capability_scope=self._capability_scope_tokens(payload),
+                )
+                self._learning_store_evidence(
+                    source="runtime",
+                    evidence_kind="runtime",
+                    envelope=envelope,
+                    evidence_payload={
+                        "decision_id": decision_log.decision_id,
+                        "trace_id": decision_log.trace_id,
+                        "model_version": decision_log.model_version,
+                        "component": decision_log.component,
+                        "policy_branch": decision_log.policy_branch,
+                        "selected_action": decision_log.selected_action,
+                        "fallback_used": decision_log.fallback_used,
+                        "feature_snapshot": dict(decision_log.feature_snapshot),
+                        "capability_scope": list(capability_scope),
+                        "decided_at": decision_log.decided_at,
+                        "training_set_hash": str(payload.get("training_set_hash", "")).strip(),
+                        "evaluation_bundle_hash": str(payload.get("evaluation_bundle_hash", "")).strip(),
+                        "promotion_policy_version": str(payload.get("promotion_policy_version", "")).strip(),
+                        "explainability_envelope": explainability_envelope,
+                    },
+                    model_version=decision_log.model_version,
+                    training_set_hash=str(payload.get("training_set_hash", "")).strip(),
+                    evaluation_bundle_hash=str(payload.get("evaluation_bundle_hash", "")).strip(),
+                    promotion_policy_version=str(payload.get("promotion_policy_version", "")).strip(),
+                    lifecycle_state="VALIDATED",
+                    quarantine_state="quarantine" if self._learning_payload_contains_quarantine_fields(payload) else "none",
+                    gate_results={
+                        "fallback_used": bool(decision_log.fallback_used),
+                        "trace_id": decision_log.trace_id,
+                    },
+                    metadata={
+                        "component": decision_log.component,
+                        "policy_branch": decision_log.policy_branch,
+                        "explainability_envelope_json": _stable_json(explainability_envelope),
+                    },
+                    command="runtime_decision",
+                    decision=decision_log.selected_action,
+                )
+        except KnowledgeBaseUnavailable:
+            raise
+        except Exception as exc:
+            raise KnowledgeBaseUnavailable("redaction failure") from exc
         record_kb_query("runtime_decisions", hit=True)
         return decision_log.decision_id
 
@@ -874,88 +905,93 @@ class KnowledgeBaseService:
             record.lineage.promotion_policy_version = str(lineage.get("promotion_policy_version", "")).strip()
             record.lineage.promotion_outcome = str(lineage.get("promotion_outcome", "")).strip()
         capability_scope = _capability_scope_tokens(payload)
-        attrs = _anonymize_mapping(dict(payload.get("attributes") or {}), salt=self._anon_salt, epoch=self._anon_epoch)
-        attrs.update(
-            {
-                "record_kind": "benchmark_run",
-                "request_hash": str(payload.get("request_hash", "")).strip(),
-                "idempotency_key": str(payload.get("idempotency_key", "")).strip(),
-                "parent_run_id": str(payload.get("parent_run_id", "")).strip(),
-                "run_state": str(payload.get("state", "")).strip(),
-                "capability_scope": _stable_json(list(capability_scope)),
-                "tenant_id": _anon_token(salt=self._anon_salt, epoch=self._anon_epoch, value=str(payload.get("tenant_id", ""))) if payload.get("tenant_id") else "",
-                "project_id": _anon_token(salt=self._anon_salt, epoch=self._anon_epoch, value=str(payload.get("project_id", ""))) if payload.get("project_id") else "",
-                "trace_id": str(payload.get("trace_id", "")).strip(),
-                "replay_bundle_ref": str(payload.get("replay_bundle_ref") or self._replay_bundle_ref(record.record_id)).strip(),
-            }
-        )
-        for key, value in attrs.items():
-            record.attributes[key] = str(value)
-        envelope = self._payload_envelope(payload)
-        with self._lock:
-            self._gc_locked()
-            self._upsert_record(
-                record=record,
-                envelope=envelope,
-                allow_overwrite=True,
-                anonymize_attributes=False,
-                source="benchmark",
-                replay_bundle_ref=attrs["replay_bundle_ref"],
-                context=None,
-                capability_scope=self._capability_scope_tokens(payload),
-            )
+        try:
+            attrs = _anonymize_mapping(dict(payload.get("attributes") or {}), salt=self._anon_salt, epoch=self._anon_epoch)
+            attrs.update(
+                {
+                    "record_kind": "benchmark_run",
+                    "request_hash": str(payload.get("request_hash", "")).strip(),
+                    "idempotency_key": str(payload.get("idempotency_key", "")).strip(),
+                    "parent_run_id": str(payload.get("parent_run_id", "")).strip(),
+                    "run_state": str(payload.get("state", "")).strip(),
+                    "capability_scope": _stable_json(list(capability_scope)),
+                    "tenant_id": _anon_token(salt=self._anon_salt, epoch=self._anon_epoch, value=str(payload.get("tenant_id", ""))) if payload.get("tenant_id") else "",
+                    "project_id": _anon_token(salt=self._anon_salt, epoch=self._anon_epoch, value=str(payload.get("project_id", ""))) if payload.get("project_id") else "",
+                    "trace_id": str(payload.get("trace_id", "")).strip(),
+                    "replay_bundle_ref": str(payload.get("replay_bundle_ref") or self._replay_bundle_ref(record.record_id)).strip(),
+                }
+             )
+            for key, value in attrs.items():
+                record.attributes[key] = str(value)
+            envelope = self._payload_envelope(payload)
+            with self._lock:
+                self._gc_locked()
+                self._upsert_record(
+                    record=record,
+                    envelope=envelope,
+                    allow_overwrite=True,
+                    anonymize_attributes=False,
+                    source="benchmark",
+                    replay_bundle_ref=attrs["replay_bundle_ref"],
+                    context=None,
+                    capability_scope=self._capability_scope_tokens(payload),
+                )
 
             self._learning_store_evidence(
-                source="benchmark",
-                evidence_kind="benchmark",
-                envelope=envelope,
-                evidence_payload={
-                    "record_id": record.record_id,
-                    "job_id": record.job_id,
-                    "circuit_id": record.circuit_id,
-                    "artifact_ref": record.artifact_ref,
-                    "dataset_ref": record.dataset_ref,
-                    "backend_profile": record.backend_profile,
-                    "optimizer_version": record.optimizer_version,
-                    "qubit_count": record.qubit_count,
-                    "entanglement_score": record.entanglement_score,
-                    "noise_profile_id": record.noise_profile_id,
-                    "backend_class": record.backend_class,
-                    "capability_scope": list(capability_scope),
-                    "provenance": {
-                        "compiler_ref": record.provenance.compiler_ref,
-                        "optimizer_ref": record.provenance.optimizer_ref,
-                        "runtime_ref": record.provenance.runtime_ref,
-                        "checkpoint_ref": record.provenance.checkpoint_ref,
+                    source="benchmark",
+                    evidence_kind="benchmark",
+                    envelope=envelope,
+                    evidence_payload={
+                        "record_id": record.record_id,
+                        "job_id": record.job_id,
+                        "circuit_id": record.circuit_id,
+                        "artifact_ref": record.artifact_ref,
+                        "dataset_ref": record.dataset_ref,
+                        "backend_profile": record.backend_profile,
+                        "optimizer_version": record.optimizer_version,
+                        "qubit_count": record.qubit_count,
+                        "entanglement_score": record.entanglement_score,
+                        "noise_profile_id": record.noise_profile_id,
+                        "backend_class": record.backend_class,
+                        "capability_scope": list(capability_scope),
+                        "provenance": {
+                            "compiler_ref": record.provenance.compiler_ref,
+                            "optimizer_ref": record.provenance.optimizer_ref,
+                            "runtime_ref": record.provenance.runtime_ref,
+                            "checkpoint_ref": record.provenance.checkpoint_ref,
+                        },
+                        "lineage": {
+                            "model_version": record.lineage.model_version,
+                            "training_set_hash": record.lineage.training_set_hash,
+                            "evaluation_bundle_hash": record.lineage.evaluation_bundle_hash,
+                            "promotion_policy_version": record.lineage.promotion_policy_version,
+                            "promotion_outcome": record.lineage.promotion_outcome,
+                        },
+                        "created_at": record.created_at,
                     },
-                    "lineage": {
-                        "model_version": record.lineage.model_version,
-                        "training_set_hash": record.lineage.training_set_hash,
-                        "evaluation_bundle_hash": record.lineage.evaluation_bundle_hash,
-                        "promotion_policy_version": record.lineage.promotion_policy_version,
+                    model_version=record.lineage.model_version,
+                    training_set_hash=record.lineage.training_set_hash,
+                    evaluation_bundle_hash=record.lineage.evaluation_bundle_hash,
+                    promotion_policy_version=record.lineage.promotion_policy_version,
+                    lifecycle_state="VALIDATED",
+                    quarantine_state="none",
+                    gate_results={
                         "promotion_outcome": record.lineage.promotion_outcome,
+                        "optimizer_version": record.optimizer_version,
                     },
-                    "created_at": record.created_at,
-                },
-                model_version=record.lineage.model_version,
-                training_set_hash=record.lineage.training_set_hash,
-                evaluation_bundle_hash=record.lineage.evaluation_bundle_hash,
-                promotion_policy_version=record.lineage.promotion_policy_version,
-                lifecycle_state="VALIDATED",
-                quarantine_state="none",
-                gate_results={
-                    "promotion_outcome": record.lineage.promotion_outcome,
-                    "optimizer_version": record.optimizer_version,
-                },
-                metadata={
-                    "backend_profile": record.backend_profile,
-                    "backend_class": record.backend_class,
-                    "noise_profile_id": record.noise_profile_id,
-                },
-                command="benchmark_ingest",
-                decision="validated",
-                capability_scope=self._capability_scope_tokens(payload),
-            )
+                    metadata={
+                        "backend_profile": record.backend_profile,
+                        "backend_class": record.backend_class,
+                        "noise_profile_id": record.noise_profile_id,
+                    },
+                    command="benchmark_ingest",
+                    decision="validated",
+                    capability_scope=self._capability_scope_tokens(payload),
+                )
+        except KnowledgeBaseUnavailable:
+            raise
+        except Exception as exc:
+            raise KnowledgeBaseUnavailable("redaction failure") from exc
         record_kb_query("benchmark_runs", hit=True)
         return record.record_id
 
@@ -964,25 +1000,30 @@ class KnowledgeBaseService:
         if self._storage_mode == "disabled":
             raise KnowledgeBaseUnavailable("knowledge base storage unavailable")
         envelope = self._payload_envelope(payload)
-        with self._lock:
-            self._gc_locked()
-            evidence = self._learning_store_evidence(
-                source=str(payload.get("source", "manual")).strip() or "manual",
-                evidence_kind=str(payload.get("evidence_kind", "learning")).strip() or "learning",
-                envelope=envelope,
-                evidence_payload=dict(payload),
-                model_version=str(payload.get("model_version", "")).strip(),
-                training_set_hash=str(payload.get("training_set_hash", "")).strip(),
-                evaluation_bundle_hash=str(payload.get("evaluation_bundle_hash", "")).strip(),
-                promotion_policy_version=str(payload.get("promotion_policy_version", "")).strip(),
-                lifecycle_state=str(payload.get("lifecycle_state", "DRAFT")).strip() or "DRAFT",
-                quarantine_state="quarantine" if self._learning_payload_contains_quarantine_fields(payload) else "none",
-                gate_results=dict(payload.get("gate_results") or {}),
-                metadata=dict(payload.get("metadata") or {}),
-                command=str(payload.get("command", "")).strip(),
-                decision=str(payload.get("decision", "")).strip(),
-                capability_scope=self._capability_scope_tokens(payload),
-            )
+        try:
+            with self._lock:
+                self._gc_locked()
+                evidence = self._learning_store_evidence(
+                    source=str(payload.get("source", "manual")).strip() or "manual",
+                    evidence_kind=str(payload.get("evidence_kind", "learning")).strip() or "learning",
+                    envelope=envelope,
+                    evidence_payload=dict(payload),
+                    model_version=str(payload.get("model_version", "")).strip(),
+                    training_set_hash=str(payload.get("training_set_hash", "")).strip(),
+                    evaluation_bundle_hash=str(payload.get("evaluation_bundle_hash", "")).strip(),
+                    promotion_policy_version=str(payload.get("promotion_policy_version", "")).strip(),
+                    lifecycle_state=str(payload.get("lifecycle_state", "DRAFT")).strip() or "DRAFT",
+                    quarantine_state="quarantine" if self._learning_payload_contains_quarantine_fields(payload) else "none",
+                    gate_results=dict(payload.get("gate_results") or {}),
+                    metadata=dict(payload.get("metadata") or {}),
+                    command=str(payload.get("command", "")).strip(),
+                    decision=str(payload.get("decision", "")).strip(),
+                    capability_scope=self._capability_scope_tokens(payload),
+                )
+        except KnowledgeBaseUnavailable:
+            raise
+        except Exception as exc:
+            raise KnowledgeBaseUnavailable("redaction failure") from exc
         record_kb_query("learning_evidence", hit=True)
         return evidence["evidence_id"]
 
@@ -1263,6 +1304,30 @@ class KnowledgeBaseService:
             raise KnowledgeBaseUnavailable("policy snapshot unavailable")
         return version
 
+    def _fail_closed(self, context: grpc.ServicerContext | None, *, operation: str, reason: str, detail: str) -> None:
+        if context is not None:
+            abort_public(
+                context,
+                PublicErrorSpec(
+                    grpc_code=grpc.StatusCode.PERMISSION_DENIED,
+                    message="access denied",
+                    reason=reason,
+                    retryable=False,
+                    metadata={"operation": operation, "reason": reason},
+                    detail=detail,
+                ),
+            )
+        raise KnowledgeBaseUnavailable(detail)
+
+    def _require_explicit_policy_snapshot(self, context: grpc.ServicerContext | None, *, operation: str) -> str:
+        if not _policy_snapshot_configured():
+            self._fail_closed(context, operation=operation, reason="KB_POLICY_SNAPSHOT_REQUIRED", detail="security policy snapshot unavailable")
+        snapshot = load_policy_snapshot()
+        version = str(snapshot.version).strip()
+        if not version:
+            self._fail_closed(context, operation=operation, reason="KB_POLICY_SNAPSHOT_REQUIRED", detail="security policy snapshot unavailable")
+        return version
+
     def _retrieval_security_context(
         self,
         context: grpc.ServicerContext | None,
@@ -1270,11 +1335,16 @@ class KnowledgeBaseService:
         operation: str,
     ) -> tuple[Any | None, str]:
         if context is None:
-            return None, self._policy_snapshot_version()
+            self._fail_closed(
+                None,
+                operation=operation,
+                reason="KB_SECURITY_CONTEXT_REQUIRED",
+                detail="security context unavailable",
+            )
         sec_ctx = security_context(context, method_name=f"KnowledgeBaseService.{operation}")
+        policy_version = sec_ctx.policy_version.strip() or self._policy_snapshot_version()
         if sec_ctx.auth_mode != "allow_all":
             enforce_sandbox_policy(context, sandbox_profile=sec_ctx.sandbox_profile)
-        policy_version = sec_ctx.policy_version.strip() or self._policy_snapshot_version()
         return sec_ctx, policy_version
 
     def _audit_retrieval_decision(
@@ -2446,73 +2516,78 @@ class KnowledgeBaseService:
     ) -> dict[str, Any]:
         normalized_kind = evidence_kind.strip().lower() or "learning"
         capability_scope = tuple(_capability_scope_tokens(evidence_payload))
-        evidence = {
-            "tenant_id": envelope["tenant_id"],
-            "project_id": envelope["project_id"],
-            "capability_scope": capability_scope,
-            "source": source,
-            "evidence_kind": normalized_kind,
-            "model_version": model_version,
-            "training_set_hash": training_set_hash,
-            "evaluation_bundle_hash": evaluation_bundle_hash,
-            "promotion_policy_version": promotion_policy_version,
-            "lifecycle_state": lifecycle_state.upper() if lifecycle_state else "DRAFT",
-            "quarantine_state": quarantine_state,
-            "gate_results": dict(gate_results or {}),
-            "metadata": _anonymize_mapping(dict(metadata or {}), salt=self._anon_salt, epoch=self._anon_epoch),
-            "command": command,
-            "decision": decision,
-            "payload": _anonymize_mapping(dict(evidence_payload or {}), salt=self._anon_salt, epoch=self._anon_epoch),
-            "capability_scope": capability_scope,
-            "created_at": datetime.now(timezone.utc).isoformat(),
-        }
-        evidence["evidence_hash"] = _stable_hash(evidence)
-        evidence["evidence_id"] = str(
-            evidence_payload.get("evidence_id")
-            or f"evid_{hashlib.sha256(_stable_json(evidence).encode('utf-8')).hexdigest()[:24]}"
-        )
-        evidence["queryable_ref"] = f"kb://learning/{evidence['evidence_id']}"
-        self._learning_evidence.append(
-            {
-                "evidence_id": evidence["evidence_id"],
-                "tenant_id": evidence["tenant_id"],
-                "project_id": evidence["project_id"],
-                "capability_scope": evidence["capability_scope"],
-                "evidence_kind": evidence["evidence_kind"],
-                "evidence_hash": evidence["evidence_hash"],
-                "model_version": evidence["model_version"],
-                "training_set_hash": evidence["training_set_hash"],
-                "evaluation_bundle_hash": evidence["evaluation_bundle_hash"],
-                "promotion_policy_version": evidence["promotion_policy_version"],
-                "lifecycle_state": evidence["lifecycle_state"],
-                "quarantine_state": evidence["quarantine_state"],
-                "source": evidence["source"],
-                "command": evidence["command"],
-                "decision": evidence["decision"],
-                "gate_results": evidence["gate_results"],
-                "metadata": evidence["metadata"],
-                "payload": evidence["payload"],
-                "capability_scope": evidence["capability_scope"],
-                "created_at": evidence["created_at"],
-                "queryable_ref": evidence["queryable_ref"],
-            }
-        )
-        if evidence["model_version"]:
-            self._learning_models[(envelope["tenant_id"], envelope["project_id"], evidence["model_version"])] = {
+        try:
+            evidence = {
                 "tenant_id": envelope["tenant_id"],
                 "project_id": envelope["project_id"],
-                "model_version": evidence["model_version"],
-                "training_set_hash": evidence["training_set_hash"],
-                "evaluation_bundle_hash": evidence["evaluation_bundle_hash"],
-                "promotion_policy_version": evidence["promotion_policy_version"],
-                "lifecycle_state": evidence["lifecycle_state"],
+                "capability_scope": capability_scope,
+                "source": source,
+                "evidence_kind": normalized_kind,
+                "model_version": model_version,
+                "training_set_hash": training_set_hash,
+                "evaluation_bundle_hash": evaluation_bundle_hash,
+                "promotion_policy_version": promotion_policy_version,
+                "lifecycle_state": lifecycle_state.upper() if lifecycle_state else "DRAFT",
+                "quarantine_state": quarantine_state,
                 "gate_results": dict(gate_results or {}),
-                "updated_at": evidence["created_at"],
-                "queryable_ref": f"kb://models/{evidence['model_version']}",
-                "evidence_ref": evidence["queryable_ref"],
-                "quarantine_state": evidence["quarantine_state"],
+                "metadata": _anonymize_mapping(dict(metadata or {}), salt=self._anon_salt, epoch=self._anon_epoch),
+                "command": command,
+                "decision": decision,
+                "payload": _anonymize_mapping(dict(evidence_payload or {}), salt=self._anon_salt, epoch=self._anon_epoch),
+                "capability_scope": capability_scope,
+                "created_at": datetime.now(timezone.utc).isoformat(),
             }
-        return evidence
+            evidence["evidence_hash"] = _stable_hash(evidence)
+            evidence["evidence_id"] = str(
+                evidence_payload.get("evidence_id")
+                or f"evid_{hashlib.sha256(_stable_json(evidence).encode('utf-8')).hexdigest()[:24]}"
+            )
+            evidence["queryable_ref"] = f"kb://learning/{evidence['evidence_id']}"
+            self._learning_evidence.append(
+                {
+                    "evidence_id": evidence["evidence_id"],
+                    "tenant_id": evidence["tenant_id"],
+                    "project_id": evidence["project_id"],
+                    "capability_scope": evidence["capability_scope"],
+                    "evidence_kind": evidence["evidence_kind"],
+                    "evidence_hash": evidence["evidence_hash"],
+                    "model_version": evidence["model_version"],
+                    "training_set_hash": evidence["training_set_hash"],
+                    "evaluation_bundle_hash": evidence["evaluation_bundle_hash"],
+                    "promotion_policy_version": evidence["promotion_policy_version"],
+                    "lifecycle_state": evidence["lifecycle_state"],
+                    "quarantine_state": evidence["quarantine_state"],
+                    "source": evidence["source"],
+                    "command": evidence["command"],
+                    "decision": evidence["decision"],
+                    "gate_results": evidence["gate_results"],
+                    "metadata": evidence["metadata"],
+                    "payload": evidence["payload"],
+                    "capability_scope": evidence["capability_scope"],
+                    "created_at": evidence["created_at"],
+                    "queryable_ref": evidence["queryable_ref"],
+                }
+            )
+            if evidence["model_version"]:
+                self._learning_models[(envelope["tenant_id"], envelope["project_id"], evidence["model_version"])] = {
+                    "tenant_id": envelope["tenant_id"],
+                    "project_id": envelope["project_id"],
+                    "model_version": evidence["model_version"],
+                    "training_set_hash": evidence["training_set_hash"],
+                    "evaluation_bundle_hash": evidence["evaluation_bundle_hash"],
+                    "promotion_policy_version": evidence["promotion_policy_version"],
+                    "lifecycle_state": evidence["lifecycle_state"],
+                    "gate_results": dict(gate_results or {}),
+                    "updated_at": evidence["created_at"],
+                    "queryable_ref": f"kb://models/{evidence['model_version']}",
+                    "evidence_ref": evidence["queryable_ref"],
+                    "quarantine_state": evidence["quarantine_state"],
+                }
+            return evidence
+        except KnowledgeBaseUnavailable:
+            raise
+        except Exception as exc:
+            raise KnowledgeBaseUnavailable("redaction failure") from exc
 
     def _learning_collect_lineage(self, *, envelope: dict[str, Any], model_version: str) -> list[dict[str, Any]]:
         lineage: list[dict[str, Any]] = []

--- a/src/services/system-api/tests/test_knowledge_base_service.py
+++ b/src/services/system-api/tests/test_knowledge_base_service.py
@@ -18,6 +18,14 @@ from eigen.api.v1 import types_pb2 as types_pb  # noqa: E402
 from system_api.knowledge_base import KnowledgeBaseService, KnowledgeBaseUnavailable  # noqa: E402
 
 
+class _MetadataContext:
+    def __init__(self, metadata: tuple[tuple[str, str], ...]) -> None:
+        self._metadata = metadata
+
+    def invocation_metadata(self):
+        return self._metadata
+
+
 def _ts(value: str) -> Timestamp:
     ts = Timestamp()
     ts.FromDatetime(datetime.fromisoformat(value).replace(tzinfo=timezone.utc))
@@ -120,6 +128,47 @@ def _okb_benchmark_payload(
             "promotion_outcome": "PROMOTED",
         },
     }
+
+
+def _kb_security_metadata() -> tuple[tuple[str, str], ...]:
+    return (
+        ("authorization", "Bearer kb-token"),
+        ("x-eigen-tenant", "tenant-a"),
+        ("x-eigen-roles", "readonly"),
+        ("x-eigen-sub", "kb-subject"),
+        ("x-eigen-service", "system-api"),
+        ("x-eigen-service-role", "public-ingress"),
+        ("x-eigen-sandbox-profile", "default"),
+    )
+
+
+def _configure_kb_security(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SYSTEM_API_AUTH_MODE", "static_token")
+    monkeypatch.setenv("SYSTEM_API_AUTH_TOKEN", "kb-token")
+    monkeypatch.setenv("SYSTEM_API_AUTH_SUBJECT", "kb-subject")
+    monkeypatch.setenv("SYSTEM_API_AUTH_ROLES", "readonly")
+    monkeypatch.setenv("SYSTEM_API_AUTH_TENANT", "tenant-a")
+    monkeypatch.setenv(
+        "SYSTEM_API_POLICY_SNAPSHOT_JSON",
+        json.dumps(
+            {
+                "version": "1.0.0",
+                "issuer": "eigen-auth",
+                "audience": "eigen-api",
+                "role_permissions": {
+                    "readonly": ["kb:read", "kb:write", "devices:list", "jobs:read"],
+                },
+                "service_permissions": {
+                    "system-api": ["public-ingress"],
+                },
+                "sandbox_profiles": ["default"],
+            },
+            sort_keys=True,
+        ),
+    )
+    monkeypatch.setenv("SYSTEM_API_SERVICE_IDENTITY", "system-api")
+    monkeypatch.setenv("SYSTEM_API_SERVICE_ROLE", "public-ingress")
+    monkeypatch.setenv("SYSTEM_API_SANDBOX_PROFILE", "default")
 
 
 def test_upsert_query_replay_and_provenance_are_deterministic(grpc_addr: str) -> None:
@@ -233,6 +282,7 @@ def test_decision_log_lineage_validation_and_ordering(grpc_addr: str) -> None:
 def test_runtime_decision_ingest_persists_explainability_envelope(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     audit_path = tmp_path / "audit.jsonl"
     monkeypatch.setenv("SYSTEM_API_AUDIT_SINK_PATH", str(audit_path))
+    _configure_kb_security(monkeypatch)
     service = KnowledgeBaseService(kb_pb=kb_pb, types_pb=types_pb)
 
     decision_id = service.ingest_runtime_decision(
@@ -243,6 +293,16 @@ def test_runtime_decision_ingest_persists_explainability_envelope(monkeypatch: p
             "tenant_id": "tenant-a",
             "project_id": "project-a",
             "caller_identity": "eigen-compiler",
+            "security_context": {
+                "subject": "eigen-compiler",
+                "tenant": "tenant-a",
+                "project_id": "project-a",
+                "policy_version": "policy-2026-06-15",
+                "auth_mode": "static_token",
+                "service_identity": "system-api",
+                "service_role": "public-ingress",
+                "sandbox_profile": "default",
+            },
             "model_version": "m1",
             "component": "runtime",
             "policy_branch": "baseline",
@@ -391,8 +451,10 @@ def test_kb_fallback_behavior_raises_when_storage_disabled() -> None:
         )
 
 
-def test_okb_query_backend_is_deterministic_and_bounded() -> None:
+def test_okb_query_backend_is_deterministic_and_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_kb_security(monkeypatch)
     service = KnowledgeBaseService(kb_pb=kb_pb, types_pb=types_pb)
+    context = _MetadataContext(_kb_security_metadata())
 
     for i in range(10):
         service.ingest_benchmark_run(
@@ -433,8 +495,8 @@ def test_okb_query_backend_is_deterministic_and_bounded() -> None:
         "candidate_budget": 99,
     }
 
-    first = service.query_optimization_candidates(query)
-    second = service.query_optimization_candidates(query)
+    first = service.query_optimization_candidates(query, context=context)
+    second = service.query_optimization_candidates(query, context=context)
 
     assert first == second
     assert first["tenant_id"] == "tenant-a"
@@ -467,14 +529,14 @@ def test_okb_query_backend_is_deterministic_and_bounded() -> None:
     assert first["index_status"]["indices"]["structural"]["status"] == "ready"
     assert first["index_status"]["indices"]["vector"]["status"] == "ready"
 
-    vector = service.query_optimization_candidates({**query, "query_mode": "vector", "candidate_budget": 2})
+    vector = service.query_optimization_candidates({**query, "query_mode": "vector", "candidate_budget": 2}, context=context)
     assert vector["query_mode"] == "vector"
     assert vector["candidate_budget"] == 2
     assert vector["selected_candidate_id"] == vector["candidates"][0]["candidate_id"]
     assert vector["candidates"][0]["score_breakdown"]["rank_source"] == "vector"
     assert len(vector["candidates"]) == 2
 
-    hybrid = service.query_optimization_candidates({**query, "query_mode": "hybrid", "candidate_budget": 3})
+    hybrid = service.query_optimization_candidates({**query, "query_mode": "hybrid", "candidate_budget": 3}, context=context)
     assert hybrid["query_mode"] == "hybrid"
     assert hybrid["candidate_budget"] == 3
     assert hybrid["selected_candidate_id"] == hybrid["candidates"][0]["candidate_id"]
@@ -482,8 +544,10 @@ def test_okb_query_backend_is_deterministic_and_bounded() -> None:
     assert len(hybrid["candidates"]) == 3
     
 
-def test_okb_query_backend_is_capability_scoped_and_fail_closed() -> None:
+def test_okb_query_backend_is_capability_scoped_and_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_kb_security(monkeypatch)
     service = KnowledgeBaseService(kb_pb=kb_pb, types_pb=types_pb)
+    context = _MetadataContext(_kb_security_metadata())
 
     service.ingest_benchmark_run(
         _okb_benchmark_payload(
@@ -522,7 +586,8 @@ def test_okb_query_backend_is_capability_scoped_and_fail_closed() -> None:
             "deterministic": True,
             "query_mode": "structural",
             "candidate_budget": 8,
-        }
+        },
+        context=context,
     )
     mismatch = service.query_optimization_candidates(
         {
@@ -542,7 +607,8 @@ def test_okb_query_backend_is_capability_scoped_and_fail_closed() -> None:
             "deterministic": True,
             "query_mode": "structural",
             "candidate_budget": 8,
-        }
+        },
+        context=context,
     )
 
     assert [item["candidate_id"] for item in matched["candidates"]] == ["okb-record-capability-candidate-01"]
@@ -551,8 +617,10 @@ def test_okb_query_backend_is_capability_scoped_and_fail_closed() -> None:
     assert mismatch["selected_candidate_id"] == ""
 
 
-def test_learning_evidence_query_is_capability_scoped_and_fail_closed() -> None:
+def test_learning_evidence_query_is_capability_scoped_and_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_kb_security(monkeypatch)
     service = KnowledgeBaseService(kb_pb=kb_pb, types_pb=types_pb)
+    context = _MetadataContext(_kb_security_metadata())
 
     service.ingest_learning_evidence(
         {
@@ -596,7 +664,8 @@ def test_learning_evidence_query_is_capability_scoped_and_fail_closed() -> None:
             "model_version": "m1",
             "capability_tags": ["qpu", "latency"],
             "page_size": 10,
-        }
+        },
+        context=context,
     )
     mismatch = service.query_learning_evidence(
         {
@@ -605,7 +674,8 @@ def test_learning_evidence_query_is_capability_scoped_and_fail_closed() -> None:
             "model_version": "m1",
             "capability_tags": ["gpu", "latency"],
             "page_size": 10,
-        }
+        },
+        context=context,
     )
 
     assert matched["total_count"] == 1
@@ -629,13 +699,26 @@ def test_okb_index_recovery_backfill_and_desync_signals() -> None:
         {
             "decision_id": "recover-decision-1",
             "trace_id": "trace-recover",
+            "tenant_id": "tenant-a",
+            "project_id": "project-a",
+            "caller_identity": "kb-subject",
+            "security_context": {
+                "subject": "kb-subject",
+                "tenant": "tenant-a",
+                "project_id": "project-a",
+                "policy_version": "1.0.0",
+                "auth_mode": "static_token",
+                "service_identity": "system-api",
+                "service_role": "public-ingress",
+                "sandbox_profile": "default",
+            },
             "model_version": "m1",
             "component": "runtime",
             "policy_branch": "baseline",
             "selected_action": "backend-alpha",
             "feature_snapshot": {"queue_depth": "2"},
-            "tenant_id": "tenant-a",
-            "project_id": "project-a",
+            "retrieval_sources": ["nsc://policy-snapshot/1.0.0"],
+            "policy_snapshot_version": "1.0.0",
         }
     )
 


### PR DESCRIPTION
## Summary

Implemented fail-closed enforcement for the system-api knowledge base path used by DPDA-NEURO-15. Runtime decision ingestion now denies on missing security context, missing policy snapshot data, permissive allow_all auth mode, or missing retrieval sources; redaction/anonymization/storage failures are also converted into denial instead of fallback. The related audit trail now records the required compliance fields, and the architecture/reference docs were updated to match the new behavior.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: API | Metrics
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Fail-closed enforcement for knowledge base runtime decision ingestion.
- Compliance audit fields for caller identity, tenant, policy snapshot, model version, retrieval sources, and final decision.

### Changed
- Runtime decision ingestion now requires explicit security context and retrieval provenance.
- Redaction/anonymization/storage failures now deny instead of falling back permissively.
- Documentation now states that KB audit/retrieval helpers do not accept permissive fallback.

### Fixed
- Security bypasses caused by missing context, missing policy evidence, or permissive-mode fallback.