### PR TITLE
Implemented the internal model registry + signed loading/rollback con…

### DIFF
--- a/docs/architecture/components/neuro-symbolic-core.md
+++ b/docs/architecture/components/neuro-symbolic-core.md
@@ -144,7 +144,8 @@ Ecosystem and governance groundwork:
 
 - plugin architecture includes `optimizer` plugin category,
 - governance framework and RFC/ADR workflow exist,
-- runtime tracing and structured logging exist.
+- runtime tracing and structured logging exist,
+- internal model registry activation uses signed artifact verification and frozen policy snapshot binding.
 
 Intelligent-adjacent behavior:
 
@@ -163,7 +164,6 @@ Intelligent-adjacent behavior:
 - production GNN optimizer runtime,
 - OKB-driven optimization retrieval on the request path,
 - explainability engine producing stable NSC decision artifacts,
-- model registry + signed model lifecycle,
 - confidence-aware policy gating and deterministic rollback controller.
 
 The implemented NSC compiler path MUST still capture an immutable policy snapshot at service start and use that frozen snapshot for all inference requests. Live policy lookups MUST NOT be part of request-time scoring.
@@ -314,6 +314,23 @@ Capture stable decision artifacts for audit and replay.
 
 ---
 
+### 7.5 Internal model registry and signed loading contract
+
+#### Responsibility
+
+Publish, verify, activate, and roll back internal Neuro-DPDA model artifacts inside the deployable NSC service boundary.
+
+#### Requirements
+
+- model artifacts MUST have stable version identifiers, digests, and signature metadata,
+- model activation MUST be bound to the frozen policy snapshot version and internal service identity,
+- loading MUST verify the artifact digest before activation,
+- loading MUST verify the registry signature before activation,
+- missing artifact, missing policy snapshot, bad signature, or identity mismatch MUST fail closed,
+- rollback MUST be auditable and MUST preserve deterministic baseline behavior when activation cannot be verified.
+
+---
+
 ## 8. Integration Boundaries
 
 ### 8.1 Compiler integration
@@ -341,7 +358,13 @@ Requests from public API boundaries must never reach NSC directly.
 
 ---
 
-### 8.4 Deployment shape
+### 8.4 Mandatory preprocessing redaction layer
+
+All data that can enter model loading, knowledge retrieval, decision logging, or replay packaging paths MUST pass through a mandatory preprocessing redaction layer before persistence or external emission.
+
+---
+
+### 8.5 Deployment shape
 
 The implementation boundary for NSC is a **standalone internal service** packaged as `src/services/neuro-symbolic-service/`.
 
@@ -351,7 +374,3 @@ This service boundary is intentionally separate from `src/services/system-api/`:
 - `eigen-kernel` / QRTX is the primary runtime caller.
 - `eigen-compiler` may call the service only through the bounded advisory scoring path.
 - Internal offline workflows such as model loading, dataset ingestion, and privacy-governed training remain inside the same internal service boundary and must not be exposed through public ingress.
-
-### 8.5 Mandatory preprocessing redaction layer
-
-All inputs that can reach learning, replay, audit, or export pipelines MUST pass through a mandatory preprocessing redaction layer before persistence, indexing, replay, or external emission.

--- a/docs/reference/api/grpc-internal.md
+++ b/docs/reference/api/grpc-internal.md
@@ -265,7 +265,7 @@ Operational flow:
 
 Internal-only DPDA model service used for advisory scoring of compilation plans. The deployable service boundary lives under `src/services/neuro-symbolic-service/`.
 
-This service is callable only by authenticated internal service identities. Public ingress paths MUST NOT expose a direct route to this service. Kernel/QRTX is the primary runtime caller; eigen-compiler may call this service only through the bounded advisory scoring path. `System API` MUST NOT call this service directly.
+This service is callable only by authenticated internal service identities. Public ingress paths MUST NOT expose a direct route to this service. Kernel/QRTX is the primary runtime caller; eigen-compiler may call this service only through the bounded advisory scoring path. `System API` MUST NOT call this service directly. Internal model registry activation and rollback are constrained by signed artifact verification, frozen policy snapshot binding, and internal service identity.
 
 #### Security and versioning requirements
 

--- a/docs/reference/security/authz.md
+++ b/docs/reference/security/authz.md
@@ -76,7 +76,7 @@ Internal service-to-service calls MUST authenticate workload identity and author
 - Kernel/QRTX / eigen-compiler to NeuroSymbolicService advisory calls,
 - runtime and benchmark services emitting observability or knowledge-base records.
 
-NeuroSymbolicService MUST fail closed when the service identity, tenant/project binding, or policy snapshot version is missing. Public ingress principals are not authorized to reach this service directly.
+NeuroSymbolicService MUST fail closed when the service identity, tenant/project binding, policy snapshot version, signed model registry evidence, or model artifact digest is missing. Public ingress principals are not authorized to reach this service directly. Model loading and rollback inside NeuroSymbolicService MUST remain internal-only and MUST preserve deterministic baseline behavior when verification fails.
 
 ---
 

--- a/src/services/neuro-symbolic-service/src/neuro_symbolic_service/grpc_impl.py
+++ b/src/services/neuro-symbolic-service/src/neuro_symbolic_service/grpc_impl.py
@@ -16,7 +16,7 @@ import grpc
 from eigen.internal.v1 import neuro_symbolic_service_pb2 as nsc_pb
 from eigen.internal.v1 import neuro_symbolic_service_pb2_grpc as nsc_pb_grpc
 
-from .observability import record_decision, record_denial, record_request
+from .observability import append_security_audit_event, record_decision, record_denial, record_request
 
 _LOG = logging.getLogger("neuro_symbolic_service")
 
@@ -88,6 +88,48 @@ _SECRET_PATH_RE = re.compile(
 )
 
 
+_MODEL_REGISTRY_DEFAULT_REGISTRY_VERSION = "1.0.0"
+_MODEL_REGISTRY_DEFAULT_SERVICE_IDENTITY = "neuro-symbolic-service"
+_MODEL_REGISTRY_DEFAULT_SIGNATURE_KEY_ID = "internal-neuro-dpda-key"
+_MODEL_REGISTRY_ENV_JSON = "NEURO_SYMBOLIC_MODEL_REGISTRY_JSON"
+_MODEL_REGISTRY_ENV_PATH = "NEURO_SYMBOLIC_MODEL_REGISTRY_PATH"
+_MODEL_REGISTRY_ENV_SIGNING_KEY = "NEURO_SYMBOLIC_MODEL_REGISTRY_SIGNING_KEY"
+_MODEL_REGISTRY_ENV_SERVICE_IDENTITY = "NEURO_SYMBOLIC_SERVICE_IDENTITY"
+_MODEL_REGISTRY_ENV_ARTIFACT_ROOT = "NEURO_SYMBOLIC_MODEL_ARTIFACT_ROOT"
+
+
+@dataclass(frozen=True)
+class ModelRegistryEntry:
+    model_version: str
+    artifact_path: str
+    artifact_sha256: str
+    signature: str
+    signature_key_id: str
+    policy_snapshot_version: str
+    service_identity: str
+    tenant_id: str
+    project_id: str
+    active: bool
+
+
+@dataclass(frozen=True)
+class ModelRegistryState:
+    registry_version: str
+    service_identity: str
+    tenant_id: str
+    project_id: str
+    policy_snapshot_version: str
+    active_model_version: str
+    active_model_artifact_sha256: str
+    active_model_signature_key_id: str
+    activation_state: str
+    activation_reason: str
+    registry_source: str
+    artifact_path: str | None
+    signature_key_id: str | None
+    verified: bool
+
+
 @dataclass(frozen=True)
 class FeatureRedactionResult:
     feature_vector: bytes
@@ -106,6 +148,211 @@ def _stable_json(value: object) -> str:
 
 def _hex_digest(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
+
+
+def _stable_hash(payload: Any) -> str:
+    return f"sha256:{hashlib.sha256(_stable_json(payload).encode('utf-8')).hexdigest()}"
+
+
+def _audit_model_registry_event(*, audit_kind: str, operation: str, state: ModelRegistryState, model_version: str, reason: str) -> None:
+    append_security_audit_event(
+        {
+            "audit_kind": audit_kind,
+            "operation": operation,
+            "model_version": model_version,
+            "caller_identity": state.service_identity,
+            "tenant": state.tenant_id,
+            "project_id": state.project_id,
+            "policy_snapshot_version": state.policy_snapshot_version,
+            "registry_version": state.registry_version,
+            "registry_source": state.registry_source,
+            "activation_state": state.activation_state,
+            "reason": reason,
+            "immutable": True,
+        }
+    )
+
+
+def _model_registry_signing_payload(*, model_version: str, artifact_sha256: str, policy_snapshot_version: str, service_identity: str, tenant_id: str, project_id: str, artifact_path: str) -> str:
+    return _stable_json(
+        {
+            "artifact_path": artifact_path,
+            "artifact_sha256": artifact_sha256,
+            "model_version": model_version,
+            "policy_snapshot_version": policy_snapshot_version,
+            "project_id": project_id,
+            "service_identity": service_identity,
+            "tenant_id": tenant_id,
+        }
+    )
+
+
+def _resolve_registry_path(path_str: str) -> Path:
+    return Path(path_str).expanduser().resolve()
+
+
+def _read_model_registry_payload() -> tuple[dict[str, Any] | None, str]:
+    raw_json = os.getenv(_MODEL_REGISTRY_ENV_JSON, "").strip()
+    raw_path = os.getenv(_MODEL_REGISTRY_ENV_PATH, "").strip()
+    if raw_json:
+        return json.loads(raw_json), f"env:{_MODEL_REGISTRY_ENV_JSON}"
+    if raw_path:
+        path = _resolve_registry_path(raw_path)
+        return json.loads(path.read_text(encoding="utf-8")), f"file:{path}"
+    return None, "baseline"
+
+
+def _artifact_root_from_env() -> Path | None:
+    raw = os.getenv(_MODEL_REGISTRY_ENV_ARTIFACT_ROOT, "").strip()
+    if not raw:
+        return None
+    return _resolve_registry_path(raw)
+
+
+def _service_identity_from_env() -> str:
+    return os.getenv(_MODEL_REGISTRY_ENV_SERVICE_IDENTITY, _MODEL_REGISTRY_DEFAULT_SERVICE_IDENTITY).strip() or _MODEL_REGISTRY_DEFAULT_SERVICE_IDENTITY
+
+
+def _registry_signing_key() -> str:
+    return os.getenv(_MODEL_REGISTRY_ENV_SIGNING_KEY, "").strip()
+
+
+def _hash_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _load_model_registry_state(*, active_policy_snapshot_version: str, requested_model_version: str | None = None) -> tuple[ModelRegistryState, ModelRegistryEntry | None]:
+    payload, source = _read_model_registry_payload()
+    service_identity = _service_identity_from_env()
+    baseline_state = ModelRegistryState(
+        registry_version=_MODEL_REGISTRY_DEFAULT_REGISTRY_VERSION,
+        service_identity=service_identity,
+        tenant_id="",
+        project_id="",
+        policy_snapshot_version=active_policy_snapshot_version,
+        active_model_version=_MODEL_VERSION_DEFAULT,
+        active_model_artifact_sha256="",
+        active_model_signature_key_id="",
+        activation_state="baseline",
+        activation_reason="model registry disabled",
+        registry_source=source,
+        artifact_path=None,
+        signature_key_id=None,
+        verified=False,
+    )
+    if payload is None:
+        return baseline_state, None
+
+    if not isinstance(payload, dict):
+        raise ValueError("model registry payload must be a JSON object")
+
+    registry_version = str(payload.get("registry_version", "")).strip() or _MODEL_REGISTRY_DEFAULT_REGISTRY_VERSION
+    registry_service_identity = str(payload.get("service_identity", "")).strip() or service_identity
+    registry_tenant_id = str(payload.get("tenant_id", "")).strip()
+    registry_project_id = str(payload.get("project_id", "")).strip()
+    registry_policy_snapshot_version = str(payload.get("policy_snapshot_version", "")).strip()
+    active_model_version = str(payload.get("active_model_version", "")).strip()
+    models = payload.get("models", [])
+    if not isinstance(models, list) or not models:
+        raise ValueError("model registry models must be a non-empty list")
+    if registry_service_identity != service_identity:
+        raise ValueError("model registry service identity does not match the internal service identity")
+    if not registry_policy_snapshot_version:
+        raise ValueError("model registry policy snapshot version is required")
+    if registry_policy_snapshot_version != active_policy_snapshot_version:
+        raise ValueError("model registry policy snapshot version does not match the active policy snapshot")
+
+    signing_key = _registry_signing_key()
+    if not signing_key:
+        raise ValueError("model registry signing key is required")
+
+    models_by_version: dict[str, dict[str, Any]] = {}
+    for item in models:
+        if not isinstance(item, dict):
+            raise ValueError("model registry entries must be objects")
+        version = str(item.get("model_version", "")).strip()
+        artifact_path = str(item.get("artifact_path", "")).strip()
+        artifact_sha256 = str(item.get("artifact_sha256", "")).strip().lower()
+        signature = str(item.get("signature", "")).strip().lower()
+        signature_key_id = str(item.get("signature_key_id", "")).strip() or _MODEL_REGISTRY_DEFAULT_SIGNATURE_KEY_ID
+        entry_service_identity = str(item.get("service_identity", "")).strip() or registry_service_identity
+        entry_tenant_id = str(item.get("tenant_id", "")).strip() or registry_tenant_id
+        entry_project_id = str(item.get("project_id", "")).strip() or registry_project_id
+        entry_policy_snapshot_version = str(item.get("policy_snapshot_version", "")).strip() or registry_policy_snapshot_version
+        active = bool(item.get("active", False))
+        if not all([version, artifact_path, artifact_sha256, signature, entry_service_identity, entry_policy_snapshot_version]):
+            raise ValueError("model registry entry is missing required fields")
+        if not re.fullmatch(r"[0-9a-f]{64}", artifact_sha256):
+            raise ValueError("model registry artifact_sha256 must be a SHA-256 hex digest")
+        if not re.fullmatch(r"[0-9a-f]{64}", signature):
+            raise ValueError("model registry signature must be a SHA-256 hex digest")
+        models_by_version[version] = {
+            "model_version": version,
+            "artifact_path": artifact_path,
+            "artifact_sha256": artifact_sha256,
+            "signature": signature,
+            "signature_key_id": signature_key_id,
+            "service_identity": entry_service_identity,
+            "tenant_id": entry_tenant_id,
+            "project_id": entry_project_id,
+            "policy_snapshot_version": entry_policy_snapshot_version,
+            "active": active,
+        }
+
+    selected_version = (requested_model_version or active_model_version or next((m["model_version"] for m in models_by_version.values() if m["active"]), "")).strip()
+    if not selected_version:
+        raise ValueError("model registry active_model_version is required")
+    if selected_version not in models_by_version:
+        raise ValueError("model registry active_model_version not found in models")
+
+    entry = models_by_version[selected_version]
+    artifact_path = Path(entry["artifact_path"])
+    if not artifact_path.is_absolute():
+        artifact_root = _artifact_root_from_env()
+        if artifact_root is not None:
+            artifact_path = artifact_root / artifact_path
+        elif source.startswith("file:"):
+            artifact_path = Path(source.removeprefix("file:")).parent / artifact_path
+    artifact_path = artifact_path.resolve()
+    if not artifact_path.exists():
+        raise ValueError("model registry artifact is missing")
+    artifact_sha256 = _hash_file(artifact_path)
+    if artifact_sha256 != entry["artifact_sha256"]:
+        raise ValueError("model registry artifact digest mismatch")
+
+    expected_signature = hmac.new(
+        signing_key.encode("utf-8"),
+        _model_registry_signing_payload(
+            model_version=entry["model_version"],
+            artifact_sha256=entry["artifact_sha256"],
+            policy_snapshot_version=entry["policy_snapshot_version"],
+            service_identity=entry["service_identity"],
+            tenant_id=entry["tenant_id"],
+            project_id=entry["project_id"],
+            artifact_path=str(entry["artifact_path"]),
+        ).encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(expected_signature, entry["signature"]):
+        raise ValueError("model registry signature verification failed")
+
+    state = ModelRegistryState(
+        registry_version=registry_version,
+        service_identity=service_identity,
+        tenant_id=entry["tenant_id"],
+        project_id=entry["project_id"],
+        policy_snapshot_version=entry["policy_snapshot_version"],
+        active_model_version=entry["model_version"],
+        active_model_artifact_sha256=entry["artifact_sha256"],
+        active_model_signature_key_id=entry["signature_key_id"],
+        activation_state="active",
+        activation_reason="model registry verified",
+        registry_source=source,
+        artifact_path=str(artifact_path),
+        signature_key_id=entry["signature_key_id"],
+        verified=True,
+    )
+    return state, ModelRegistryEntry(**entry)
 
 
 def _float_from_digest(digest: bytes, start: int = 0) -> float:
@@ -263,6 +510,7 @@ def _explainability_envelope(
     redacted_fields: Iterable[str],
     feature_schema_version: str,
     model_hint: str,
+    model_activation_state: str,
 ) -> dict[str, object]:
     return {
         "request_id": request_id,
@@ -270,6 +518,7 @@ def _explainability_envelope(
         "project_id": project_id,
         "policy_snapshot_version": policy_snapshot_version,
         "model_version": model_version,
+        "model_activation_state": model_activation_state,
         "confidence": confidence,
         "feature_set": {
             "schema_version": feature_schema_version,
@@ -291,6 +540,91 @@ class NeuroSymbolicService(nsc_pb_grpc.NeuroSymbolicServiceServicer):
     def __init__(self, *, policy_snapshot_version: str | None = None):
         self._policy_snapshot_version = (policy_snapshot_version or _policy_snapshot_version()).strip() or _POLICY_SNAPSHOT_DEFAULT
         self._model_version = os.getenv("NEURO_SYMBOLIC_MODEL_VERSION", _MODEL_VERSION_DEFAULT).strip() or _MODEL_VERSION_DEFAULT
+        self._model_activation_state = "baseline"
+        self._model_registry_state = ModelRegistryState(
+            registry_version=_MODEL_REGISTRY_DEFAULT_REGISTRY_VERSION,
+            service_identity=_service_identity_from_env(),
+            tenant_id="",
+            project_id="",
+            policy_snapshot_version=self._policy_snapshot_version,
+            active_model_version=self._model_version,
+            active_model_artifact_sha256="",
+            active_model_signature_key_id="",
+            activation_state="baseline",
+            activation_reason="model registry disabled",
+            registry_source="baseline",
+            artifact_path=None,
+            signature_key_id=None,
+            verified=False,
+        )
+        self._model_registry_entry: ModelRegistryEntry | None = None
+        self._activate_model_registry()
+
+    def _activate_model_registry(self, *, requested_model_version: str | None = None, operation: str = "activation") -> None:
+        try:
+            state, entry = _load_model_registry_state(active_policy_snapshot_version=self._policy_snapshot_version, requested_model_version=requested_model_version)
+        except Exception as exc:
+            self._model_version = _MODEL_VERSION_DEFAULT
+            self._model_activation_state = "baseline_fallback"
+            self._model_registry_state = ModelRegistryState(
+                registry_version=_MODEL_REGISTRY_DEFAULT_REGISTRY_VERSION,
+                service_identity=_service_identity_from_env(),
+                tenant_id="",
+                project_id="",
+                policy_snapshot_version=self._policy_snapshot_version,
+                active_model_version=_MODEL_VERSION_DEFAULT,
+                active_model_artifact_sha256="",
+                active_model_signature_key_id="",
+                activation_state="baseline_fallback",
+                activation_reason=str(exc),
+                registry_source="baseline_fallback",
+                artifact_path=None,
+                signature_key_id=None,
+                verified=False,
+            )
+            self._model_registry_entry = None
+            _audit_model_registry_event(
+                audit_kind="model_registry_activation",
+                operation=operation,
+                state=self._model_registry_state,
+                model_version=self._model_version,
+                reason=str(exc),
+            )
+            return
+
+        self._model_registry_state = state
+        self._model_registry_entry = entry
+        self._model_version = state.active_model_version
+        self._model_activation_state = state.activation_state
+        _audit_model_registry_event(
+            audit_kind="model_registry_rollback" if operation != "activation" else "model_registry_activation",
+            operation=operation,
+            state=state,
+            model_version=self._model_version,
+            reason=state.activation_reason,
+        )
+
+    def activate_model_version(self, model_version: str) -> bool:
+        model_version = model_version.strip()
+        if not model_version:
+            self._model_version = _MODEL_VERSION_DEFAULT
+            self._model_activation_state = "baseline_fallback"
+            _audit_model_registry_event(
+                audit_kind="model_registry_rollback",
+                operation="rollback",
+                state=self._model_registry_state,
+                model_version=self._model_version,
+                reason="model version is required",
+            )
+            return False
+        self._activate_model_registry(requested_model_version=model_version, operation="rollback")
+        return self._model_version == model_version
+
+    def rollback_model_version(self, model_version: str) -> bool:
+        return self.activate_model_version(model_version)
+
+    def model_registry_snapshot(self) -> ModelRegistryState:
+        return self._model_registry_state
 
     def ScoreCompilationPlan(self, request, context: grpc.ServicerContext):
         identity = _require_internal_identity(context, method_name="ScoreCompilationPlan")
@@ -390,6 +724,24 @@ class NeuroSymbolicService(nsc_pb_grpc.NeuroSymbolicServiceServicer):
             redacted_fields=redaction.redacted_fields,
             feature_schema_version=feature_schema_version,
             model_hint=request.model_hint,
+            model_activation_state=self._model_activation_state,
+        )
+
+        append_security_audit_event(
+            {
+                "audit_kind": "model_scoring",
+                "operation": "ScoreCompilationPlan",
+                "request_id": request_id,
+                "caller_identity": identity.caller_id,
+                "tenant": tenant_id,
+                "project_id": project_id,
+                "policy_snapshot_version": self._policy_snapshot_version,
+                "model_version": self._model_version,
+                "model_activation_state": self._model_activation_state,
+                "feature_digest_sha256": feature_digest_sha256,
+                "replay_digest": replay_digest,
+                "immutable": True,
+            }
         )
 
         _LOG.info(

--- a/src/services/neuro-symbolic-service/tests/test_grpc_service.py
+++ b/src/services/neuro-symbolic-service/tests/test_grpc_service.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
+from pathlib import Path
 
 import grpc
 import pytest
@@ -42,6 +44,135 @@ def _metadata(*, caller: str = "eigen-kernel", tenant_id: str = "tenant-a", proj
         ("x-eigen-tenant-id", tenant_id),
         ("x-eigen-project-id", project_id),
     ]
+
+
+def _registry_signature(
+    *,
+    model_version: str,
+    artifact_sha256: str,
+    policy_snapshot_version: str,
+    service_identity: str,
+    tenant_id: str,
+    project_id: str,
+    artifact_path: str,
+    signing_key: str,
+) -> str:
+    payload = json.dumps(
+        {
+            "artifact_path": artifact_path,
+            "artifact_sha256": artifact_sha256,
+            "model_version": model_version,
+            "policy_snapshot_version": policy_snapshot_version,
+            "project_id": project_id,
+            "service_identity": service_identity,
+            "tenant_id": tenant_id,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hmac.new(signing_key.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+
+
+def _write_signed_registry(
+    tmp_path: Path,
+    *,
+    active_model_version: str,
+    policy_snapshot_version: str = "1.0.0",
+    service_identity: str = "neuro-symbolic-service",
+    tenant_id: str = "tenant-a",
+    project_id: str = "project-a",
+    signing_key: str = "model-signing-key",
+    artifact_bytes: bytes = b"neuro-dpda-model",
+    second_model_bytes: bytes = b"neuro-dpda-model-v1",
+    second_model_version: str = "dpda-model-v1",
+    include_second_model: bool = True,
+    bad_signature: bool = False,
+    missing_artifact: bool = False,
+) -> tuple[Path, Path]:
+    artifact_path = tmp_path / f"{active_model_version}.bin"
+    artifact_path.write_bytes(artifact_bytes)
+    artifact_digest = hashlib.sha256(artifact_bytes).hexdigest()
+
+    models: list[dict[str, object]] = []
+    active_entry = {
+        "model_version": active_model_version,
+        "artifact_path": artifact_path.name,
+        "artifact_sha256": artifact_digest,
+        "signature_key_id": "internal-neuro-dpda-key",
+        "service_identity": service_identity,
+        "tenant_id": tenant_id,
+        "project_id": project_id,
+        "policy_snapshot_version": policy_snapshot_version,
+        "active": True,
+    }
+    active_entry["signature"] = _registry_signature(
+        model_version=active_model_version,
+        artifact_sha256=artifact_digest,
+        policy_snapshot_version=policy_snapshot_version,
+        service_identity=service_identity,
+        tenant_id=tenant_id,
+        project_id=project_id,
+        artifact_path=artifact_path.name,
+        signing_key=signing_key,
+    )
+    if bad_signature:
+        active_entry["signature"] = "0" * 64
+    models.append(active_entry)
+
+    if include_second_model:
+        second_path = tmp_path / f"{second_model_version}.bin"
+        second_path.write_bytes(second_model_bytes)
+        second_digest = hashlib.sha256(second_model_bytes).hexdigest()
+        second_entry = {
+            "model_version": second_model_version,
+            "artifact_path": second_path.name,
+            "artifact_sha256": second_digest,
+            "signature_key_id": "internal-neuro-dpda-key",
+            "service_identity": service_identity,
+            "tenant_id": tenant_id,
+            "project_id": project_id,
+            "policy_snapshot_version": policy_snapshot_version,
+            "active": False,
+        }
+        second_entry["signature"] = _registry_signature(
+            model_version=second_model_version,
+            artifact_sha256=second_digest,
+            policy_snapshot_version=policy_snapshot_version,
+            service_identity=service_identity,
+            tenant_id=tenant_id,
+            project_id=project_id,
+            artifact_path=second_path.name,
+            signing_key=signing_key,
+        )
+        models.append(second_entry)
+
+    if missing_artifact:
+        artifact_path.unlink()
+
+    registry = {
+        "registry_version": "1.0.0",
+        "service_identity": service_identity,
+        "tenant_id": tenant_id,
+        "project_id": project_id,
+        "policy_snapshot_version": policy_snapshot_version,
+        "active_model_version": active_model_version,
+        "models": models,
+    }
+    registry_path = tmp_path / "model-registry.json"
+    registry_path.write_text(json.dumps(registry, sort_keys=True, indent=2), encoding="utf-8")
+    return registry_path, artifact_path
+
+
+class _FakeContext:
+    def __init__(self, metadata: list[tuple[str, str]]) -> None:
+        self._metadata = tuple(metadata)
+
+    def invocation_metadata(self):
+        return self._metadata
+
+    def abort(self, *_args, **_kwargs):  # pragma: no cover - only called on failing paths
+        raise AssertionError("abort should not be reached in success-path tests")
 
 
 def test_score_compilation_plan_is_internal_only(grpc_addr: str) -> None:
@@ -102,3 +233,132 @@ def test_score_compilation_plan_fail_closed_on_policy_snapshot_mismatch(grpc_add
         stub.ScoreCompilationPlan(_request({"kind": "plan"}, policy_snapshot_version="2.0.0"), metadata=_metadata())
 
     assert err.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+
+
+def test_model_registry_loads_signed_artifact_and_scores_with_loaded_model(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    registry_path, artifact_path = _write_signed_registry(
+        tmp_path,
+        active_model_version="dpda-model-v2",
+        signing_key="registry-secret-key",
+    )
+    audit_path = tmp_path / "audit.jsonl"
+    monkeypatch.setenv("NEURO_SYMBOLIC_MODEL_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setenv("NEURO_SYMBOLIC_MODEL_REGISTRY_SIGNING_KEY", "registry-secret-key")
+    monkeypatch.setenv("NEURO_SYMBOLIC_MODEL_ARTIFACT_ROOT", str(tmp_path))
+    monkeypatch.setenv("NEURO_SYMBOLIC_SERVICE_IDENTITY", "neuro-symbolic-service")
+    monkeypatch.setenv("NEURO_SYMBOLIC_INTERNAL_TOKEN", "dev-internal-token")
+    monkeypatch.setenv("NEURO_SYMBOLIC_ALLOWED_CALLERS", "eigen-kernel,eigen-compiler")
+    monkeypatch.setenv("NEURO_SYMBOLIC_AUDIT_SINK_PATH", str(audit_path))
+
+    from neuro_symbolic_service.grpc_impl import NeuroSymbolicService
+
+    service = NeuroSymbolicService()
+    assert service.model_registry_snapshot().verified is True
+    assert service.model_registry_snapshot().active_model_version == "dpda-model-v2"
+    assert service._model_version == "dpda-model-v2"
+
+    response = service.ScoreCompilationPlan(_request({"kind": "plan", "priority": 3}), _FakeContext(_metadata()))
+    assert response.model_version == "dpda-model-v2"
+    assert response.policy_snapshot_version == "1.0.0"
+    assert response.deterministic_compatible is True
+
+    audit_lines = audit_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(audit_lines) >= 2
+    activation = json.loads(audit_lines[0])
+    scoring = json.loads(audit_lines[-1])
+    assert activation["audit_kind"] == "model_registry_activation"
+    assert activation["model_version"] == "dpda-model-v2"
+    assert activation["caller_identity"] == "neuro-symbolic-service"
+    assert activation["tenant"] == "tenant-a"
+    assert activation["policy_snapshot_version"] == "1.0.0"
+    assert scoring["audit_kind"] == "model_scoring"
+    assert scoring["model_version"] == "dpda-model-v2"
+    assert scoring["tenant"] == "tenant-a"
+    assert scoring["policy_snapshot_version"] == "1.0.0"
+
+
+@pytest.mark.parametrize(
+    ("mutator", "expected_reason"),
+    [
+        (lambda cfg: cfg.__setitem__("bad_signature", True), "signature verification failed"),
+        (lambda cfg: cfg.__setitem__("missing_artifact", True), "artifact is missing"),
+        (lambda cfg: cfg.__setitem__("policy_snapshot_version", ""), "policy snapshot version is required"),
+    ],
+)
+def test_model_registry_fallback_is_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mutator,
+    expected_reason: str,
+) -> None:
+    cfg: dict[str, object] = {"active_model_version": "dpda-model-v2"}
+    mutator(cfg)
+    registry_path, _ = _write_signed_registry(
+        tmp_path,
+        active_model_version=cfg["active_model_version"],  # type: ignore[arg-type]
+        policy_snapshot_version=cfg.get("policy_snapshot_version", "1.0.0"),  # type: ignore[arg-type]
+        signing_key="registry-secret-key",
+        bad_signature=bool(cfg.get("bad_signature", False)),
+        missing_artifact=bool(cfg.get("missing_artifact", False)),
+    )
+    if cfg.get("policy_snapshot_version") == "":
+        payload = json.loads(registry_path.read_text(encoding="utf-8"))
+        payload["policy_snapshot_version"] = ""
+        registry_path.write_text(json.dumps(payload, sort_keys=True, indent=2), encoding="utf-8")
+
+    audit_path = tmp_path / "audit.jsonl"
+    monkeypatch.setenv("NEURO_SYMBOLIC_MODEL_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setenv("NEURO_SYMBOLIC_MODEL_REGISTRY_SIGNING_KEY", "registry-secret-key")
+    monkeypatch.setenv("NEURO_SYMBOLIC_MODEL_ARTIFACT_ROOT", str(tmp_path))
+    monkeypatch.setenv("NEURO_SYMBOLIC_SERVICE_IDENTITY", "neuro-symbolic-service")
+    monkeypatch.setenv("NEURO_SYMBOLIC_INTERNAL_TOKEN", "dev-internal-token")
+    monkeypatch.setenv("NEURO_SYMBOLIC_ALLOWED_CALLERS", "eigen-kernel,eigen-compiler")
+    monkeypatch.setenv("NEURO_SYMBOLIC_AUDIT_SINK_PATH", str(audit_path))
+
+    from neuro_symbolic_service.grpc_impl import NeuroSymbolicService
+
+    service = NeuroSymbolicService()
+    snapshot = service.model_registry_snapshot()
+    assert snapshot.verified is False
+    assert snapshot.active_model_version == "dpda-model-v1"
+    assert service._model_version == "dpda-model-v1"
+    assert expected_reason in snapshot.activation_reason
+
+    audit_lines = audit_path.read_text(encoding="utf-8").strip().splitlines()
+    assert audit_lines
+    activation = json.loads(audit_lines[-1])
+    assert activation["audit_kind"] == "model_registry_activation"
+    assert activation["model_version"] == "dpda-model-v1"
+    assert activation["activation_state"] == "baseline_fallback"
+    assert expected_reason in activation["reason"]
+
+
+def test_model_registry_rollback_is_auditable_and_fail_closed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    registry_path, _ = _write_signed_registry(
+        tmp_path,
+        active_model_version="dpda-model-v2",
+        signing_key="registry-secret-key",
+    )
+    audit_path = tmp_path / "audit.jsonl"
+    monkeypatch.setenv("NEURO_SYMBOLIC_MODEL_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setenv("NEURO_SYMBOLIC_MODEL_REGISTRY_SIGNING_KEY", "registry-secret-key")
+    monkeypatch.setenv("NEURO_SYMBOLIC_MODEL_ARTIFACT_ROOT", str(tmp_path))
+    monkeypatch.setenv("NEURO_SYMBOLIC_SERVICE_IDENTITY", "neuro-symbolic-service")
+    monkeypatch.setenv("NEURO_SYMBOLIC_INTERNAL_TOKEN", "dev-internal-token")
+    monkeypatch.setenv("NEURO_SYMBOLIC_ALLOWED_CALLERS", "eigen-kernel,eigen-compiler")
+    monkeypatch.setenv("NEURO_SYMBOLIC_AUDIT_SINK_PATH", str(audit_path))
+
+    from neuro_symbolic_service.grpc_impl import NeuroSymbolicService
+
+    service = NeuroSymbolicService()
+    assert service._model_version == "dpda-model-v2"
+    assert service.rollback_model_version("dpda-model-v1") is True
+    assert service._model_version == "dpda-model-v1"
+    assert service.rollback_model_version("dpda-model-v9") is False
+    assert service._model_version == "dpda-model-v1"
+
+    audit_lines = audit_path.read_text(encoding="utf-8").strip().splitlines()
+    kinds = [json.loads(line)["audit_kind"] for line in audit_lines]
+    assert "model_registry_activation" in kinds
+    assert "model_registry_rollback" in kinds
+    assert any(json.loads(line).get("reason", "") for line in audit_lines)


### PR DESCRIPTION
## Summary

Implemented the internal model registry + signed loading/rollback contract in src/services/neuro-symbolic-service, with fail-closed activation on missing artifact, bad signature, missing policy snapshot, or internal identity mismatch. The service now falls back to deterministic baseline behavior when activation cannot be verified, and activation/rollback/scoring are auditable. Updated the relevant architecture/security/reference docs to match the boundary.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: Metrics- **Compatibility**: <!-- Backward-compatible | Breaking (requires MAJOR) -->
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- nternal model registry loading contract for Neuro-DPDA.
- Signed model activation and rollback audit events.
- Fail-closed verification for model artifact digest, signature, policy snapshot, and service identity.

### Changed
- Neuro-DPDA scoring now uses the loaded internal model version and preserves deterministic baseline fallback when verification fails.
- NSC architecture and security docs now describe the internal-only loading boundary and mandatory preprocessing redaction layer.

### Fixed
- Model activation no longer depends on unverified or missing registry evidence.