### PR TITLE
Updated the documentation so the neuro-symbolic layer

### DIFF
--- a/docs/architecture/components/gnn-optimizer.md
+++ b/docs/architecture/components/gnn-optimizer.md
@@ -22,6 +22,8 @@ The optimizer operates between:
 - kernel scheduling / dispatch,
 - driver-manager backend execution.
 
+The optimizer MUST execute a deterministic symbolic baseline first; ML recommendations may only refine that baseline.
+
 The authoritative boundary between the symbolic core, KB, optimizer, and ML advisor is defined in `docs/architecture/components/neuro-symbolic-core.md`.
 
 Primary objectives:
@@ -71,6 +73,7 @@ Hardware / Simulator / Vendor Cloud
 - not allowed to introduce nondeterministic behavior in deterministic mode,
 - not allowed to bypass policy constraints or security validation,
 - not allowed to infer topology, noise, or availability from unvalidated model output,
+- not allowed to treat missing, malformed, low-confidence, or invalid model output as authoritative,
 - not allowed to leak provider secrets or raw provider payloads.
 
 ---
@@ -214,6 +217,7 @@ Allowed transformations include (policy- and backend-dependent):
 The optimizer is subordinate to symbolic validation:
 
 - ML inference is advisory, not authoritative.
+- If model output is missing, malformed, low-confidence, or invalid, the optimizer MUST ignore it and run the symbolic baseline.
 - Symbolic checks MUST reject invalid transformations deterministically.
 - In deterministic mode, the optimizer MUST behave replayably given identical inputs.
 
@@ -236,7 +240,7 @@ When `deterministic=true`, the optimizer output MUST be a pure function of:
 
 - AQO content hash (canonical AQO bytes)
 - `contract_version`
-- `optimizer_model_id` (or explicit `fallback_used=true`)
+- `optimizer_model_id` (or explicit `fallback_used=true` when the symbolic baseline is used)
 - backend identity + topology snapshot hash
 - calibration snapshot hash (or explicit “no calibration” sentinel)
 - policy envelope (mode + constraints)

--- a/docs/architecture/components/neuro-symbolic-advisory-boundary.md
+++ b/docs/architecture/components/neuro-symbolic-advisory-boundary.md
@@ -10,6 +10,8 @@ The normative source of truth for the full symbolic-core / KB / ML-advisor bound
 
 The compiler must treat neuro-symbolic output as advisory only. Deterministic validation, normalization, lowering, AQO contract checks, and workload-profile resolution remain authoritative.
 
+If model output is missing, malformed, low-confidence, or invalid, the compiler must ignore it and continue with the symbolic baseline.
+
 Neuro-symbolic suggestions must not be able to produce invalid IR, bypass semantic validation, infer compiler legality, or relax lowering constraints.
 
 ## Allowed advisor behavior
@@ -45,6 +47,8 @@ Telemetry for these outcomes is exported from the neuro-symbolic service as:
 - `eigen_neuro_suggestion_outcomes_total{outcome="transformed"}`
 
 Structured logs should include the same `suggestion_outcome` field when available.
+
+A missing or invalid advisory payload is treated as ignored input to the symbolic baseline; it does not authorize a compiler action.
 
 ## Compatibility
 

--- a/docs/architecture/components/neuro-symbolic-core.md
+++ b/docs/architecture/components/neuro-symbolic-core.md
@@ -49,6 +49,8 @@ The symbolic core is the deterministic execution path that performs:
 
 The symbolic core is implemented as a deterministic pushdown automaton (DPDA) plus the compiler rule engine and the fixed policy evaluation path.
 
+The symbolic baseline is the same deterministic path with advisory inputs removed. When model output is absent, malformed, low-confidence, or rejected by validation, the symbolic baseline MUST run without consuming that output.
+
 ### 1.2 Knowledge base
 
 The knowledge base stores and serves replay-safe facts, historical decisions, candidate patterns, canonical patterns, snapshots, and decision logs.
@@ -271,7 +273,9 @@ Live lookup of policy or model versions during request handling is forbidden.
 
 ### 6.3 Fail-closed rule
 
-Missing snapshots, digest mismatches, integrity failures, policy mismatches, and tenant/project boundary violations MUST fail closed.
+Missing snapshots, digest mismatches, integrity failures, policy mismatches, tenant/project boundary violations, missing model output, malformed model output, and low-confidence model output MUST fail closed.
+
+When advisory output is absent, invalid, or below the policy-defined confidence threshold, the deterministic symbolic baseline MUST be used and the advisory result MUST be ignored for decision-making.
 
 ---
 

--- a/docs/reference/api/model-output-classification.md
+++ b/docs/reference/api/model-output-classification.md
@@ -41,9 +41,13 @@ There is no direct path from model output to execution.
 ## Validation
 
 - Unknown or empty values MUST be rejected.
+- Missing, malformed, or low-confidence advisory payloads MUST be treated as invalid at the caller boundary.
 - Rejection MUST be fail-closed and use `INVALID_ARGUMENT` at the service boundary.
+- When validation fails, the caller MUST fall back to the deterministic symbolic baseline and ignore the model output for decision-making.
 - Classification labels MUST remain stable within the same contract major version.
 
 ## Notes
 
 The label is a response classification, not a free-form confidence string. Consumers MUST NOT infer additional labels beyond the four approved values.
+
+A low-confidence label is not a separate approval state; if the advisory payload cannot be validated deterministically, the symbolic baseline wins.


### PR DESCRIPTION
## Summary

Updated the documentation so the neuro-symbolic layer is explicitly advisory only and the compiler/optimizer must fail closed to the symbolic baseline when model output is missing, malformed, low-confidence, or invalid.

## Validation

- [ ] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: PATCH
- **Affected Interfaces**: Metrics
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Explicit symbolic-baseline fallback rules for missing, malformed, low-confidence, or invalid model output.
- Clear advisory-only boundary language for the neuro-symbolic compiler and optimizer path.

### Changed
- The neuro-symbolic core spec now states that the symbolic baseline is authoritative when advisory output is not usable.
- Compiler-facing and optimizer-facing docs now describe fail-closed behavior consistently.
- Model output classification guidance now requires invalid advisory payloads to be rejected and ignored in favor of deterministic fallback.

### Fixed
- Removed ambiguity about what happens when ML advice is absent, low-confidence, or invalid.