### PR TITLE
Formalize the symbolic rewrite pipeline as a stable API

### DIFF
--- a/docs/architecture/components/compiler-neuro-symbolic-advisor.md
+++ b/docs/architecture/components/compiler-neuro-symbolic-advisor.md
@@ -22,6 +22,8 @@ Deterministic validation, normalization, lowering, AQO contract checks, and work
 
 Neuro-symbolic suggestions must not be able to produce invalid IR, bypass semantic validation, or relax lowering constraints.
 
+The compiler may invoke the symbolic rewrite pipeline one stage at a time, but stage order and stage advancement remain deterministic and under compiler control.
+
 ---
 
 ## 2. Allowed advisor behavior
@@ -61,6 +63,8 @@ Telemetry for these outcomes is exported from the neuro-symbolic service as:
 - `eigen_neuro_suggestion_outcomes_total{outcome="transformed"}`
 
 Structured logs should include the same `suggestion_outcome` field when available.
+
+For the symbolic rewrite pipeline, each stage invocation MUST be logged independently with the stage name, stage index, and stage outcome attached to the same bounded replay evidence.
 
 ---
 

--- a/docs/architecture/components/neuro-symbolic-core.md
+++ b/docs/architecture/components/neuro-symbolic-core.md
@@ -49,6 +49,17 @@ The symbolic core is the deterministic execution path that performs:
 
 The symbolic core is implemented as a deterministic pushdown automaton (DPDA) plus the compiler rule engine and the fixed policy evaluation path.
 
+Its symbolic rewrite pipeline is a fixed sequence of explicit, independently invocable stages:
+
+1. parse
+2. normalize
+3. candidate_generation
+4. legality_check
+5. rewrite
+6. emit_aqo
+
+Each stage MUST be deterministic, MUST log its own start and completion outcome, and MUST preserve the same replay identity when executed under the same frozen snapshots and normalized inputs.
+
 The symbolic baseline is the same deterministic path with advisory inputs removed. When model output is absent, malformed, low-confidence, or rejected by validation, the symbolic baseline MUST run without consuming that output.
 
 ### 1.2 Knowledge base
@@ -171,6 +182,7 @@ The compiler is authoritative for:
 - rule-engine approval,
 - lowering,
 - AQO emission,
+- stage-by-stage symbolic rewrite pipeline invocation,
 - compiler diagnostics,
 - replay evidence for accepted and rejected rules.
 

--- a/docs/reference/api/grpc-internal.md
+++ b/docs/reference/api/grpc-internal.md
@@ -43,7 +43,7 @@ This API layer directly implements the architecture defined in Eigen OS Target S
 | QRTX                        | Central orchestration |
 | Compilation Service         | Neuro-DPDA compiler |
 | Optimizer Service           | GNN routing & placement |
-| Neuro-Symbolic Service      | Internal-only Neuro-DPDA + ML advisor; source-of-truth boundary in `docs/architecture/components/neuro-symbolic-core.md` |
+| Neuro-Symbolic Service      | Internal-only Neuro-DPDA rewrite stages + ML advisor; source-of-truth boundary in `docs/architecture/components/neuro-symbolic-core.md` |
 | Driver Manager              | Hardware abstraction |
 | QFS                         | Artifact and state persistence |
 | Knowledge Base              | Long-term learning memory |
@@ -407,7 +407,7 @@ Operational flow:
 
 #### Purpose
 
-Internal-only DPDA model service used for advisory scoring of compilation plans. The deployable service boundary lives under `src/services/neuro-symbolic-service/`.
+Internal-only DPDA service used for explicit symbolic rewrite stages and advisory scoring of compilation plans. The deployable service boundary lives under `src/services/neuro-symbolic-service/`.
 
 This service is callable only by authenticated internal service identities. Public ingress paths MUST NOT expose a direct route to this service. Kernel/QRTX is the primary runtime caller; eigen-compiler may call this service only through the bounded advisory scoring path. `System API` MUST NOT call this service directly. Internal model registry activation and rollback are constrained by signed artifact verification, frozen policy snapshot binding, and internal service identity.
 
@@ -420,10 +420,48 @@ This service is callable only by authenticated internal service identities. Publ
 - Unsupported contract versions MUST be rejected before model scoring.
 - The request path MUST remain kernel-owned for runtime decisions and compiler-advisory only for compile-time scoring.
 
+#### Symbolic rewrite stage contract
+
+`RunSymbolicRewriteStage` exposes the symbolic rewrite pipeline as explicit stages. Exactly one stage is executed per request, and the stage outcome MUST be logged independently.
+
+Canonical stage order:
+
+1. parse
+2. normalize
+3. candidate_generation
+4. legality_check
+5. rewrite
+6. emit_aqo
+
+Required request semantics:
+
+- `contract_version` is required.
+- `stage` is required and MUST be one of the canonical stage names listed above.
+- `stage_index` is required and MUST match the canonical order when `deterministic=true`.
+- `tenant_id` and `project_id` are required.
+- `policy_snapshot_version` is required and MUST match the frozen immutable policy snapshot.
+- `model_snapshot_id` and `model_snapshot_digest` are required whenever the stage consults the ML advisor.
+- `kb_snapshot_id` and `kb_snapshot_digest` are required whenever the stage consults the KB.
+- `request_digest_sha256` is required.
+
+Returned responses MUST expose:
+
+- `contract_version`
+- `stage`
+- `stage_index`
+- `stage_outcome`
+- `replay_digest`
+- `diagnostics`
+
+`ScoreCompilationPlan` remains a compatibility wrapper that runs the full canonical stage sequence and returns the final `emit_aqo` result.
+
 #### Service definition
 
 ```text
 service NeuroSymbolicService {
+    rpc RunSymbolicRewriteStage(RunSymbolicRewriteStageRequest)
+        returns (RunSymbolicRewriteStageResponse);
+
     rpc ScoreCompilationPlan(ScoreCompilationPlanRequest)
         returns (ScoreCompilationPlanResponse);
 }
@@ -431,7 +469,7 @@ service NeuroSymbolicService {
 
 #### Request/response envelope contract
 
-- `ScoreCompilationPlanRequest.envelope.contract_version` is required.
+- `ScoreCompilationPlanRequest.envelope.contract_version` is required for the compatibility wrapper; `RunSymbolicRewriteStageRequest.contract_version` is required for the stage API.
 - `ScoreCompilationPlanRequest.context.feature_schema_version` is required.
 - `ScoreCompilationPlanRequest.context.policy_snapshot_version` is required.
 - The active policy snapshot MUST be frozen at service start and treated as immutable for the lifetime of the service process.
@@ -461,6 +499,8 @@ service NeuroSymbolicService {
   - `feature_set`,
   - `confidence`,
   - `retrieval_references`.
+- `RunSymbolicRewriteStageResponse` MUST include the executed `stage`, the `stage_index`, the stage-specific `stage_outcome`, and the `replay_digest` for that stage.
+- Stage log entries MUST be emitted with the same `stage` and `stage_index` values so each DPDA step can be replayed and audited independently.
 - Every scoring request MUST also emit an immutable audit record containing caller identity, tenant, active policy snapshot version, model version, retrieval sources, and final decision.
 - The explainability envelope MUST be derived from the minimized/redacted feature vector and the immutable policy snapshot, not from raw payloads.
 - Responses MUST remain bounded and MUST NOT return raw secrets, bearer tokens, or unredacted payload fragments.
@@ -469,7 +509,8 @@ service NeuroSymbolicService {
 
 #### Determinism requirements
 
-- The service MUST be deterministic for the same feature vector, contract version, active policy snapshot version, and deterministic seed.
+- The service MUST be deterministic for the same feature vector, contract version, active policy snapshot version, model snapshot version, stage, and deterministic seed.
+- The stage API MUST reproduce the same response for the same canonical input, stage index, and frozen snapshots.
 - The response MUST include a replay digest and a bounded confidence value.
 - The service output is advisory only and MUST NOT directly change security-relevant decisions.
 - Any recommendation intended for security-sensitive use MUST pass through validation before the policy engine sees it.

--- a/docs/reference/compiler-observability-contract.md
+++ b/docs/reference/compiler-observability-contract.md
@@ -43,14 +43,18 @@ The compiler observability surface MUST include:
 - `eigen_compiler_validation_failures_total{stage,reason}`
 - `eigen_compiler_aqo_digest_emitted_total{kind}`
 - `eigen_compiler_replay_compiles_total{kind}`
+- `eigen_compiler_symbolic_rewrite_stage_duration_seconds_count{stage,outcome}`
+- `eigen_compiler_symbolic_rewrite_stage_duration_seconds_sum{stage,outcome}`
 
 ### Allowed label values
 
 **rpc**
+
 - `CompileCircuit`
 - `CompileJob`
 
 **stage**
+
 - `request_validation`
 - `parse`
 - `validate_ast`
@@ -60,11 +64,22 @@ The compiler observability surface MUST include:
 - `canonicalize_aqo`
 - `emit`
 
+**symbolic_rewrite_stage**
+
+- `parse`
+- `normalize`
+- `candidate_generation`
+- `legality_check`
+- `rewrite`
+- `emit_aqo`
+
 **outcome**
+
 - `success`
 - `failure`
 
 **reason**
+
 - `invalid_argument`
 - `not_found`
 - `resource_exhausted`
@@ -72,6 +87,7 @@ The compiler observability surface MUST include:
 - `internal`
 
 **kind**
+
 - `aqo`
 - `duplicate`
 
@@ -93,6 +109,8 @@ Compiler logs MUST include stable correlation fields:
 - `elapsed_ms`
 - `aqo_sha256`
 - `source_sha256`
+
+When the symbolic rewrite pipeline is executed, logs MUST additionally include `rewrite_stage`, `rewrite_stage_index`, `rewrite_stage_outcome`, and `rewrite_stage_digest`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Formalized the symbolic rewrite pipeline as a stage-based API in:
    - docs/architecture/components/neuro-symbolic-core.md
    - docs/architecture/components/compiler-neuro-symbolic-advisor.md
    - docs/reference/api/grpc-internal.md
    - docs/reference/compiler-observability-contract.md
- Added explicit stage order: parse → normalize → candidate_generation → legality_check → rewrite → emit_aqo.
- Added independent stage logging and replay requirements so each DPDA step can be invoked and audited separately.

## Validation

- [ ] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: API | Metrics
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- A stable symbolic rewrite stage contract for the Neuro-Symbolic service.
- Canonical stage names and order for the DPDA rewrite pipeline.
- Dedicated compiler observability metrics and log fields for stage-level replay.

### Changed
- Compiler-facing docs now describe the rewrite pipeline as explicit deterministic stages.
- The internal gRPC reference now distinguishes stage-level rewrite handling from compatibility-wrapper scoring.

### Fixed
- Removed ambiguity around how the symbolic rewrite pipeline is invoked and logged independently.