### PR TITLE
Unified the documented ingress/security/audit contract

### DIFF
--- a/docs/architecture/components/system-api.md
+++ b/docs/architecture/components/system-api.md
@@ -142,6 +142,7 @@ The System API SHALL evolve into a **strict gateway** providing:
 - policy-driven authorization,
 - tenant isolation enforcement at ingress,
 - audit-safe security context propagation,
+- one normalized ingress path for every workload-family kind; workload semantics may vary, but authn/authz, trace propagation, and audit formatting MUST remain shared,
 - release readiness is blocked until the production readiness gate evidence bundle validates redaction, tenant isolation, policy enforcement, explainability, audit, and fail-closed behavior.
 
 #### Observability ingress

--- a/docs/reference/jobspec.md
+++ b/docs/reference/jobspec.md
@@ -103,6 +103,26 @@ ReplayJob
 
 ---
 
+### 2.1 Unified ingress, security, and audit path
+
+All supported workload-family kinds share the same normalized ingress path through System API. The workload family may change execution semantics, but it MUST NOT fork authentication, authorization, trace propagation, or audit formatting.
+
+For every workload-family kind (`QuantumJob`, `HybridWorkflow`, `DistributedJob`, `BenchmarkJob`, `PipelineJob`, `ReplayJob`), the normalized envelope MUST carry the same bounded security context fields end to end:
+
+- `traceparent`
+- derived `trace_id`
+- `subject`
+- `tenant` / `tenant_id`
+- `project` / `project_id`
+- `service_identity`
+- `policy_snapshot_ref` or equivalent policy evidence handle
+- `sandbox_profile`
+- replay markers when replay-safe processing is requested
+
+Replay-sensitive profiles, including replay and benchmark flows, MUST fail closed when policy evidence is missing or cannot be normalized. Observability and audit records for all workload kinds MUST remain bounded, secret-free, and schema-stable; kind-specific behavior is limited to workload execution semantics, not ingress security or audit structure.
+
+---
+
 # 3. Design Principles
 
 ## 3.1 Declarative Execution

--- a/docs/reference/security/authz.md
+++ b/docs/reference/security/authz.md
@@ -112,11 +112,15 @@ Wave 9 public ingress handlers MUST normalize and propagate a deterministic secu
 
 The public ingress boundary MUST reject requests by default unless the configured identity and policy checks succeed. Allow-all behavior remains a local/dev compatibility mode only when explicitly configured.
 
+All workload-family variants (`QuantumJob`, `HybridWorkflow`, `DistributedJob`, `BenchmarkJob`, `PipelineJob`, `ReplayJob`) MUST use this same normalized ingress path. No workload kind may introduce a separate authn/authz, trace, or audit branch.
+
 ---
 
 ### 7.1 Security audit trail and replay evidence
 
 Security decisions MUST be written to the canonical append-only audit sink with bounded, secret-free metadata. Each audit event MUST include the decision outcome, decision reason, policy version, service identity, sandbox profile, replay marker, and request trace correlation where available.
+
+This audit schema applies uniformly to every workload-family kind. Workload-specific semantics MAY influence the decision reason, but they MUST NOT change the audit envelope shape or introduce family-specific security fields.
 
 Security telemetry for the audit path MUST remain bounded. Audit sink health is surfaced as counters rather than free-form labels, and audit records MUST NOT embed raw payloads, bearer tokens, or provider secrets.
 

--- a/src/services/system-api/tests/test_kernel_delegation.py
+++ b/src/services/system-api/tests/test_kernel_delegation.py
@@ -23,11 +23,22 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from eigen.api.v1 import job_service_pb2 as job_pb
 from eigen.internal.v1 import kernel_gateway_pb2 as kernel_pb
 from system_api.kernel_client import KernelGatewayClient, KernelClientConfig
+from system_api.observability import trace_id_from_traceparent
 from system_api.grpc_delegation import DelegationHandler
 
 
 def _run(awaitable):
     return asyncio.run(awaitable)
+
+
+WORKLOAD_KIND_CASES = (
+    ("QuantumJob", 1, "quantum", False),
+    ("HybridWorkflow", 2, "hybrid", True),
+    ("DistributedJob", 3, "distributed", True),
+    ("BenchmarkJob", 4, "benchmark", True),
+    ("PipelineJob", 5, "pipeline", True),
+    ("ReplayJob", 6, "replay", True),
+)
 
 
 class TestMetadataNormalization:
@@ -81,6 +92,88 @@ class TestMetadataNormalization:
         # Verify request_id was generated
         assert internal_metadata["request_id"] is not None
         assert len(internal_metadata["request_id"]) > 0
+
+
+@pytest.mark.parametrize(("kind", "enum_value", "execution_profile", "replayable"), WORKLOAD_KIND_CASES)
+def test_request_metadata_proto_preserves_unified_security_and_trace_context_for_all_workload_kinds(
+    kind: str,
+    enum_value: int,
+    execution_profile: str,
+    replayable: bool,
+) -> None:
+    traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+    trace_id = trace_id_from_traceparent(traceparent)
+    public_envelope = {
+        "contract_version": "1.0.0",
+        "request_id": "req-12345",
+        "idempotency_key": "idempotent-key-001",
+        "traceparent": traceparent,
+        "trace_id": trace_id,
+        "tenant_id": "tenant-a",
+        "project_id": "project-b",
+        "auth_subject": "ingress-user",
+        "auth_role": "readonly",
+        "security_context": "policy://snapshot-v1",
+    }
+    workload_payload = {
+        "kind": kind,
+        "execution_profile": execution_profile,
+        "replayable": replayable,
+        "artifact_lineage": {
+            "root_ref": "qfs://root",
+            "parent_ref": "qfs://parent",
+            "policy_snapshot_ref": "qfs://policy",
+            "execution_ref": "qfs://exec",
+        },
+        "observability": {
+            "traceparent": traceparent,
+            "trace_id": trace_id,
+            "trace_ref": "trace://ref",
+            "emit_metrics": True,
+        },
+        "security": {
+            "tenant_id": "tenant-a",
+            "project_id": "project-b",
+            "service_identity": "system-api",
+            "policy_snapshot_ref": "policy://snapshot-v1",
+            "fail_closed": kind == "ReplayJob",
+        },
+        "backend_target": "sim:local",
+    }
+
+    client = KernelGatewayClient()
+    metadata = client._request_metadata_proto(public_envelope, workload=workload_payload)
+
+    assert metadata.contract_version == "1.0.0"
+    assert metadata.request_id == "req-12345"
+    assert metadata.idempotency_key == "idempotent-key-001"
+    assert metadata.traceparent == traceparent
+    assert metadata.trace_id == trace_id
+    assert metadata.tenant_id == "tenant-a"
+    assert metadata.project_id == "project-b"
+    assert metadata.subject == "ingress-user"
+    assert metadata.role == "readonly"
+    assert metadata.security_context == "policy://snapshot-v1"
+
+    workload = metadata.workload
+    assert workload is not None
+    assert workload.kind == enum_value
+    assert workload.execution_profile == execution_profile
+    assert workload.replayable is replayable
+    assert workload.artifact_lineage.root_ref == "qfs://root"
+    assert workload.artifact_lineage.parent_ref == "qfs://parent"
+    assert workload.artifact_lineage.policy_snapshot_ref == "qfs://policy"
+    assert workload.artifact_lineage.execution_ref == "qfs://exec"
+    assert workload.observability.traceparent == traceparent
+    assert workload.observability.trace_id == trace_id
+    assert workload.observability.trace_ref == "trace://ref"
+    assert workload.observability.emit_metrics is True
+    assert workload.security.tenant_id == "tenant-a"
+    assert workload.security.project_id == "project-b"
+    assert workload.security.service_identity == "system-api"
+    assert workload.security.policy_snapshot_ref == "policy://snapshot-v1"
+    assert workload.security.fail_closed is (kind == "ReplayJob")
+    assert workload.backend_target == "sim:local"
 
 
 class TestSubmitJobDelegation:

--- a/src/services/system-api/tests/test_security_baseline.py
+++ b/src/services/system-api/tests/test_security_baseline.py
@@ -18,6 +18,7 @@ from grpc_status import rpc_status
 from system_api.grpc_impl import JobService
 from system_api.grpc_server import serve
 from system_api.observability import start_metrics_server
+from system_api.observability import trace_id_from_traceparent
 from system_api.proto_gen import ensure_generated
 from system_api.security import security_context
 from system_api.security import validate_recommendation_gateway
@@ -428,6 +429,119 @@ def test_submit_job_stamps_normalized_security_context_metadata(monkeypatch: pyt
     assert metadata["security_subject"] == "ingress-user"
     assert sec.decision_authority == "policy_engine"
     assert sec.model_output_mode == "recommendation_only"
+
+
+@pytest.mark.parametrize("workload_kind", [
+    "QuantumJob",
+    "HybridWorkflow",
+    "DistributedJob",
+    "BenchmarkJob",
+    "PipelineJob",
+    "ReplayJob",
+])
+def test_submit_job_trace_and_audit_snapshot_are_identical_across_workload_kinds(
+    monkeypatch: pytest.MonkeyPatch,
+    workload_kind: str,
+) -> None:
+    monkeypatch.setenv("SYSTEM_API_AUTH_MODE", "static_token")
+    monkeypatch.setenv("SYSTEM_API_AUTH_TOKEN", "context-token")
+    monkeypatch.setenv("SYSTEM_API_AUTH_SUBJECT", "ingress-user")
+    monkeypatch.setenv("SYSTEM_API_AUTH_ROLES", "user,readonly")
+    monkeypatch.setenv("SYSTEM_API_AUTH_TENANT", "tenant-a")
+    monkeypatch.setenv("SYSTEM_API_SERVICE_IDENTITY", "system-api")
+    monkeypatch.setenv("SYSTEM_API_SERVICE_ROLE", "public-ingress")
+    monkeypatch.setenv("SYSTEM_API_SANDBOX_PROFILE", "restricted")
+
+    traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+    trace_id = trace_id_from_traceparent(traceparent)
+    workload = {
+        "kind": workload_kind,
+        "execution_profile": workload_kind.lower().replace("workflow", "").replace("job", ""),
+        "replayable": workload_kind != "QuantumJob",
+        "artifact_lineage": {
+            "root_ref": "qfs://root",
+            "parent_ref": "qfs://parent",
+            "policy_snapshot_ref": "policy://snapshot-v1",
+            "execution_ref": "qfs://exec",
+        },
+        "observability": {
+            "traceparent": traceparent,
+            "trace_id": trace_id,
+            "trace_ref": "trace://ref",
+            "emit_metrics": True,
+        },
+        "security": {
+            "tenant_id": "tenant-a",
+            "project_id": "project-b",
+            "service_identity": "system-api",
+            "policy_snapshot_ref": "policy://snapshot-v1",
+            "fail_closed": workload_kind == "ReplayJob",
+        },
+        "backend_target": "sim:local",
+    }
+
+    request = job_pb.SubmitJobRequest(
+        name=f"{workload_kind.lower()}-security-audit",
+        target="sim:local",
+        metadata={"jobspec_workload": json.dumps(workload, sort_keys=True)},
+        envelope=types_pb.ApiRequestEnvelope(
+            contract_version="1.0.0",
+            request_id="req-security-audit",
+            traceparent=traceparent,
+        ),
+        eigen_lang=types_pb.EigenLangSource(source=b"def main():\n    return 1", entrypoint="main"),
+    )
+
+    class _Context:
+        def invocation_metadata(self):
+            return (
+                ("authorization", "Bearer context-token"),
+                ("x-eigen-service", "system-api"),
+                ("x-eigen-service-role", "public-ingress"),
+                ("x-eigen-sandbox-profile", "restricted"),
+            )
+
+        def abort(self, code, details):
+            raise RuntimeError(f"{code}: {details}")
+
+    service = JobService(job_pb=job_pb, types_pb=types_pb)
+    sec = security_context(_Context(), method_name="JobService.SubmitJob")
+    created_at = Timestamp()
+    created_at.FromDatetime(datetime.now(timezone.utc))
+    record = service._build_job_record(
+        request,
+        job_id="job-security-audit",
+        created_at=created_at,
+        trace_id=trace_id,
+        request_id="req-security-audit",
+        traceparent=traceparent,
+        security=sec,
+        owner_subject=sec.subject,
+        owner_tenant=sec.tenant or "tenant-a",
+        owner_project="project-b",
+    )
+
+    snapshot = json.loads(record.results_metadata["security_context"])
+    assert snapshot == {
+        "auth_mode": "static_token",
+        "policy_version": "1.0.0",
+        "request_id": "req-security-audit",
+        "roles": ["readonly", "user"],
+        "sandbox_profile": "restricted",
+        "service_identity": "system-api",
+        "service_role": "public-ingress",
+        "subject": "ingress-user",
+        "tenant": "tenant-a",
+        "trace_id": trace_id,
+        "traceparent": traceparent,
+    }
+    assert record.results_metadata["traceparent"] == traceparent
+    assert record.results_metadata["trace_id"] == trace_id
+    assert record.results_metadata["trace_ref"] == f"trace://{trace_id}"
+    assert record.results_metadata["security_policy_version"] == "1.0.0"
+    assert record.results_metadata["security_service_identity"] == "system-api"
+    assert record.results_metadata["security_service_role"] == "public-ingress"
+    assert record.results_metadata["security_subject"] == "ingress-user"
 
 
 def test_security_conformance_suite_blocks_mandatory_security_gates(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary

Unified the documented ingress/security/audit contract for all workload-family kinds and added conformance coverage to prove the same normalized trace and security context is carried for QuantumJob, HybridWorkflow, DistributedJob, BenchmarkJob, PipelineJob, and ReplayJob.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: API | Metrics
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Shared conformance coverage for normalized workload-family ingress across all supported kinds.
- Audit snapshot assertions proving the same security context shape is emitted regardless of workload kind.

### Changed
- Documented a single normalized security, tracing, and audit path for every workload-family kind.
- Clarified that replay-sensitive profiles must fail closed when policy evidence is missing.

### Fixed
- Removed ambiguity that could allow workload-family-specific security or tracing branches in the contract language.