### PR TITLE
Implemented the privacy-safe production-trace retraining flow

### DIFF
--- a/docs/architecture/components/neuro-symbolic-core.md
+++ b/docs/architecture/components/neuro-symbolic-core.md
@@ -385,7 +385,25 @@ That workflow MUST:
 
 - remain inside `src/services/neuro-symbolic-service/`,
 - require a stable manifest with dataset version and record schema version,
-- validate ownership, provenance, redaction, and policy snapshot evidence,
+- validate ownership, provenance, redaction, approval, replay identifiers, and policy snapshot evidence,
 - fail closed on missing or mismatched integrity digests,
 - preserve replay-safe dataset records for later training runs,
 - avoid public ingress and live model discovery on the request path.
+
+---
+
+### 8.7 Privacy-safe production-trace retraining
+
+Production execution traces MAY feed the training corpus only after an offline governance bundle has been selected and approved.
+
+The bundle MUST be tenant-scoped and MUST include:
+
+- tenant/project binding,
+- record-level provenance digests,
+- replay identifiers,
+- explicit selection metadata,
+- explicit approval metadata,
+- redaction validation evidence,
+- policy snapshot version.
+
+Cross-tenant mixing is prohibited. Any missing or mismatched provenance, approval, replay, or redaction evidence MUST fail closed before a dataset manifest is emitted.

--- a/docs/reference/api/grpc-internal.md
+++ b/docs/reference/api/grpc-internal.md
@@ -320,6 +320,8 @@ service NeuroSymbolicService {
 - Every scoring request MUST also emit an immutable audit record containing caller identity, tenant, active policy snapshot version, model version, retrieval sources, and final decision.
 - The explainability envelope MUST be derived from the minimized/redacted feature vector and the immutable policy snapshot, not from raw payloads.
 - Responses MUST remain bounded and MUST NOT return raw secrets, bearer tokens, or unredacted payload fragments.
+- Offline production-trace training is handled by the internal Neuro-DPDA service boundary via the KB-backed ingestion CLI/module path, not by a request-time RPC.
+- That offline path MUST only accept redacted, tenant-scoped bundles with explicit selection, approval, provenance, and replay metadata.
 
 #### Determinism requirements
 

--- a/docs/reference/security/authz.md
+++ b/docs/reference/security/authz.md
@@ -90,6 +90,8 @@ Authorization failures MUST use canonical error semantics:
 - authenticated principals lacking required scope map to `PERMISSION_DENIED`,
 - tenant/project/resource policy denials must include a stable reason code when exposed through structured error details.
 
+NeuroSymbolicService MUST fail closed when the service identity, tenant/project binding, or policy snapshot version is missing. Public ingress principals are not authorized to reach this service directly. CLI dataset ingestion MUST also reject missing ownership, provenance, redaction, approval, replay identifiers, or manifest digest evidence.
+
 All denial behavior must follow `docs/reference/error-model.md` and `docs/reference/error-mapping.md`.
 
 ---

--- a/src/services/neuro-symbolic-service/src/neuro_symbolic_service/grpc_impl.py
+++ b/src/services/neuro-symbolic-service/src/neuro_symbolic_service/grpc_impl.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 import hashlib
 import hmac
 import json

--- a/src/services/neuro-symbolic-service/src/neuro_symbolic_service/knowledge_base.py
+++ b/src/services/neuro-symbolic-service/src/neuro_symbolic_service/knowledge_base.py
@@ -1320,6 +1320,72 @@ class KnowledgeBaseService:
         computed_redaction_digest = hashlib.sha256(_stable_json({k: v for k, v in redaction.items() if k != "redaction_digest_sha256"}).encode("utf-8")).hexdigest()
         if computed_redaction_digest != redaction_digest:
             raise KnowledgeBaseUnavailable("redaction digest mismatch")
+        
+        selection = manifest_payload.get("selection")
+        normalized_selection: dict[str, Any] | None = None
+        if selection is not None:
+            if not isinstance(selection, dict):
+                raise ValueError("selection must be an object")
+            selection_trace_ids = _audit_string_list(selection.get("trace_ids") or selection.get("selected_trace_ids"))
+            selection_replay_ids = _audit_string_list(selection.get("replay_ids"))
+            selection_id = str(selection.get("selection_id", "")).strip()
+            selected_by = str(selection.get("selected_by", "")).strip()
+            selection_reason = str(selection.get("selection_reason", "")).strip()
+            selection_policy_snapshot_version = str(selection.get("policy_snapshot_version", policy_snapshot_version)).strip() or policy_snapshot_version
+            selection_tenant_id = str(selection.get("tenant_id", tenant_id)).strip() or tenant_id
+            selection_project_id = str(selection.get("project_id", project_id)).strip() or project_id
+            if not selection_id or not selected_by or not selection_reason or not selection_trace_ids or not selection_replay_ids:
+                raise ValueError("selection.selection_id, selected_by, selection_reason, trace_ids, and replay_ids are required")
+            if selection_tenant_id != tenant_id or selection_project_id != project_id:
+                raise KnowledgeBaseUnavailable("selection must remain tenant-scoped")
+            if selection_policy_snapshot_version != policy_snapshot_version:
+                raise KnowledgeBaseUnavailable("selection policy snapshot version mismatch")
+            normalized_selection = {
+                "selection_id": selection_id,
+                "selected_by": selected_by,
+                "selection_reason": selection_reason,
+                "trace_ids": selection_trace_ids,
+                "replay_ids": selection_replay_ids,
+                "tenant_id": selection_tenant_id,
+                "project_id": selection_project_id,
+                "policy_snapshot_version": selection_policy_snapshot_version,
+            }
+
+        approval = manifest_payload.get("approval")
+        normalized_approval: dict[str, Any] | None = None
+        if approval is not None:
+            if not isinstance(approval, dict):
+                raise ValueError("approval must be an object")
+            approval_id = str(approval.get("approval_id", "")).strip()
+            approved_by = str(approval.get("approved_by", "")).strip()
+            approved_at = str(approval.get("approved_at", "")).strip()
+            decision = str(approval.get("decision", "")).strip().lower()
+            ticket_ref = str(approval.get("ticket_ref", "")).strip()
+            approval_policy_snapshot_version = str(approval.get("policy_snapshot_version", policy_snapshot_version)).strip() or policy_snapshot_version
+            approval_tenant_id = str(approval.get("tenant_id", tenant_id)).strip() or tenant_id
+            approval_project_id = str(approval.get("project_id", project_id)).strip() or project_id
+            approval_replay_ids = _audit_string_list(approval.get("replay_ids"))
+            if not approval_replay_ids and normalized_selection is not None:
+                approval_replay_ids = list(normalized_selection["replay_ids"])
+            if not all([approval_id, approved_by, approved_at, ticket_ref]) or decision != "approved" or not approval_replay_ids:
+                raise ValueError("approval.approval_id, approved_by, approved_at, decision, ticket_ref, and replay_ids are required")
+            if approval_tenant_id != tenant_id or approval_project_id != project_id:
+                raise KnowledgeBaseUnavailable("approval must remain tenant-scoped")
+            if approval_policy_snapshot_version != policy_snapshot_version:
+                raise KnowledgeBaseUnavailable("approval policy snapshot version mismatch")
+            if normalized_selection is not None and not set(normalized_selection["replay_ids"]).issubset(set(approval_replay_ids)):
+                raise KnowledgeBaseUnavailable("approval replay_ids must cover all selected replay identifiers")
+            normalized_approval = {
+                "approval_id": approval_id,
+                "approved_by": approved_by,
+                "approved_at": approved_at,
+                "decision": decision,
+                "ticket_ref": ticket_ref,
+                "policy_snapshot_version": approval_policy_snapshot_version,
+                "tenant_id": approval_tenant_id,
+                "project_id": approval_project_id,
+                "replay_ids": approval_replay_ids,
+            }
 
         records = manifest_payload.get("records")
         if not isinstance(records, list) or not records:
@@ -1392,6 +1458,24 @@ class KnowledgeBaseService:
                     "rules": [str(rule).strip() for rule in (record_redaction.get("rules") or []) if str(rule).strip()],
                 },
             }
+            trace_id = str(record.get("trace_id", "")).strip()
+            replay_id = str(record.get("replay_id", "")).strip()
+            source_kind = str(record.get("source_kind", "")).strip()
+            if trace_id:
+                normalized_record["trace_id"] = trace_id
+                normalized_record["trace_ref"] = f"nsc://trace/{trace_id}"
+            if replay_id:
+                normalized_record["replay_id"] = replay_id
+                if trace_id:
+                    normalized_record["replay_ref"] = f"nsc://replay/{trace_id}/{replay_id}"
+            if str(record.get("tenant_id", "")).strip():
+                normalized_record["tenant_id"] = str(record.get("tenant_id", "")).strip()
+            if str(record.get("project_id", "")).strip():
+                normalized_record["project_id"] = str(record.get("project_id", "")).strip()
+            if str(record.get("policy_snapshot_version", "")).strip():
+                normalized_record["policy_snapshot_version"] = str(record.get("policy_snapshot_version", "")).strip()
+            if source_kind:
+                normalized_record["source_kind"] = source_kind
             normalized_records.append(normalized_record)
             record_digests.append(content_digest)
 
@@ -1426,6 +1510,13 @@ class KnowledgeBaseService:
             "records": normalized_records,
             "manifest_digest_sha256": manifest_digest_sha256,
         }
+        source_kind = str(manifest_payload.get("source_kind", "")).strip()
+        if source_kind:
+            normalized_manifest["source_kind"] = source_kind
+        if normalized_selection is not None:
+            normalized_manifest["selection"] = normalized_selection
+        if normalized_approval is not None:
+            normalized_manifest["approval"] = normalized_approval
         computed_manifest_digest = hashlib.sha256(_stable_json({k: v for k, v in normalized_manifest.items() if k != "manifest_digest_sha256"}).encode("utf-8")).hexdigest()
         if computed_manifest_digest != manifest_digest_sha256:
             raise KnowledgeBaseUnavailable("manifest digest mismatch")
@@ -1441,6 +1532,12 @@ class KnowledgeBaseService:
             "redaction": normalized_manifest["redaction"],
             "record_digests": record_digests,
         }
+        if normalized_selection is not None:
+            dataset_digest_source["selection"] = normalized_selection
+            dataset_digest_source["trace_ids"] = list(normalized_selection["trace_ids"])
+            dataset_digest_source["replay_ids"] = list(normalized_selection["replay_ids"])
+        if normalized_approval is not None:
+            dataset_digest_source["approval"] = normalized_approval
         dataset_digest_sha256 = hashlib.sha256(_stable_json(dataset_digest_source).encode("utf-8")).hexdigest()
         now = datetime.now(timezone.utc)
         dataset_summary = {
@@ -1462,6 +1559,14 @@ class KnowledgeBaseService:
             "created_at": now.isoformat(),
             "updated_at": now.isoformat(),
         }
+        if "source_kind" in normalized_manifest:
+            dataset_summary["source_kind"] = normalized_manifest["source_kind"]
+        if normalized_selection is not None:
+            dataset_summary["selection"] = normalized_selection
+            dataset_summary["trace_ids"] = list(normalized_selection["trace_ids"])
+            dataset_summary["replay_ids"] = list(normalized_selection["replay_ids"])
+        if normalized_approval is not None:
+            dataset_summary["approval"] = normalized_approval
 
         with self._lock:
             self._gc_locked()
@@ -1471,6 +1576,25 @@ class KnowledgeBaseService:
                 if existing.get("manifest_digest_sha256") != manifest_digest_sha256:
                     raise KnowledgeBaseUnavailable("dataset version already exists with different content")
                 return json.loads(_stable_json(existing))
+
+            evidence_metadata = {
+                "dataset_id": dataset_id,
+                "dataset_version": dataset_version,
+                "requested_by": requested_by,
+                "service_identity": owner_identity,
+                "service_role": service_role,
+                "source_ref": provenance_source_ref,
+                "source_digest_sha256": provenance_source_digest,
+                "record_count": len(normalized_records),
+                "manifest_digest_sha256": manifest_digest_sha256,
+                "redaction_digest_sha256": redaction_digest,
+            }
+            if normalized_selection is not None:
+                evidence_metadata["selection_id"] = normalized_selection["selection_id"]
+                evidence_metadata["replay_ids"] = list(normalized_selection["replay_ids"])
+                evidence_metadata["trace_ids"] = list(normalized_selection["trace_ids"])
+            if normalized_approval is not None:
+                evidence_metadata["approval_id"] = normalized_approval["approval_id"]
 
             evidence = self._learning_store_evidence(
                 source="cli",
@@ -1488,18 +1612,7 @@ class KnowledgeBaseService:
                     "record_count": len(normalized_records),
                     "record_schema_version": record_schema_version,
                 },
-                metadata={
-                    "dataset_id": dataset_id,
-                    "dataset_version": dataset_version,
-                    "requested_by": requested_by,
-                    "service_identity": owner_identity,
-                    "service_role": service_role,
-                    "source_ref": provenance_source_ref,
-                    "source_digest_sha256": provenance_source_digest,
-                    "record_count": len(normalized_records),
-                    "manifest_digest_sha256": manifest_digest_sha256,
-                    "redaction_digest_sha256": redaction_digest,
-                },
+                metadata=evidence_metadata,
                 command="ingest_training_dataset",
                 decision="accepted",
                 capability_scope=(),
@@ -1601,7 +1714,7 @@ class KnowledgeBaseService:
                 queryable_ref=f"kb://models/{model_version}",
                 evidence_ref=dataset["queryable_ref"],
             )
-           result.update(
+            result.update(
                 {
                     "dataset_id": dataset["dataset_id"],
                     "dataset_version": dataset["dataset_version"],

--- a/src/services/neuro-symbolic-service/src/neuro_symbolic_service/main.py
+++ b/src/services/neuro-symbolic-service/src/neuro_symbolic_service/main.py
@@ -14,6 +14,7 @@ from eigen.api.v1 import types_pb2 as types_pb
 
 from .grpc_server import serve
 from .knowledge_base import KnowledgeBaseService
+from .production_trace_training import prepare_training_dataset_manifest
 from .observability import JsonFormatter, start_metrics_server
 
 
@@ -33,6 +34,15 @@ def _ingest_dataset(manifest_path: Path, *, caller_identity: str) -> int:
     return 0
 
 
+def _ingest_production_traces(manifest_path: Path, *, caller_identity: str) -> int:
+    service = KnowledgeBaseService(kb_pb=kb_pb, types_pb=types_pb)
+    bundle = _load_manifest(manifest_path)
+    dataset_manifest = prepare_training_dataset_manifest(bundle, caller_identity=caller_identity)
+    summary = service.ingest_training_dataset(dataset_manifest, caller_identity=caller_identity)
+    print(json.dumps(summary, sort_keys=True, ensure_ascii=False))
+    return 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="neuro-symbolic-service")
     subparsers = parser.add_subparsers(dest="command")
@@ -40,6 +50,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     ingest = subparsers.add_parser("ingest-dataset", help="Ingest a KB-backed training dataset manifest")
     ingest.add_argument("--manifest", required=True, type=Path, help="Path to the dataset manifest JSON")
     ingest.add_argument(
+        "--caller-identity",
+        default=os.getenv("NEURO_SYMBOLIC_CLI_CALLER_IDENTITY", os.getenv("NEURO_SYMBOLIC_SERVICE_IDENTITY", "neuro-symbolic-service")),
+        help="Internal caller identity that must match the manifest ownership",
+    )
+
+    production = subparsers.add_parser(
+        "ingest-production-traces",
+        help="Promote redacted production execution traces into the KB-backed training corpus",
+    )
+    production.add_argument("--manifest", required=True, type=Path, help="Path to the production trace bundle JSON")
+    production.add_argument(
         "--caller-identity",
         default=os.getenv("NEURO_SYMBOLIC_CLI_CALLER_IDENTITY", os.getenv("NEURO_SYMBOLIC_SERVICE_IDENTITY", "neuro-symbolic-service")),
         help="Internal caller identity that must match the manifest ownership",
@@ -58,6 +79,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.command == "ingest-dataset":
         return _ingest_dataset(args.manifest, caller_identity=args.caller_identity)
+    if args.command == "ingest-production-traces":
+        return _ingest_production_traces(args.manifest, caller_identity=args.caller_identity)
     return _serve()
 
     server = serve()

--- a/src/services/neuro-symbolic-service/src/neuro_symbolic_service/production_trace_training.py
+++ b/src/services/neuro-symbolic-service/src/neuro_symbolic_service/production_trace_training.py
@@ -1,0 +1,479 @@
+"""Privacy-safe production trace training helpers for Neuro-DPDA."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+
+_CONTRACT_VERSION = "1.0.0"
+_TRACE_BUNDLE_SCHEMA = "neuro-symbolic.production-trace-training.bundle.v1"
+_TRACE_RECORD_SCHEMA = "neuro-symbolic.production-trace-training.record.v1"
+_TRAINING_DATASET_MANIFEST_SCHEMA = "neuro-symbolic.training-dataset.manifest.v1"
+
+_REDACTED_VALUE = "[REDACTED]"
+_MASKED_EMAIL_VALUE = "[REDACTED_EMAIL]"
+_MASKED_PHONE_VALUE = "[REDACTED_PHONE]"
+_MASKED_IDENTIFIER_VALUE = "[REDACTED_ID]"
+
+_REDACT_DELETE_KEYS = {
+    "authorization",
+    "auth_header",
+    "bearer",
+    "cookie",
+    "credentials",
+    "credential",
+    "password",
+    "passwd",
+    "pwd",
+    "secret",
+    "session_cookie",
+    "session_token",
+    "token",
+    "api_key",
+    "access_token",
+    "refresh_token",
+    "id_token",
+    "raw_authorization",
+    "raw_auth_header",
+    "body",
+    "payload",
+    "raw_payload",
+    "raw_request_body",
+    "request_body",
+    "stack_trace",
+    "trace_dump",
+}
+_REDACT_MASK_EMAIL_KEYS = {"email", "email_address", "contact_email", "e_mail"}
+_REDACT_MASK_PHONE_KEYS = {"phone", "phone_number", "mobile", "msisdn", "contact_phone"}
+_REDACT_MASK_IDENTIFIER_KEYS = {
+    "id",
+    "identifier",
+    "internal_id",
+    "internal_identifier",
+    "subject_id",
+    "user_id",
+    "tenant_id",
+    "project_id",
+    "request_id",
+    "trace_id",
+    "session_id",
+    "correlation_id",
+    "device_id",
+    "account_id",
+}
+
+_EMAIL_RE = re.compile(r"(?i)\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}\b")
+_PHONE_RE = re.compile(r"(?i)(?<!\d)(?:\+?\d{1,3}[-.\s]?)?(?:\(?\d{2,4}\)?[-.\s]?){1,3}\d{2,4}(?!\d)")
+_BEARER_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{8,}\b")
+_UUID_RE = re.compile(r"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b")
+_SECRET_PATH_RE = re.compile(
+    r"(?i)(?P<path>(?:[A-Za-z]:\\|/)(?:[^\s\"'<>]*/)*(?:secrets?|secret|private|credentials?|tokens?|keys?)(?:/[^\s\"'<>]*)?)"
+)
+
+
+class ProductionTraceTrainingError(ValueError):
+    """Raised when a production trace bundle cannot be promoted into the training corpus."""
+
+
+@dataclass(frozen=True)
+class TrainingSelectionSummary:
+    trace_ids: tuple[str, ...]
+    replay_ids: tuple[str, ...]
+    selection_id: str
+    selected_by: str
+    selection_reason: str
+
+
+@dataclass(frozen=True)
+class TrainingApprovalSummary:
+    approval_id: str
+    approved_by: str
+    approved_at: str
+    ticket_ref: str
+    decision: str
+    policy_snapshot_version: str
+    tenant_id: str
+    project_id: str
+    replay_ids: tuple[str, ...]
+
+
+def _stable_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+
+
+def _hex_digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _redact_scalar_text(text: str, path: str, redactions: set[str]) -> str:
+    original = text
+    text = _BEARER_RE.sub(_REDACTED_VALUE, text)
+    text = _SECRET_PATH_RE.sub(_REDACTED_VALUE, text)
+    text = _EMAIL_RE.sub(_MASKED_EMAIL_VALUE, text)
+    text = _PHONE_RE.sub(_MASKED_PHONE_VALUE, text)
+    text = _UUID_RE.sub(_MASKED_IDENTIFIER_VALUE, text)
+    if text != original:
+        redactions.add(path)
+    return text
+
+
+def _redact_json_value(value: Any, path: str, redactions: set[str]):
+    if isinstance(value, dict):
+        redacted: dict[str, object] = {}
+        for key, nested in value.items():
+            key_lower = str(key).strip().lower()
+            nested_path = f"{path}.{key}" if path else str(key)
+            if key_lower in _REDACT_DELETE_KEYS:
+                redacted[key] = _REDACTED_VALUE
+                redactions.add(nested_path)
+                continue
+            if key_lower in _REDACT_MASK_EMAIL_KEYS:
+                redacted[key] = _MASKED_EMAIL_VALUE
+                redactions.add(nested_path)
+                continue
+            if key_lower in _REDACT_MASK_PHONE_KEYS:
+                redacted[key] = _MASKED_PHONE_VALUE
+                redactions.add(nested_path)
+                continue
+            if key_lower in _REDACT_MASK_IDENTIFIER_KEYS or key_lower.endswith("_id"):
+                if isinstance(nested, (dict, list)):
+                    redacted[key] = _redact_json_value(nested, nested_path, redactions)
+                else:
+                    redacted[key] = _MASKED_IDENTIFIER_VALUE
+                    redactions.add(nested_path)
+                continue
+            redacted[key] = _redact_json_value(nested, nested_path, redactions)
+        return redacted
+    if isinstance(value, list):
+        return [_redact_json_value(item, f"{path}[{idx}]", redactions) for idx, item in enumerate(value)]
+    if isinstance(value, str):
+        return _redact_scalar_text(value, path, redactions)
+    return value
+
+
+def _is_redacted_payload(payload: Any) -> bool:
+    redactions: set[str] = set()
+    return _redact_json_value(payload, "$", redactions) == payload
+
+
+def _require_mapping(value: Any, *, field_name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ProductionTraceTrainingError(f"{field_name} must be an object")
+    return value
+
+
+def _require_string(value: Any, *, field_name: str) -> str:
+    if value is None:
+        raise ProductionTraceTrainingError(f"{field_name} is required")
+    text = str(value).strip()
+    if not text or text.lower() == "none":
+        raise ProductionTraceTrainingError(f"{field_name} is required")
+    return text
+
+
+def _require_digest(value: Any, *, field_name: str) -> str:
+    digest = str(value).strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise ProductionTraceTrainingError(f"{field_name} must be a SHA-256 hex digest")
+    return digest
+
+
+def _normalize_replay_ids(value: Any, *, field_name: str) -> tuple[str, ...]:
+    if value in (None, ""):
+        raise ProductionTraceTrainingError(f"{field_name} is required")
+    if isinstance(value, (list, tuple, set)):
+        items = value
+    else:
+        items = (value,)
+    normalized: list[str] = []
+    for item in items:
+        text = str(item).strip()
+        if text and text not in normalized:
+            normalized.append(text)
+    if not normalized:
+        raise ProductionTraceTrainingError(f"{field_name} is required")
+    return tuple(normalized)
+
+
+def _normalize_trace_selection(bundle: dict[str, Any], *, caller_identity: str, tenant_id: str, project_id: str, policy_snapshot_version: str) -> TrainingSelectionSummary:
+    selection = _require_mapping(bundle.get("selection"), field_name="selection")
+    selection_id = _require_string(selection.get("selection_id"), field_name="selection.selection_id")
+    selected_by = _require_string(selection.get("selected_by"), field_name="selection.selected_by")
+    selection_reason = _require_string(selection.get("selection_reason"), field_name="selection.selection_reason")
+    trace_ids = _normalize_replay_ids(selection.get("trace_ids") or selection.get("selected_trace_ids"), field_name="selection.trace_ids")
+    replay_ids = _normalize_replay_ids(selection.get("replay_ids"), field_name="selection.replay_ids")
+    selection_policy = _require_string(selection.get("policy_snapshot_version", policy_snapshot_version), field_name="selection.policy_snapshot_version")
+    selection_tenant = _require_string(selection.get("tenant_id", tenant_id), field_name="selection.tenant_id")
+    selection_project = _require_string(selection.get("project_id", project_id), field_name="selection.project_id")
+    if selection_tenant != tenant_id or selection_project != project_id:
+        raise ProductionTraceTrainingError("selection must remain tenant-scoped")
+    if selection_policy != policy_snapshot_version:
+        raise ProductionTraceTrainingError("selection policy snapshot version must match the bundle")
+    if selected_by != caller_identity:
+        raise ProductionTraceTrainingError("selection.selected_by must match the internal caller identity")
+    return TrainingSelectionSummary(
+        trace_ids=trace_ids,
+        replay_ids=replay_ids,
+        selection_id=selection_id,
+        selected_by=selected_by,
+        selection_reason=selection_reason,
+    )
+
+
+def _normalize_trace_approval(bundle: dict[str, Any], *, tenant_id: str, project_id: str, policy_snapshot_version: str, selection: TrainingSelectionSummary) -> TrainingApprovalSummary:
+    approval = _require_mapping(bundle.get("approval"), field_name="approval")
+    approval_id = _require_string(approval.get("approval_id"), field_name="approval.approval_id")
+    approved_by = _require_string(approval.get("approved_by"), field_name="approval.approved_by")
+    approved_at = _require_string(approval.get("approved_at"), field_name="approval.approved_at")
+    decision = _require_string(approval.get("decision", "approved"), field_name="approval.decision")
+    if decision.lower() != "approved":
+        raise ProductionTraceTrainingError("approval.decision must be approved")
+    approval_ticket_ref = _require_string(approval.get("ticket_ref"), field_name="approval.ticket_ref")
+    approval_policy = _require_string(approval.get("policy_snapshot_version", policy_snapshot_version), field_name="approval.policy_snapshot_version")
+    approval_tenant = _require_string(approval.get("tenant_id", tenant_id), field_name="approval.tenant_id")
+    approval_project = _require_string(approval.get("project_id", project_id), field_name="approval.project_id")
+    replay_ids = _normalize_replay_ids(approval.get("replay_ids") or selection.replay_ids, field_name="approval.replay_ids")
+    if approval_tenant != tenant_id or approval_project != project_id:
+        raise ProductionTraceTrainingError("approval must remain tenant-scoped")
+    if approval_policy != policy_snapshot_version:
+        raise ProductionTraceTrainingError("approval policy snapshot version must match the bundle")
+    if not set(selection.replay_ids).issubset(set(replay_ids)):
+        raise ProductionTraceTrainingError("approval replay_ids must cover all selected replay identifiers")
+    return TrainingApprovalSummary(
+        approval_id=approval_id,
+        approved_by=approved_by,
+        approved_at=approved_at,
+        ticket_ref=approval_ticket_ref,
+        decision=decision.lower(),
+        policy_snapshot_version=approval_policy,
+        tenant_id=approval_tenant,
+        project_id=approval_project,
+        replay_ids=replay_ids,
+    )
+
+
+def _normalize_provenance(provenance: Any, *, field_name: str) -> dict[str, str]:
+    mapping = _require_mapping(provenance, field_name=field_name)
+    source_ref = _require_string(mapping.get("source_ref"), field_name=f"{field_name}.source_ref")
+    captured_at = _require_string(mapping.get("captured_at"), field_name=f"{field_name}.captured_at")
+    signed_by = _require_string(mapping.get("signed_by"), field_name=f"{field_name}.signed_by")
+    signature_algorithm = _require_string(mapping.get("signature_algorithm"), field_name=f"{field_name}.signature_algorithm")
+    signature = _require_string(mapping.get("signature"), field_name=f"{field_name}.signature")
+    source_digest_sha256 = _require_digest(mapping.get("source_digest_sha256"), field_name=f"{field_name}.source_digest_sha256")
+    computed_digest = hashlib.sha256(_stable_json({k: v for k, v in mapping.items() if k != "source_digest_sha256"}).encode("utf-8")).hexdigest()
+    if computed_digest != source_digest_sha256:
+        raise ProductionTraceTrainingError(f"{field_name}.source_digest_sha256 mismatch")
+    return {
+        "source_ref": source_ref,
+        "captured_at": captured_at,
+        "signed_by": signed_by,
+        "signature_algorithm": signature_algorithm,
+        "signature": signature,
+        "source_digest_sha256": source_digest_sha256,
+    }
+
+
+def _normalize_redaction(redaction: Any, *, field_name: str) -> dict[str, Any]:
+    mapping = _require_mapping(redaction, field_name=field_name)
+    if not bool(mapping.get("applied", False)) or not bool(mapping.get("validated", False)):
+        raise ProductionTraceTrainingError(f"{field_name} must be applied and validated")
+    rules = [str(rule).strip() for rule in (mapping.get("rules") or []) if str(rule).strip()]
+    if not rules:
+        raise ProductionTraceTrainingError(f"{field_name}.rules are required")
+    redaction_digest_sha256 = _require_digest(mapping.get("redaction_digest_sha256"), field_name=f"{field_name}.redaction_digest_sha256")
+    computed_digest = hashlib.sha256(_stable_json({k: v for k, v in mapping.items() if k != "redaction_digest_sha256"}).encode("utf-8")).hexdigest()
+    if computed_digest != redaction_digest_sha256:
+        raise ProductionTraceTrainingError(f"{field_name}.redaction_digest_sha256 mismatch")
+    return {
+        "applied": True,
+        "validated": True,
+        "rules": rules,
+        "redaction_digest_sha256": redaction_digest_sha256,
+    }
+
+
+def _normalize_record_provenance(provenance: Any, *, field_name: str) -> dict[str, str]:
+    mapping = _require_mapping(provenance, field_name=field_name)
+    source_ref = _require_string(mapping.get("source_ref"), field_name=f"{field_name}.source_ref")
+    captured_at = _require_string(mapping.get("captured_at"), field_name=f"{field_name}.captured_at")
+    requested_by = _require_string(mapping.get("requested_by"), field_name=f"{field_name}.requested_by")
+    source_digest_sha256 = _require_digest(mapping.get("source_digest_sha256"), field_name=f"{field_name}.source_digest_sha256")
+    computed_digest = hashlib.sha256(_stable_json({k: v for k, v in mapping.items() if k != "source_digest_sha256"}).encode("utf-8")).hexdigest()
+    if computed_digest != source_digest_sha256:
+        raise ProductionTraceTrainingError(f"{field_name}.source_digest_sha256 mismatch")
+    return {
+        "source_ref": source_ref,
+        "captured_at": captured_at,
+        "requested_by": requested_by,
+        "source_digest_sha256": source_digest_sha256,
+    }
+
+
+def _normalize_trace_record(record: Any, *, idx: int, tenant_id: str, project_id: str, policy_snapshot_version: str, record_schema_version: str) -> dict[str, Any]:
+    mapping = _require_mapping(record, field_name=f"records[{idx}]")
+    record_id = _require_string(mapping.get("record_id"), field_name=f"records[{idx}].record_id")
+    schema_version = _require_string(mapping.get("schema_version"), field_name=f"records[{idx}].schema_version")
+    if schema_version != record_schema_version:
+        raise ProductionTraceTrainingError(f"records[{idx}].schema_version must match the bundle record_schema_version")
+    trace_id = _require_string(mapping.get("trace_id", record_id), field_name=f"records[{idx}].trace_id")
+    replay_id = _require_string(mapping.get("replay_id"), field_name=f"records[{idx}].replay_id")
+    record_tenant = _require_string(mapping.get("tenant_id", tenant_id), field_name=f"records[{idx}].tenant_id")
+    record_project = _require_string(mapping.get("project_id", project_id), field_name=f"records[{idx}].project_id")
+    record_policy = _require_string(mapping.get("policy_snapshot_version", policy_snapshot_version), field_name=f"records[{idx}].policy_snapshot_version")
+    if record_tenant != tenant_id or record_project != project_id:
+        raise ProductionTraceTrainingError(f"records[{idx}] must remain tenant-scoped")
+    if record_policy != policy_snapshot_version:
+        raise ProductionTraceTrainingError(f"records[{idx}].policy_snapshot_version must match the bundle")
+    payload = mapping.get("payload")
+    if not isinstance(payload, (dict, list, str, int, float, bool)):
+        raise ProductionTraceTrainingError(f"records[{idx}].payload must be JSON-serializable")
+    if not _is_redacted_payload(payload):
+        raise ProductionTraceTrainingError(f"records[{idx}] must be redacted before ingestion")
+    content_digest_sha256 = _require_digest(mapping.get("content_digest_sha256"), field_name=f"records[{idx}].content_digest_sha256")
+    computed_content_digest = hashlib.sha256(_stable_json(payload).encode("utf-8")).hexdigest()
+    if computed_content_digest != content_digest_sha256:
+        raise ProductionTraceTrainingError(f"records[{idx}].content_digest_sha256 mismatch")
+    provenance = _normalize_record_provenance(mapping.get("provenance"), field_name=f"records[{idx}].provenance")
+    redaction = _normalize_redaction(mapping.get("redaction"), field_name=f"records[{idx}].redaction")
+    replay_ref = f"nsc://replay/{trace_id}/{replay_id}"
+    trace_ref = f"nsc://trace/{trace_id}"
+    return {
+        "record_id": record_id,
+        "schema_version": schema_version,
+        "trace_id": trace_id,
+        "replay_id": replay_id,
+        "tenant_id": tenant_id,
+        "project_id": project_id,
+        "policy_snapshot_version": policy_snapshot_version,
+        "source_kind": "production_execution_trace",
+        "content_digest_sha256": content_digest_sha256,
+        "payload": payload,
+        "provenance": provenance,
+        "redaction": redaction,
+        "replay_ref": replay_ref,
+        "trace_ref": trace_ref,
+    }
+
+
+def prepare_training_dataset_manifest(bundle: dict[str, Any], *, caller_identity: str) -> dict[str, Any]:
+    schema_version = _require_string(bundle.get("schema_version"), field_name="schema_version")
+    if schema_version != _TRACE_BUNDLE_SCHEMA:
+        raise ProductionTraceTrainingError("unsupported production trace bundle schema")
+    contract_version = _require_string(bundle.get("contract_version", _CONTRACT_VERSION), field_name="contract_version")
+    dataset_id = _require_string(bundle.get("dataset_id"), field_name="dataset_id")
+    dataset_version = _require_string(bundle.get("dataset_version"), field_name="dataset_version")
+    record_schema_version = _require_string(bundle.get("record_schema_version", _TRACE_RECORD_SCHEMA), field_name="record_schema_version")
+    tenant_id = _require_string(bundle.get("tenant_id"), field_name="tenant_id")
+    project_id = _require_string(bundle.get("project_id"), field_name="project_id")
+    policy_snapshot_version = _require_string(bundle.get("policy_snapshot_version"), field_name="policy_snapshot_version")
+
+    ownership = _require_mapping(bundle.get("ownership"), field_name="ownership")
+    service_identity = _require_string(ownership.get("service_identity"), field_name="ownership.service_identity")
+    requested_by = _require_string(ownership.get("requested_by", caller_identity), field_name="ownership.requested_by")
+    service_role = _require_string(ownership.get("service_role", "internal-ingest"), field_name="ownership.service_role")
+    if service_identity != caller_identity or requested_by != caller_identity:
+        raise ProductionTraceTrainingError("ownership must resolve to the internal caller identity")
+
+    selection = _normalize_trace_selection(
+        bundle,
+        caller_identity=caller_identity,
+        tenant_id=tenant_id,
+        project_id=project_id,
+        policy_snapshot_version=policy_snapshot_version,
+    )
+    approval = _normalize_trace_approval(
+        bundle,
+        tenant_id=tenant_id,
+        project_id=project_id,
+        policy_snapshot_version=policy_snapshot_version,
+        selection=selection,
+    )
+    provenance = _normalize_provenance(bundle.get("provenance"), field_name="provenance")
+    redaction = _normalize_redaction(bundle.get("redaction"), field_name="redaction")
+
+    records = bundle.get("records")
+    if not isinstance(records, list) or not records:
+        raise ProductionTraceTrainingError("records must be a non-empty list")
+
+    normalized_records = [
+        _normalize_trace_record(
+            record,
+            idx=idx,
+            tenant_id=tenant_id,
+            project_id=project_id,
+            policy_snapshot_version=policy_snapshot_version,
+            record_schema_version=record_schema_version,
+        )
+        for idx, record in enumerate(records)
+    ]
+
+    record_digests = [record["content_digest_sha256"] for record in normalized_records]
+    trace_ids = [record["trace_id"] for record in normalized_records]
+    replay_ids = [record["replay_id"] for record in normalized_records]
+    if tuple(trace_ids) != selection.trace_ids:
+        raise ProductionTraceTrainingError("selection.trace_ids must match the selected records")
+    if not set(replay_ids).issubset(set(selection.replay_ids)):
+        raise ProductionTraceTrainingError("selection.replay_ids must cover the selected records")
+
+    normalized_manifest = {
+        "schema_version": _TRAINING_DATASET_MANIFEST_SCHEMA,
+        "contract_version": _CONTRACT_VERSION,
+        "dataset_id": dataset_id,
+        "dataset_version": dataset_version,
+        "record_schema_version": record_schema_version,
+        "tenant_id": tenant_id,
+        "project_id": project_id,
+        "policy_snapshot_version": policy_snapshot_version,
+        "source_kind": "production_execution_traces",
+        "ownership": {
+            "service_identity": service_identity,
+            "requested_by": requested_by,
+            "service_role": service_role,
+        },
+        "selection": {
+            "selection_id": selection.selection_id,
+            "selected_by": selection.selected_by,
+            "selection_reason": selection.selection_reason,
+            "trace_ids": list(selection.trace_ids),
+            "replay_ids": list(selection.replay_ids),
+            "tenant_id": tenant_id,
+            "project_id": project_id,
+            "policy_snapshot_version": policy_snapshot_version,
+        },
+        "approval": {
+            "approval_id": approval.approval_id,
+            "approved_by": approval.approved_by,
+            "approved_at": approval.approved_at,
+            "decision": approval.decision,
+            "ticket_ref": approval.ticket_ref,
+            "tenant_id": tenant_id,
+            "project_id": project_id,
+            "policy_snapshot_version": policy_snapshot_version,
+            "replay_ids": list(approval.replay_ids),
+        },
+        "provenance": provenance,
+        "redaction": redaction,
+        "records": normalized_records,
+    }
+
+    normalized_manifest["manifest_digest_sha256"] = _hex_digest(_stable_json(normalized_manifest).encode("utf-8"))
+    dataset_digest_source = {
+        "dataset_id": dataset_id,
+        "dataset_version": dataset_version,
+        "tenant_id": tenant_id,
+        "project_id": project_id,
+        "policy_snapshot_version": policy_snapshot_version,
+        "ownership": normalized_manifest["ownership"],
+        "selection": normalized_manifest["selection"],
+        "approval": normalized_manifest["approval"],
+        "provenance": provenance,
+        "redaction": redaction,
+        "record_digests": record_digests,
+        "replay_ids": replay_ids,
+    }
+    normalized_manifest["dataset_digest_sha256"] = _hex_digest(_stable_json(dataset_digest_source).encode("utf-8"))
+    return normalized_manifest

--- a/src/services/neuro-symbolic-service/tests/test_knowledge_base_versioning.py
+++ b/src/services/neuro-symbolic-service/tests/test_knowledge_base_versioning.py
@@ -14,6 +14,7 @@ from eigen.api.v1 import types_pb2 as types_pb  # noqa: E402
 from neuro_symbolic_service.knowledge_base_versioned import KnowledgeBaseService  # noqa: E402
 from neuro_symbolic_service.knowledge_base import KnowledgeBaseUnavailable  # noqa: E402
 from neuro_symbolic_service.main import main as neuro_main  # noqa: E402
+from neuro_symbolic_service.production_trace_training import ProductionTraceTrainingError, prepare_training_dataset_manifest  # noqa: E402
 
 
 def _ts(value: str) -> Timestamp:
@@ -293,6 +294,152 @@ def _training_dataset_manifest() -> dict[str, object]:
     return manifest
 
 
+def _production_trace_training_bundle() -> dict[str, object]:
+    trace_payload_1 = {
+        "tenant": "tenant-a",
+        "project": "project-a",
+        "decision": "accepted",
+        "features": {
+            "compiler": "dpda",
+            "label": "stable",
+            "masked_email": "[REDACTED_EMAIL]",
+            "masked_token": "[REDACTED]",
+        },
+        "notes": ["redacted", "tenant-scoped"],
+    }
+    trace_payload_2 = {
+        "tenant": "tenant-a",
+        "project": "project-a",
+        "decision": "review",
+        "features": {
+            "compiler": "dpda",
+            "label": "stable",
+            "masked_email": "[REDACTED_EMAIL]",
+            "masked_token": "[REDACTED]",
+        },
+        "notes": ["redacted", "tenant-scoped"],
+    }
+
+    record_provenance_1 = _with_digest(
+        {
+            "source_ref": "qfs://production-traces/raw/trace-1.json",
+            "captured_at": "2026-06-16T09:00:00+00:00",
+            "requested_by": "neuro-symbolic-service",
+        },
+        "source_digest_sha256",
+    )
+    record_provenance_2 = _with_digest(
+        {
+            "source_ref": "qfs://production-traces/raw/trace-2.json",
+            "captured_at": "2026-06-16T09:01:00+00:00",
+            "requested_by": "neuro-symbolic-service",
+        },
+        "source_digest_sha256",
+    )
+    record_redaction = _with_digest(
+        {
+            "applied": True,
+            "validated": True,
+            "rules": ["secret", "pii", "tenant-id"],
+        },
+        "redaction_digest_sha256",
+    )
+
+    records = [
+        {
+            "record_id": "trace-1",
+            "schema_version": "neuro-symbolic.production-trace-training.record.v1",
+            "trace_id": "trace-1",
+            "replay_id": "replay-1",
+            "tenant_id": "tenant-a",
+            "project_id": "project-a",
+            "policy_snapshot_version": "1.0.0",
+            "payload": trace_payload_1,
+            "provenance": record_provenance_1,
+            "redaction": record_redaction,
+            "content_digest_sha256": _json_digest(trace_payload_1),
+        },
+        {
+            "record_id": "trace-2",
+            "schema_version": "neuro-symbolic.production-trace-training.record.v1",
+            "trace_id": "trace-2",
+            "replay_id": "replay-2",
+            "tenant_id": "tenant-a",
+            "project_id": "project-a",
+            "policy_snapshot_version": "1.0.0",
+            "payload": trace_payload_2,
+            "provenance": record_provenance_2,
+            "redaction": record_redaction,
+            "content_digest_sha256": _json_digest(trace_payload_2),
+        },
+    ]
+
+    provenance = _with_digest(
+        {
+            "source_ref": "qfs://production-traces/raw/batch-2026-06-16.jsonl",
+            "captured_at": "2026-06-16T09:00:00+00:00",
+            "signed_by": "neuro-symbolic-service",
+            "signature_algorithm": "HS256",
+            "signature": "sig-trace-batch-001",
+        },
+        "source_digest_sha256",
+    )
+    redaction = _with_digest(
+        {
+            "applied": True,
+            "validated": True,
+            "rules": ["secret", "pii", "tenant-id"],
+        },
+        "redaction_digest_sha256",
+    )
+    selection = {
+        "selection_id": "selection-2026-06-16",
+        "selected_by": "neuro-symbolic-service",
+        "selection_reason": "tenant-scoped production traces approved for replay-safe retraining",
+        "trace_ids": ["trace-1", "trace-2"],
+        "replay_ids": ["replay-1", "replay-2"],
+        "tenant_id": "tenant-a",
+        "project_id": "project-a",
+        "policy_snapshot_version": "1.0.0",
+    }
+    selection["selection_digest_sha256"] = _json_digest(selection)
+    approval = {
+        "approval_id": "approval-2026-06-16",
+        "approved_by": "privacy-review-board",
+        "approved_at": "2026-06-16T09:05:00+00:00",
+        "decision": "approved",
+        "ticket_ref": "GOV-2026-0616",
+        "tenant_id": "tenant-a",
+        "project_id": "project-a",
+        "policy_snapshot_version": "1.0.0",
+        "replay_ids": ["replay-1", "replay-2"],
+    }
+    approval["approval_digest_sha256"] = _json_digest(approval)
+
+    bundle = {
+        "schema_version": "neuro-symbolic.production-trace-training.bundle.v1",
+        "contract_version": "1.0.0",
+        "dataset_id": "production-trace-batch-2026-06-16",
+        "dataset_version": "2026.06.16",
+        "record_schema_version": "neuro-symbolic.production-trace-training.record.v1",
+        "tenant_id": "tenant-a",
+        "project_id": "project-a",
+        "policy_snapshot_version": "1.0.0",
+        "source_kind": "production_execution_traces",
+        "ownership": {
+            "service_identity": "neuro-symbolic-service",
+            "requested_by": "neuro-symbolic-service",
+            "service_role": "internal-ingest",
+        },
+        "selection": selection,
+        "approval": approval,
+        "provenance": provenance,
+        "redaction": redaction,
+        "records": records,
+    }
+    bundle["manifest_digest_sha256"] = _json_digest(bundle)
+    return bundle
+
 def test_training_dataset_ingestion_round_trip_and_replayability(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(
         "SYSTEM_API_POLICY_SNAPSHOT_JSON",
@@ -428,3 +575,74 @@ def test_training_dataset_cli_ingest_command(monkeypatch: pytest.MonkeyPatch, tm
     assert summary["dataset_version"] == "2026.06.16"
     assert summary["record_count"] == 2
     assert summary["evidence_ref"].startswith("kb://learning/")
+
+
+def test_production_trace_training_requires_redaction_tenant_scope_and_approval() -> None:
+    bundle = _production_trace_training_bundle()
+
+    manifest = prepare_training_dataset_manifest(bundle, caller_identity="neuro-symbolic-service")
+    assert manifest["dataset_id"] == "production-trace-batch-2026-06-16"
+    assert manifest["selection"]["trace_ids"] == ["trace-1", "trace-2"]
+    assert manifest["approval"]["replay_ids"] == ["replay-1", "replay-2"]
+    assert manifest["records"][0]["replay_ref"] == "nsc://replay/trace-1/replay-1"
+    assert manifest["records"][0]["trace_ref"] == "nsc://trace/trace-1"
+
+    unredacted_bundle = json.loads(json.dumps(bundle))
+    unredacted_bundle["records"][0]["payload"]["features"]["masked_email"] = "alice@example.com"
+    with pytest.raises(ProductionTraceTrainingError):
+        prepare_training_dataset_manifest(unredacted_bundle, caller_identity="neuro-symbolic-service")
+
+    foreign_scope_bundle = json.loads(json.dumps(bundle))
+    foreign_scope_bundle["records"][1]["tenant_id"] = "tenant-b"
+    with pytest.raises(ProductionTraceTrainingError):
+        prepare_training_dataset_manifest(foreign_scope_bundle, caller_identity="neuro-symbolic-service")
+
+    missing_approval_bundle = json.loads(json.dumps(bundle))
+    missing_approval_bundle.pop("approval")
+    with pytest.raises(ProductionTraceTrainingError):
+        prepare_training_dataset_manifest(missing_approval_bundle, caller_identity="neuro-symbolic-service")
+
+
+def test_production_trace_training_is_replayable_and_cli_ingestable(monkeypatch: pytest.MonkeyPatch, tmp_path, capsys) -> None:
+    monkeypatch.setenv(
+        "SYSTEM_API_POLICY_SNAPSHOT_JSON",
+        json.dumps(
+            {
+                "version": "1.0.0",
+                "issuer": "eigen-auth",
+                "audience": "eigen-api",
+                "role_permissions": {"readonly": ["jobs:read"]},
+                "service_permissions": {"neuro-symbolic-service": ["kb:ingest"]},
+                "sandbox_profiles": ["default"],
+            },
+            sort_keys=True,
+        ),
+    )
+    bundle = _production_trace_training_bundle()
+    bundle_path = tmp_path / "production-trace-bundle.json"
+    bundle_path.write_text(json.dumps(bundle, indent=2), encoding="utf-8")
+
+    first = prepare_training_dataset_manifest(bundle, caller_identity="neuro-symbolic-service")
+    second = prepare_training_dataset_manifest(json.loads(bundle_path.read_text(encoding="utf-8")), caller_identity="neuro-symbolic-service")
+    assert first["manifest_digest_sha256"] == second["manifest_digest_sha256"]
+    assert first["dataset_digest_sha256"] == second["dataset_digest_sha256"]
+
+    exit_code = neuro_main([
+        "ingest-production-traces",
+        "--manifest",
+        str(bundle_path),
+        "--caller-identity",
+        "neuro-symbolic-service",
+    ])
+    output = capsys.readouterr().out.strip()
+    summary = json.loads(output)
+
+    assert exit_code == 0
+    assert summary["dataset_id"] == "production-trace-batch-2026-06-16"
+    assert summary["tenant_id"] == "tenant-a"
+    assert summary["policy_snapshot_version"] == "1.0.0"
+    assert summary["trace_ids"] == ["trace-1", "trace-2"]
+    assert summary["replay_ids"] == ["replay-1", "replay-2"]
+    assert summary["approval"]["approval_id"] == "approval-2026-06-16"
+    assert summary["selection"]["selection_id"] == "selection-2026-06-16"
+    assert summary["records"][0]["payload"]["features"]["masked_email"] == "[REDACTED_EMAIL]"


### PR DESCRIPTION
## Summary

Implemented the privacy-safe production-trace retraining flow for Neuro-DPDA with an internal offline governance bundle, replay/approval metadata preservation in KB ingestion, and a CLI path for ingesting approved production traces.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: CLI |payloads | knowledge base training manifests
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Offline production-trace training bundle preparation and ingestion path for Neuro-DPDA.
- Explicit tenant-scoped selection, approval, provenance, redaction, and replay metadata for retraining.

### Changed
- KB training ingestion now preserves optional governance metadata when present.

### Fixed
- Fail-closed validation for missing provenance, redaction, tenant isolation, approval, or replay evidence.