### PR TITLE
Implemented a bounded symbolic candidate enumeration interface

### DIFF
--- a/docs/architecture/components/compiler-neuro-symbolic-advisor.md
+++ b/docs/architecture/components/compiler-neuro-symbolic-advisor.md
@@ -36,6 +36,8 @@ The advisor may:
 - explain why a deterministic compiler action was suggested,
 - contribute bounded replay evidence that can be validated by the compiler.
 
+The compiler must enumerate the candidate set first. That set is bounded, deterministic, and produced by the symbolic core. The advisor may rank only candidates whose legality flag is `true`; it must not invent new candidates, rename IDs, or promote an illegal candidate into the admissible set.
+
 The advisor may not:
 
 - override rule-engine approval,
@@ -53,6 +55,8 @@ When a suggestion is observed by the compiler boundary, the outcome must be reco
 - `accepted`
 - `rejected`
 - `transformed`
+
+When the compiler emits a bounded symbolic candidate set, each candidate entry must carry a stable `candidate_id`, a compact `features` object, and a `legal` flag. Downstream ranking logic must ignore any candidate whose `legal` flag is false.
 
 `transformed` is used when a suggestion is converted into a deterministic compiler action after rule-engine approval.
 

--- a/docs/architecture/components/compiler.md
+++ b/docs/architecture/components/compiler.md
@@ -183,6 +183,10 @@ Within the lowering boundary, the compiler also exposes a deterministic pass pip
 
 The semantic rule engine gates `validate_ast`, `rewrite_ir`, and `validate_lowering`. Advisory hints may influence ranking of rewrite candidates, but they do not change pass ordering, pass membership, or validation authority.
 
+The compiler also emits a bounded symbolic candidate set for model ranking. Each candidate is produced by the symbolic core, has a stable `candidate_id`, a compact feature map, and a legality flag. The emitted candidate set is serialized in compiler metadata as `symbolic_candidate_set_json`.
+
+Ranking layers may only score candidates whose `legal` flag is `true`. They must not invent additional candidates, rename emitted IDs, or treat illegal candidates as admissible.
+
 Optional deterministic rewrite or hardware-adaptation work may be added as long as it remains replay-safe and does not change the meaning of canonical AQO. Workload-family specific validation happens before lowering and may reject a valid-looking source when the selected profile forbids it.
 
 Pass ordering and pass outputs must remain stable for identical normalized inputs.
@@ -245,6 +249,8 @@ The compiler may use a neuro-symbolic advisor, but it must remain advisory only.
 - The final AQO payload must be valid without any neural-only field.
 - Advisor outcomes are recorded when they are accepted, rejected, or transformed into a deterministic compiler action.
 - Advisors can be swapped or disabled without breaking the compiler.
+
+When the symbolic core enumerates candidates for ranking, the compiler must expose only the bounded candidate set that it produced. The model may rank those candidates, but it must not invent or relabel candidates and it must not use illegal candidates as ranking inputs.
 
 The compiler must preserve determinism even when the advisor is enabled.
 

--- a/docs/reference/compiler-observability-contract.md
+++ b/docs/reference/compiler-observability-contract.md
@@ -126,6 +126,8 @@ Required payload fields:
 - `compiler_replay_json`
 - `compiler_replay_sha256`
 - `compiler_diagnostics_json`
+- `symbolic_candidate_set_json`
+- `symbolic_candidate_set_sha256`
 
 Those payloads MUST remain deterministic for identical inputs and MUST include only bounded trace and metric fields:
 
@@ -134,6 +136,8 @@ Those payloads MUST remain deterministic for identical inputs and MUST include o
 - label-family bounds: no request, trace, tenant, or project identifiers in metric labels
 
 `compiler_diagnostics_json` MUST summarize the compiler stage order, the resolved workload profile, and the backend contract in a machine-readable payload that remains stable for identical inputs.
+
+`symbolic_candidate_set_json` MUST summarize the bounded candidate set emitted by the symbolic core. Each candidate entry MUST expose a stable `candidate_id`, a compact feature map, and a boolean legality flag. Model ranking layers MUST only score candidates where `legal` is true.
 
 Validation failures MUST also carry structured gRPC details with:
 

--- a/src/services/eigen-compiler/src/eigen_compiler/compiler.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/compiler.py
@@ -25,6 +25,9 @@ from .validation import (
 
 AQO_VERSION = "1.0.0"
 
+_SYMBOLIC_CANDIDATE_ENUMERATION_VERSION = "1.0.0"
+_SYMBOLIC_CANDIDATE_BUDGET = 8
+
 _REPLAY_MODE_DETERMINISTIC = "deterministic"
 _NEURO_MODEL_VERSION_ENV = "EIGEN_NEURO_SYMBOLIC_MODEL_VERSION"
 _NEURO_POLICY_SNAPSHOT_VERSION_ENV = "EIGEN_NEURO_SYMBOLIC_POLICY_SNAPSHOT_VERSION"
@@ -147,6 +150,21 @@ class CompilerPassPipeline:
     aqo: dict[str, object]
 
 
+@dataclass(frozen=True)
+class SymbolicCandidate:
+    candidate_id: str
+    features: dict[str, object]
+    legal: bool
+    legality_reason: str
+
+
+@dataclass(frozen=True)
+class SymbolicCandidateSet:
+    version: str
+    candidate_budget: int
+    candidates: tuple[SymbolicCandidate, ...]
+
+
 @dataclass
 class CompilerValidationError(Exception):
     violations: tuple[FieldViolation, ...]
@@ -191,6 +209,7 @@ def _compiler_replay_bundle(
     compiler_stage_order: list[str],
     handoff_stage_order: list[str],
     pass_pipeline: CompilerPassPipeline,
+    symbolic_candidate_set: SymbolicCandidateSet,
 ) -> tuple[dict[str, object], str]:
     snapshot = _compiler_replay_snapshot()
     symbolic_rules = []
@@ -206,6 +225,8 @@ def _compiler_replay_bundle(
                 "output_sha256": hashlib.sha256(_canonical_json_bytes(record.output)).hexdigest(),
             }
         )
+    symbolic_candidates = _symbolic_candidate_set_payload(symbolic_candidate_set)
+    symbolic_candidates["candidate_ids"] = [candidate["candidate_id"] for candidate in symbolic_candidates["candidates"]]
 
     replay_bundle: dict[str, object] = {
         "contract_version": "1.0.0",
@@ -231,6 +252,7 @@ def _compiler_replay_bundle(
         "handoff_stage_order": handoff_stage_order,
         "symbolic_rules": symbolic_rules,
         "model_snapshot": snapshot,
+        "symbolic_candidate_set": symbolic_candidates,
         "model_recommendations": [],
     }
     replay_bundle_json = _canonical_json_text(replay_bundle)
@@ -437,6 +459,119 @@ def _validate_aqo_payload(aqo: dict[str, object]) -> tuple[FieldViolation, ...]:
             violations.append(FieldViolation(field=f"operations[{idx}].c", description=f"{op_name} must not include c"))
 
     return tuple(violations)
+
+
+def _count_measurements(operations: list[dict]) -> int:
+    return sum(1 for operation in operations if operation.get("op") == "MEASURE")
+
+
+def _symbolic_candidate_features(
+    *,
+    candidate_kind: str,
+    qubits: int,
+    operations: list[dict],
+    has_expectation: bool,
+    has_minimize: bool,
+    distributed: DistributedCompileConfig,
+) -> dict[str, object]:
+    return {
+        "candidate_kind": candidate_kind,
+        "qubits": qubits,
+        "operation_count": len(operations),
+        "measurement_count": _count_measurements(operations),
+        "terminal_measurement_present": bool(operations and operations[-1].get("op") == "MEASURE"),
+        "has_expectation": has_expectation,
+        "has_minimize": has_minimize,
+        "distributed_enabled": distributed.enabled,
+        "distributed_target": distributed.target or "",
+        "distributed_partition_count": distributed.partition_count or 0,
+    }
+
+
+def _symbolic_candidate_payload(candidate: SymbolicCandidate) -> dict[str, object]:
+    return {
+        "candidate_id": candidate.candidate_id,
+        "features": candidate.features,
+        "legal": candidate.legal,
+        "legality_reason": candidate.legality_reason,
+    }
+
+
+def _symbolic_candidate_set_payload(candidate_set: SymbolicCandidateSet) -> dict[str, object]:
+    candidates = [_symbolic_candidate_payload(candidate) for candidate in candidate_set.candidates]
+    return {
+        "version": candidate_set.version,
+        "candidate_budget": candidate_set.candidate_budget,
+        "candidate_count": len(candidates),
+        "legal_candidate_count": sum(1 for candidate in candidate_set.candidates if candidate.legal),
+        "candidates": candidates,
+    }
+
+
+def enumerate_symbolic_candidates(
+    *,
+    qubits: int,
+    operations: list[dict],
+    params: dict[str, dict[str, object]],
+    source_digest: str,
+    request_digest: str,
+    has_expectation: bool,
+    has_minimize: bool,
+    observable_bindings: dict[str, dict[str, object]],
+    expectation_annotation: dict[str, object] | None,
+    distributed: DistributedCompileConfig,
+) -> SymbolicCandidateSet:
+    """Enumerate the bounded symbolic candidate set used for ranking."""
+
+    lowered_ir = json.loads(json.dumps(operations, sort_keys=True, separators=(",", ":"), allow_nan=False))
+    rewritten_operations = _rewrite_terminal_measurement(lowered_ir, qubits)
+    candidate_variants = (
+        ("symbolic.keep_lowered_ir", "keep_lowered_ir", lowered_ir),
+        ("symbolic.rewrite_terminal_measurement", "terminal_measurement_normalized", rewritten_operations),
+    )
+    candidates: list[SymbolicCandidate] = []
+    for candidate_id, candidate_kind, candidate_operations in candidate_variants:
+        aqo_payload = _build_aqo_payload(
+            qubits=qubits,
+            operations=candidate_operations,
+            params=params,
+            source_digest=source_digest,
+            source_ref=None,
+            request_digest=request_digest,
+            has_expectation=has_expectation,
+            has_minimize=has_minimize,
+            observable_bindings=observable_bindings,
+            expectation_annotation=expectation_annotation,
+            distributed=distributed,
+        )
+        try:
+            _validate_lowering_payload(aqo_payload)
+            legal = True
+            legality_reason = "aqo_contract_valid"
+        except CompilerValidationError as exc:
+            legal = False
+            legality_reason = ",".join(sorted({violation.field for violation in exc.violations})) or "aqo_contract_invalid"
+        candidates.append(
+            SymbolicCandidate(
+                candidate_id=candidate_id,
+                features=_symbolic_candidate_features(
+                    candidate_kind=candidate_kind,
+                    qubits=qubits,
+                    operations=candidate_operations,
+                    has_expectation=has_expectation,
+                    has_minimize=has_minimize,
+                    distributed=distributed,
+                ),
+                legal=legal,
+                legality_reason=legality_reason,
+            )
+        )
+
+    return SymbolicCandidateSet(
+        version=_SYMBOLIC_CANDIDATE_ENUMERATION_VERSION,
+        candidate_budget=_SYMBOLIC_CANDIDATE_BUDGET,
+        candidates=tuple(candidates[:_SYMBOLIC_CANDIDATE_BUDGET]),
+    )
 
 
 def _encode_aqo_payload(aqo: dict[str, object]) -> bytes:
@@ -1224,6 +1359,22 @@ def compile_eigen_lang(
     options_json = _canonical_json_bytes(normalized_options).decode("utf-8")
     request_context_json = _canonical_json_bytes(asdict(normalized_request_context)).decode("utf-8")
 
+    symbolic_candidate_set = enumerate_symbolic_candidates(
+        qubits=qubits,
+        operations=operations,
+        params=params,
+        source_digest=source_digest,
+        request_digest=aqo_request_digest,
+        has_expectation=has_expectation,
+        has_minimize=has_minimize,
+        observable_bindings=observable_bindings,
+        expectation_annotation=expectation_annotation,
+        distributed=distributed,
+    )
+    symbolic_candidate_set_payload = _symbolic_candidate_set_payload(symbolic_candidate_set)
+    symbolic_candidate_set_json = _canonical_json_text(symbolic_candidate_set_payload)
+    symbolic_candidate_set_sha256 = hashlib.sha256(symbolic_candidate_set_json.encode("utf-8")).hexdigest()
+
     def _build_pass_pipeline() -> CompilerPassPipeline:
         try:
             return _build_compiler_pass_pipeline(
@@ -1298,6 +1449,7 @@ def compile_eigen_lang(
         compiler_stage_order=compiler_stage_order,
         handoff_stage_order=handoff_stage_order,
         pass_pipeline=pass_pipeline,
+        symbolic_candidate_set=symbolic_candidate_set,
     )
 
     decision_lineage = {
@@ -1362,6 +1514,7 @@ def compile_eigen_lang(
                 "stage_order": compiler_stage_order,
             },
         },
+        "symbolic_candidate_set": symbolic_candidate_set_payload,
     }
 
     metadata = {
@@ -1411,6 +1564,8 @@ def compile_eigen_lang(
         "backend_contract_version": "1.0.0",
         "backend_contract_json": backend_contract_json,
         "compiler_diagnostics_json": _canonical_json_text(compiler_diagnostics),
+        "symbolic_candidate_set_json": symbolic_candidate_set_json,
+        "symbolic_candidate_set_sha256": symbolic_candidate_set_sha256,
     }
     if has_minimize:
         metadata["hybrid_plan_marker"] = "minimize"

--- a/src/services/eigen-compiler/tests/test_compilation_rpc.py
+++ b/src/services/eigen-compiler/tests/test_compilation_rpc.py
@@ -75,6 +75,14 @@ def test_compile_circuit_happy_path(grpc_addr: str) -> None:
     assert resp.metadata["distributed.enabled"] == "false"
     assert resp.metadata["compiler_replay_json"]
     assert len(resp.metadata["compiler_replay_sha256"]) == 64
+    assert len(resp.metadata["symbolic_candidate_set_sha256"]) == 64
+
+    candidate_set = json.loads(resp.metadata["symbolic_candidate_set_json"])
+    assert candidate_set["version"] == "1.0.0"
+    assert candidate_set["candidate_budget"] == 8
+    assert candidate_set["candidate_count"] == len(candidate_set["candidates"])
+    assert candidate_set["candidate_count"] <= candidate_set["candidate_budget"]
+    assert all({"candidate_id", "features", "legal", "legality_reason"} <= set(candidate) for candidate in candidate_set["candidates"])
 
 
 def test_compile_job_uses_request_metadata_workload_profile(grpc_addr: str) -> None:
@@ -111,9 +119,12 @@ def test_compile_job_uses_request_metadata_workload_profile(grpc_addr: str) -> N
 
     diagnostics = json.loads(resp.metadata["compiler_diagnostics_json"])
     replay = json.loads(resp.metadata["compiler_replay_json"])
+    candidate_set = json.loads(resp.metadata["symbolic_candidate_set_json"])
     assert resp.metadata["workload_profile"] == "HybridWorkflow"
     assert diagnostics["workload_profile"] == "HybridWorkflow"
     assert replay["replay_mode"] == "deterministic"
+    assert diagnostics["symbolic_candidate_set"] == candidate_set
+    assert replay["symbolic_candidate_set"]["candidate_count"] == candidate_set["candidate_count"]
     assert [rule["rule"] for rule in replay["symbolic_rules"]] == [
         "compiler.source.lower_to_ir",
         "compiler.rewrite.terminal_measurement",


### PR DESCRIPTION
## Summary

- Implemented a bounded symbolic candidate enumeration interface in the compiler so model ranking consumes only candidates produced by the symbolic core.
- Added stable candidate IDs, compact feature payloads, and legality flags to compiler metadata and replay evidence.
- Updated compiler-facing architecture and observability docs to describe the new candidate contract.
- Added tests that validate the emitted candidate set and its serialization.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: API | AQO | Metrics
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Bounded symbolic candidate enumeration for model ranking with stable candidate IDs, features, and legality flags.
- Metadata fields for `symbolic_candidate_set_json` and `symbolic_candidate_set_sha256`.

### Changed
- Compiler diagnostics and replay evidence now include the symbolic candidate set emitted by the symbolic core.
- Documentation now states that ranking layers may only consume legal candidates produced by the compiler.

### Fixed
- Prevented downstream ranking logic from inventing candidates outside the symbolic core output.