### PR TITLE
Define the KB contract for compiler queries

### DIFF
--- a/docs/architecture/components/compiler.md
+++ b/docs/architecture/components/compiler.md
@@ -18,6 +18,7 @@ Companion docs:
 
 - `docs/architecture/adr/compiler-rule-engine-and-advisory-boundary.md`
 - `docs/reference/compiler-model-migration-notes.md`
+- `docs/architecture/components/knowledge-base.md`
 - `docs/reference/formats/aqo.md`
 - `docs/reference/eigen-lang.md`
 

--- a/docs/architecture/components/knowledge-base.md
+++ b/docs/architecture/components/knowledge-base.md
@@ -30,9 +30,261 @@ A canonical pattern is the single template selected by `GetPattern` when the req
 
 An explanation pattern is a bounded diagnostic envelope that explains why a canonical pattern was selected or why no canonical pattern was available.
 
+## 2.4 Stable request/response contract
+
+The compiler, optimizer, and driver-manager integrations MUST use the same versioned KB envelope for both similarity lookup and canonical pattern lookup.
+
+The envelope is deterministic and replay-safe. The ML layer may rank or explain results, but it MUST NOT invent or rewrite any authoritative field in the request, the returned pattern record, or the attached provenance.
+
+### 2.4.1 `knowledge_context`
+
+`knowledge_context` is the normalized request context attached to every KB call and mirrored in every response.
+
+Required fields:
+
+| Field | Type | Required | Semantics |
+|---|---|---:|---|
+| `contract_version` | string | yes | KB request/response contract version. Must be `1.0.0` for this document set. |
+| `schema_version` | string | yes | Schema revision for the normalized context envelope. |
+| `request_id` | string | yes | Deterministic request identifier used for replay and provenance. |
+| `tenant_id` | string | yes | Tenant boundary. Never inferred. |
+| `project_id` | string | yes | Project boundary. Never inferred. |
+| `caller_component` | string | yes | One of `compiler`, `optimizer`, `driver_manager`, `neuro_symbolic_service`, `kernel_gateway`. |
+| `request_kind` | string | yes | One of `similar_pattern_lookup`, `canonical_pattern_lookup`, `record_query`, `decision_log_query`. |
+| `deterministic` | bool | yes | `true` when the caller requires exact replay semantics. |
+| `seed` | uint64 | yes | Deterministic seed for ranking and tie-breaking. |
+| `snapshot_id` | string | yes | Snapshot identifier for the KB and model/policy binding. |
+| `policy_snapshot_version` | string | yes | Policy snapshot version used to validate the request. |
+| `policy_mode` | string | yes | Policy mode used by the deterministic selection path. |
+| `policy_digest` | string | yes | Canonical digest of the policy snapshot. |
+| `model_snapshot_id` | string | yes | Model snapshot identifier bound to the advisory layer. |
+| `model_snapshot_digest` | string | yes | Canonical digest of the model snapshot. |
+| `compiler_version` | string | conditional | Required for compiler-originated requests. |
+| `optimizer_version` | string | conditional | Required for optimizer-originated requests. |
+| `aqo_version` | string | conditional | Required when the request references AQO. |
+| `backend_class` | string | yes | Backend class used to scope canonical pattern selection. |
+| `circuit_id` | string | yes | Circuit identity for the lookup scope. |
+| `semantic_hash` | string | yes | Canonical semantic fingerprint for the request payload. |
+| `aqo_hash` | string | conditional | Required when the request concerns AQO reuse. |
+| `capability_scope` | string | yes | Normalized capability scope. Must fail closed on mismatch. |
+| `capability_tags` | repeated string | yes | Normalized capability tags used to derive the capability scope. |
+| `candidate_budget` | uint32 | yes | Requested candidate budget before clamping. |
+| `query_mode` | string | yes | One of `structural`, `vector`, or `hybrid`. |
+| `include_provenance` | bool | yes | When `true`, the response MUST include full provenance metadata. |
+| `request_digest_sha256` | string | yes | Digest of the normalized request envelope. |
+
+Normative rules:
+
+- `knowledge_context` is authoritative input, not model output.
+- The ML layer MUST NOT infer `tenant_id`, `project_id`, `snapshot_id`, `policy_digest`, `request_digest_sha256`, or any compatibility field.
+- Requests that omit required boundary fields MUST fail closed.
+- The same normalized `knowledge_context` MUST produce the same replay identity, candidate ordering, and provenance fields.
+
+### 2.4.2 `PatternRecord`
+
+`PatternRecord` is the canonical stored and returned representation of a candidate or canonical pattern.
+
+Required fields:
+
+| Field | Type | Required | Semantics |
+|---|---|---:|---|
+| `pattern_id` | string | yes | Stable record identifier. |
+| `pattern_family` | string | yes | Family name used in canonical selection ordering. |
+| `pattern_kind` | string | yes | Kind such as compiler pattern, optimizer pattern, or driver pattern. |
+| `tenant_id` | string | yes | Tenant boundary. |
+| `project_id` | string | yes | Project boundary. |
+| `circuit_id` | string | yes | Circuit identity. |
+| `backend_class` | string | yes | Backend scope. |
+| `source_record_ids` | repeated string | yes | Primary-source record identifiers for provenance and replay. |
+| `support` | uint64 | yes | Deterministic support count used for canonical ranking. |
+| `compatibility_window` | object | yes | The normalized compatibility window. |
+| `compatibility_signature` | string | yes | SHA-256 over the normalized compatibility window. |
+| `canonical_eligible` | bool | yes | Whether the pattern satisfies the exact canonical eligibility gate. |
+| `selected` | bool | yes | Whether this record was selected in the current response. |
+| `rank` | uint32 | yes | Deterministic rank in the returned list. |
+| `score_breakdown` | object | yes | Deterministic score components. |
+| `score_total` | float | yes | Final deterministic ranking score. |
+| `confidence` | float | yes | Secondary ordering key. |
+| `incompatibility_reasons` | repeated string | yes | Deterministic reason codes for ineligibility. |
+| `metadata` | object | yes | Additional bounded metadata, never authoritative truth. |
+| `provenance` | object | yes | Attached provenance for this record. |
+
+`compatibility_window` MUST contain the exact fields used by canonical selection:
+
+- `schema_version`
+- `compiler_version`
+- `aqo_version`
+- `optimizer_version`
+- `policy_mode`
+- `policy_digest`
+- `snapshot_id`
+- `backend_class`
+- `capability_scope`
+
+### 2.4.3 Response provenance
+
+Every KB response MUST include a provenance object, including empty-result responses and diagnostics-only fallbacks.
+
+Required provenance fields:
+
+| Field | Type | Required | Semantics |
+|---|---|---:|---|
+| `contract_version` | string | yes | Provenance schema version. |
+| `request_id` | string | yes | Echo of `knowledge_context.request_id`. |
+| `request_digest_sha256` | string | yes | Echo of the normalized request digest. |
+| `response_digest_sha256` | string | yes | Digest of the normalized response payload. |
+| `snapshot_id` | string | yes | Snapshot bound to the response. |
+| `policy_snapshot_version` | string | yes | Policy snapshot used for validation. |
+| `model_snapshot_id` | string | yes | Model snapshot bound to advisory ranking. |
+| `retrieval_mode` | string | yes | `similar_pattern_lookup`, `canonical_pattern_lookup`, `record_query`, or `decision_log_query`. |
+| `selected_pattern_id` | string | conditional | Present when a canonical or best-effort pattern is selected. |
+| `source_record_ids` | repeated string | yes | Source records that informed the response. |
+| `generated_at` | string | yes | RFC 3339 timestamp for the deterministic response envelope. |
+| `replay_safe` | bool | yes | `true` when the response is replay-safe under the same normalized input. |
+
+The provenance object is attached to:
+
+- `SearchSimilarResponse`
+- `GetPatternResponse`
+- any other KB response that can affect compiler, optimizer, or driver-manager decisions
+
+### 2.4.4 Similar-pattern lookup
+
+The stable request/response contract for similar-pattern lookup is:
+
+```protobuf
+message SearchSimilarRequest {
+  string contract_version = 1;
+  KnowledgeContext knowledge_context = 2;
+  PatternQuery pattern_query = 3;
+  uint32 candidate_budget = 4;
+  string query_mode = 5;   // structural | vector | hybrid
+  bool deterministic = 6;
+}
+
+message SearchSimilarResponse {
+  string contract_version = 1;
+  KnowledgeContext knowledge_context = 2;
+  repeated PatternRecord candidate_patterns = 3;
+  PatternRecord selected_candidate = 4;
+  PatternRecord explanation_pattern = 5;
+  ResponseProvenance provenance = 6;
+  Diagnostics diagnostics = 7;
+}
+```
+
+Semantics:
+
+- `candidate_budget` is clamped to the service maximum of `8`.
+- The response MUST preserve the ordered candidate list returned by the deterministic ranking path.
+- `selected_candidate` MUST be the first ranked candidate when one exists.
+- `explanation_pattern` MAY be empty, but its provenance MUST still be present.
+- When there are no candidates, `candidate_patterns` MUST be empty and `selected_candidate` MUST be unset.
+
+### 2.4.5 Canonical pattern lookup
+
+The stable request/response contract for canonical pattern lookup is:
+
+```protobuf
+message GetPatternRequest {
+  string contract_version = 1;
+  KnowledgeContext knowledge_context = 2;
+  PatternQuery pattern_query = 3;
+  uint32 candidate_budget = 4;
+  bool deterministic = 5;
+}
+
+message GetPatternResponse {
+  string contract_version = 1;
+  KnowledgeContext knowledge_context = 2;
+  PatternRecord canonical_pattern = 3;
+  repeated PatternRecord candidate_patterns = 4;
+  PatternRecord explanation_pattern = 5;
+  ResponseProvenance provenance = 6;
+  Diagnostics diagnostics = 7;
+}
+```
+
+Semantics:
+
+- The canonical pattern is selected only when the exact compatibility window matches.
+- If no canonical pattern exists, `canonical_pattern` MUST be unset and diagnostics MUST report the deterministic incompatibility reason codes.
+- `candidate_patterns` MAY still contain compatible or nearly compatible records, but only `canonical_pattern` may be treated as authoritative.
+- The canonical response MUST be reproducible from the same `knowledge_context` and `pattern_query`.
+
+### 2.4.6 Pattern query
+
+```protobuf
+message PatternQuery {
+  string semantic_hash = 1;
+  string aqo_hash = 2;
+  string circuit_id = 3;
+  string backend_class = 4;
+  CompatibilityWindow compatibility_window = 5;
+}
+```
+
+```protobuf
+message CompatibilityWindow {
+  string schema_version = 1;
+  string compiler_version = 2;
+  string aqo_version = 3;
+  string optimizer_version = 4;
+  string policy_mode = 5;
+  string policy_digest = 6;
+  string snapshot_id = 7;
+  string backend_class = 8;
+  string capability_scope = 9;
+}
+```
+
+```protobuf
+message ResponseProvenance {
+  string contract_version = 1;
+  string request_id = 2;
+  string request_digest_sha256 = 3;
+  string response_digest_sha256 = 4;
+  string snapshot_id = 5;
+  string policy_snapshot_version = 6;
+  string model_snapshot_id = 7;
+  string retrieval_mode = 8;
+  string selected_pattern_id = 9;
+  repeated string source_record_ids = 10;
+  string generated_at = 11;
+  bool replay_safe = 12;
+}
+```
+
+```protobuf
+message PatternRecord {
+  string pattern_id = 1;
+  string pattern_family = 2;
+  string pattern_kind = 3;
+  string tenant_id = 4;
+  string project_id = 5;
+  string circuit_id = 6;
+  string backend_class = 7;
+  repeated string source_record_ids = 8;
+  uint64 support = 9;
+  CompatibilityWindow compatibility_window = 10;
+  string compatibility_signature = 11;
+  bool canonical_eligible = 12;
+  bool selected = 13;
+  uint32 rank = 14;
+  map<string, double> score_breakdown = 15;
+  double score_total = 16;
+  double confidence = 17;
+  repeated string incompatibility_reasons = 18;
+  map<string, string> metadata = 19;
+  ResponseProvenance provenance = 20;
+}
+```
+
+`PatternQuery` is never authoritative truth; it is only a deterministic retrieval key. The model may score candidates, but it MUST NOT infer or mutate the compatibility window.
+
 ## 3. Similarity query definition
 
-A similarity query is a deterministic ranking query over a scoped candidate pool.
+A similarity query is a deterministic ranking query over a scoped candidate pool. It MUST use the `knowledge_context`, `PatternQuery`, `PatternRecord`, and `ResponseProvenance` shapes defined above.
 
 Every query MUST be scoped by:
 
@@ -171,7 +423,7 @@ Returned candidate patterns MUST include:
 - `score_breakdown`
 - `score_total`
 - `confidence`
-- `incompatibility_reasons
+- `incompatibility_reasons`
 - `metadata`
 
 The canonical response MUST also include:

--- a/docs/architecture/components/neuro-symbolic-core.md
+++ b/docs/architecture/components/neuro-symbolic-core.md
@@ -53,7 +53,7 @@ The symbolic core is implemented as a deterministic pushdown automaton (DPDA) pl
 
 The knowledge base stores and serves replay-safe facts, historical decisions, candidate patterns, canonical patterns, snapshots, and decision logs.
 
-The knowledge base may return ranked candidates and canonical matches, but it does not invent new semantic truth.
+The knowledge base may return ranked candidates and canonical matches, but it does not invent new semantic truth. The stable request/response envelope for compiler queries is defined in `docs/architecture/components/knowledge-base.md` and `docs/reference/api/grpc-internal.md`.
 
 ### 1.3 ML advisor
 

--- a/docs/architecture/contract-map.md
+++ b/docs/architecture/contract-map.md
@@ -111,6 +111,7 @@ It serves as:
 - **GNN Optimizer** (placement/routing): AQO + topology → QASM (or backend-native)
 
 The source-of-truth boundary for the symbolic core, KB, optimizer, and driver-manager integrations is `docs/architecture/components/neuro-symbolic-core.md`.
+The stable KB request/response contract used by compiler queries is defined in `docs/architecture/components/knowledge-base.md` and `docs/reference/api/grpc-internal.md`.
 
 #### Responsibilities
 

--- a/docs/reference/api/grpc-internal.md
+++ b/docs/reference/api/grpc-internal.md
@@ -172,6 +172,148 @@ Returned responses MUST expose:
 
 The canonical pattern MUST be distinct from the candidate pattern list and MUST not be recomputed from an arbitrary nearest neighbor.
 
+#### KB request/response contract
+
+The internal KnowledgeBaseService MUST use the same versioned envelope as the architecture contract in `docs/architecture/components/knowledge-base.md`.
+
+Canonical request/response shapes:
+
+```protobuf
+message KnowledgeContext {
+  string contract_version = 1;
+  string schema_version = 2;
+  string request_id = 3;
+  string tenant_id = 4;
+  string project_id = 5;
+  string caller_component = 6;
+  string request_kind = 7;
+  bool deterministic = 8;
+  uint64 seed = 9;
+  string snapshot_id = 10;
+  string policy_snapshot_version = 11;
+  string policy_mode = 12;
+  string policy_digest = 13;
+  string model_snapshot_id = 14;
+  string model_snapshot_digest = 15;
+  string compiler_version = 16;
+  string optimizer_version = 17;
+  string aqo_version = 18;
+  string backend_class = 19;
+  string circuit_id = 20;
+  string semantic_hash = 21;
+  string aqo_hash = 22;
+  string capability_scope = 23;
+  repeated string capability_tags = 24;
+  uint32 candidate_budget = 25;
+  string query_mode = 26;
+  bool include_provenance = 27;
+  string request_digest_sha256 = 28;
+}
+
+message CompatibilityWindow {
+  string schema_version = 1;
+  string compiler_version = 2;
+  string aqo_version = 3;
+  string optimizer_version = 4;
+  string policy_mode = 5;
+  string policy_digest = 6;
+  string snapshot_id = 7;
+  string backend_class = 8;
+  string capability_scope = 9;
+}
+
+message PatternQuery {
+  string semantic_hash = 1;
+  string aqo_hash = 2;
+  string circuit_id = 3;
+  string backend_class = 4;
+  CompatibilityWindow compatibility_window = 5;
+}
+
+message ResponseProvenance {
+  string contract_version = 1;
+  string request_id = 2;
+  string request_digest_sha256 = 3;
+  string response_digest_sha256 = 4;
+  string snapshot_id = 5;
+  string policy_snapshot_version = 6;
+  string model_snapshot_id = 7;
+  string retrieval_mode = 8;
+  string selected_pattern_id = 9;
+  repeated string source_record_ids = 10;
+  string generated_at = 11;
+  bool replay_safe = 12;
+}
+
+message PatternRecord {
+  string pattern_id = 1;
+  string pattern_family = 2;
+  string pattern_kind = 3;
+  string tenant_id = 4;
+  string project_id = 5;
+  string circuit_id = 6;
+  string backend_class = 7;
+  repeated string source_record_ids = 8;
+  uint64 support = 9;
+  CompatibilityWindow compatibility_window = 10;
+  string compatibility_signature = 11;
+  bool canonical_eligible = 12;
+  bool selected = 13;
+  uint32 rank = 14;
+  map<string, double> score_breakdown = 15;
+  double score_total = 16;
+  double confidence = 17;
+  repeated string incompatibility_reasons = 18;
+  map<string, string> metadata = 19;
+  ResponseProvenance provenance = 20;
+}
+
+message SearchSimilarRequest {
+  string contract_version = 1;
+  KnowledgeContext knowledge_context = 2;
+  PatternQuery pattern_query = 3;
+  uint32 candidate_budget = 4;
+  string query_mode = 5;
+  bool deterministic = 6;
+}
+
+message SearchSimilarResponse {
+  string contract_version = 1;
+  KnowledgeContext knowledge_context = 2;
+  repeated PatternRecord candidate_patterns = 3;
+  PatternRecord selected_candidate = 4;
+  PatternRecord explanation_pattern = 5;
+  ResponseProvenance provenance = 6;
+  Diagnostics diagnostics = 7;
+}
+
+message GetPatternRequest {
+  string contract_version = 1;
+  KnowledgeContext knowledge_context = 2;
+  PatternQuery pattern_query = 3;
+  uint32 candidate_budget = 4;
+  bool deterministic = 5;
+}
+
+message GetPatternResponse {
+  string contract_version = 1;
+  KnowledgeContext knowledge_context = 2;
+  PatternRecord canonical_pattern = 3;
+  repeated PatternRecord candidate_patterns = 4;
+  PatternRecord explanation_pattern = 5;
+  ResponseProvenance provenance = 6;
+  Diagnostics diagnostics = 7;
+}
+```
+
+Contract rules:
+
+- `knowledge_context` is the only request context that compiler queries may rely on.
+- `PatternRecord` is the only stable record shape returned to compiler, optimizer, and driver-manager integrations.
+- `ResponseProvenance` MUST be attached to every KB response, including empty results and diagnostics-only fallbacks.
+- The ML layer MAY rank candidates, but it MUST NOT infer the boundary fields in `KnowledgeContext`, the compatibility window, or the provenance fields.
+- The contract version is pinned to `1.0.0` for this interface family. Any incompatible schema change requires a version bump and a new documented contract.
+
 ---
 
 ```text


### PR DESCRIPTION
## Summary

- Defined the KB contract for compiler queries in docs/architecture/components/knowledge-base.md.
- Added the stable request/response envelope in docs/reference/api/grpc-internal.md.
- Specified knowledge_context, PatternRecord, PatternQuery, CompatibilityWindow, and ResponseProvenance as the versioned contract surface.
- Made provenance mandatory on every KB response, including empty and diagnostics-only responses.
- Added cross-references from the compiler and neuro-symbolic boundary docs so the KB contract is discoverable from the compiler path.

## Validation

- [ ] Tests added/updated
- [ ] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: API
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- A versioned KB request/response contract for compiler-originated queries.
- Explicit schemas for knowledge_context, PatternRecord, PatternQuery, CompatibilityWindow, and ResponseProvenance.
- Mandatory provenance attachment for all KB responses.

### Changed
- Compiler and neuro-symbolic boundary docs now point to the KB contract as the stable source of truth.
- Internal gRPC reference now documents the exact KB envelope used by compiler integrations.

### Fixed
- Removed ambiguity around which fields are authoritative versus advisory in KB-assisted compiler lookup flows.