### PR TITLE
Attached bounded provenance to every KB pattern returned by PatternMi…

### DIFF
--- a/docs/architecture/components/knowledge-base.md
+++ b/docs/architecture/components/knowledge-base.md
@@ -113,6 +113,17 @@ Required fields:
 | `metadata` | object | yes | Additional bounded metadata, never authoritative truth. |
 | `provenance` | object | yes | Attached provenance for this record. |
 
+`provenance` MUST be a bounded object with these subfields:
+
+| Field | Type | Required | Semantics |
+|---|---|---:|---|
+| `source` | object | yes | Snapshot and source-record lineage, including `snapshot_id`, `config_digest`, `source_record_ids`, and `source_record_count`. |
+| `version` | object | yes | Pattern versioning data, including `contract_version`, `pattern_miner_version`, and `compatibility_signature`. |
+| `compilation_context` | object | yes | Normalized context used to produce and rank the pattern, including the compatibility window, circuit/backend scope, query signature, query mode, candidate budget, and deterministic flag. |
+| `validation_status` | object | yes | Deterministic validation outcome for the record, including `state`, `compatible`, `canonical_eligible`, `selected`, `rank`, and `incompatibility_reasons`. |
+
+Allowed validation states include `catalogued`, `compatible`, `incompatible`, `selected`, `canonical`, and `explanation`.
+
 `compatibility_window` MUST contain the exact fields used by canonical selection:
 
 - `schema_version`

--- a/docs/reference/api/grpc-internal.md
+++ b/docs/reference/api/grpc-internal.md
@@ -268,6 +268,15 @@ message PatternRecord {
   ResponseProvenance provenance = 20;
 }
 
+`provenance` MUST be a bounded object with these subfields:
+
+- `source` — snapshot and source-record lineage, including `snapshot_id`, `config_digest`, `source_record_ids`, and `source_record_count`
+- `version` — pattern versioning data, including `contract_version`, `pattern_miner_version`, and `compatibility_signature`
+- `compilation_context` — normalized circuit/backend/query context, including `compatibility_window`, `query_signature`, `query_mode`, `candidate_budget`, and `deterministic`
+- `validation_status` — deterministic validation state, including `state`, `compatible`, `canonical_eligible`, `selected`, `rank`, and `incompatibility_reasons`
+
+Allowed validation states include `catalogued`, `compatible`, `incompatible`, `selected`, `canonical`, and `explanation`.
+
 message SearchSimilarRequest {
   string contract_version = 1;
   KnowledgeContext knowledge_context = 2;

--- a/src/services/neuro-symbolic-service/src/neuro_symbolic_service/pattern_miner.py
+++ b/src/services/neuro-symbolic-service/src/neuro_symbolic_service/pattern_miner.py
@@ -50,6 +50,121 @@ def _sha256_hex(payload: Any) -> str:
     return sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
 
 
+def _pattern_source_provenance(
+    *,
+    snapshot_id: str,
+    config_digest: str,
+    source_record_ids: list[str],
+) -> dict[str, Any]:
+    return {
+        "kind": "knowledge_base_snapshot",
+        "snapshot_id": snapshot_id,
+        "config_digest": config_digest,
+        "source_record_ids": source_record_ids,
+        "source_record_count": len(source_record_ids),
+    }
+
+
+def _pattern_version_provenance(
+    *,
+    compatibility_signature: str,
+) -> dict[str, Any]:
+    return {
+        "contract_version": PATTERN_CONTRACT_VERSION,
+        "pattern_miner_version": PATTERN_CONTRACT_VERSION,
+        "compatibility_signature": compatibility_signature,
+    }
+
+
+def _pattern_compilation_context(
+    *,
+    snapshot_id: str,
+    circuit_id: str,
+    backend_class: str,
+    compatibility_window: dict[str, str],
+    query_signature: str = "",
+    query: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    query_payload = query or {}
+    return {
+        "snapshot_id": snapshot_id,
+        "circuit_id": circuit_id,
+        "backend_class": backend_class,
+        "compatibility_window": compatibility_window,
+        "query_signature": query_signature,
+        "query_mode": _normalized_text(query_payload.get("query_mode", "")) or "structural",
+       "candidate_budget": int(query_payload.get("candidate_budget", PATTERN_MINER_MAX_CANDIDATES) or PATTERN_MINER_MAX_CANDIDATES),
+        "deterministic": bool(query_payload.get("deterministic", True)),
+        "semantic_hash": _normalized_text(query_payload.get("semantic_hash", "")),
+        "aqo_hash": _normalized_text(query_payload.get("aqo_hash", "")),
+        "schema_version": _normalized_text(query_payload.get("schema_version", "")),
+        "compiler_version": _normalized_text(query_payload.get("compiler_version", "")),
+        "aqo_version": _normalized_text(query_payload.get("aqo_version", "")),
+        "optimizer_version": _normalized_text(query_payload.get("optimizer_version", "")),
+        "policy_mode": _normalized_text(query_payload.get("policy_mode", "")) or "deterministic",
+        "policy_digest": _normalized_text(query_payload.get("policy_digest", "")),
+    }
+
+
+def _pattern_validation_status(
+    *,
+    state: str,
+    compatible: bool,
+    canonical_eligible: bool,
+    selected: bool,
+    rank: int,
+    incompatibility_reasons: Sequence[str],
+) -> dict[str, Any]:
+    return {
+        "state": state,
+        "compatible": compatible,
+        "canonical_eligible": canonical_eligible,
+        "selected": selected,
+        "rank": rank,
+        "incompatibility_reasons": list(incompatibility_reasons),
+    }
+
+
+def _pattern_provenance(
+    *,
+    snapshot_id: str,
+    config_digest: str,
+    source_record_ids: list[str],
+    compatibility_signature: str,
+    snapshot_state: str,
+    circuit_id: str,
+    backend_class: str,
+    compatibility_window: dict[str, str],
+    query_signature: str = "",
+    query: dict[str, Any] | None = None,
+    validation_status: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "source": _pattern_source_provenance(
+            snapshot_id=snapshot_id,
+            config_digest=config_digest,
+            source_record_ids=source_record_ids,
+        ),
+        "version": _pattern_version_provenance(compatibility_signature=compatibility_signature),
+        "compilation_context": _pattern_compilation_context(
+            snapshot_id=snapshot_id,
+            circuit_id=circuit_id,
+            backend_class=backend_class,
+            compatibility_window=compatibility_window,
+            query_signature=query_signature,
+            query=query,
+        ),
+        "validation_status": _pattern_validation_status(
+            state=snapshot_state,
+            compatible=True if validation_status is None else bool(validation_status.get("compatible", True)),
+            canonical_eligible=True if validation_status is None else bool(validation_status.get("canonical_eligible", True)),
+            selected=False if validation_status is None else bool(validation_status.get("selected", False)),
+            rank=0 if validation_status is None else int(validation_status.get("rank", 0) or 0),
+            incompatibility_reasons=() if validation_status is None else tuple(validation_status.get("incompatibility_reasons", []) or []),
+        ),
+    }
+
+
 def _digest_to_unit_interval(digest: str, *, start: int = 0, end: int = 16) -> float:
     raw = int(digest[start:end], 16)
     return raw / float(0xFFFFFFFFFFFFFFFF)
@@ -195,6 +310,11 @@ class PatternMinerService:
         for rank, candidate in enumerate(selected_candidates, start=1):
             candidate["rank"] = rank
             candidate["selected"] = candidate["pattern_id"] == canonical_pattern_id if canonical_candidate else False
+            validation_status = dict(candidate["provenance"]["validation_status"])
+            validation_status["selected"] = candidate["selected"]
+            validation_status["rank"] = rank
+            validation_status["state"] = "selected" if candidate["selected"] else validation_status["state"]
+            candidate["provenance"] = {**candidate["provenance"], "validation_status": validation_status}
 
         canonical_pattern = None
         if canonical_candidate is not None:
@@ -204,6 +324,11 @@ class PatternMinerService:
             canonical_pattern["canonical_template_ref"] = f"kb://patterns/{canonical_pattern['pattern_id']}"
             canonical_pattern["explanation_ref"] = f"kb://patterns/{canonical_pattern['pattern_id']}/explanation"
             canonical_pattern["rank"] = 1
+            canonical_validation_status = dict(canonical_pattern["provenance"]["validation_status"])
+            canonical_validation_status["state"] = "canonical"
+            canonical_validation_status["selected"] = True
+            canonical_validation_status["rank"] = 1
+            canonical_pattern["provenance"] = {**canonical_pattern["provenance"], "validation_status": canonical_validation_status}
 
         incompatible_reasons = self._collect_incompatibility_reasons(scored_candidates)
         fallback_used = canonical_pattern is None
@@ -242,6 +367,25 @@ class PatternMinerService:
                 "Exact compatibility window matched a canonical template."
                 if canonical_candidate is not None
                 else "No canonical template matched the requested compatibility window."
+            ),
+            "provenance": _pattern_provenance(
+                snapshot_id=snapshot_id,
+                config_digest=snapshot["config_digest"],
+                source_record_ids=sorted({rid for candidate in selected_candidates for rid in candidate["source_record_ids"]}),
+                compatibility_signature=query_signature,
+                snapshot_state="explanation",
+                circuit_id=circuit_id,
+                backend_class=backend_class,
+                compatibility_window=query_window,
+                query_signature=query_signature,
+                query=query,
+                validation_status={
+                    "compatible": canonical_candidate is not None,
+                    "canonical_eligible": canonical_candidate is not None,
+                    "selected": False,
+                    "rank": 0,
+                    "incompatibility_reasons": incompatible_reasons,
+                },
             ),
         }
 
@@ -434,6 +578,16 @@ class PatternMinerService:
                         "config_digest": snapshot["config_digest"],
                         "source_record_count": len(source_record_ids),
                     },
+                    "provenance": _pattern_provenance(
+                        snapshot_id=snapshot_id,
+                        config_digest=snapshot["config_digest"],
+                        source_record_ids=source_record_ids,
+                        compatibility_signature=compatibility_signature,
+                        snapshot_state="catalogued",
+                        circuit_id=circuit_id,
+                        backend_class=backend_class,
+                        compatibility_window=compatibility_window,
+                    ),
                 }
             )
 
@@ -543,6 +697,25 @@ class PatternMinerService:
                     "compatibility_ratio": compatibility_ratio,
                     "support_ratio": round(support_ratio, 6),
                 },
+                "provenance": _pattern_provenance(
+                    snapshot_id=pattern["provenance"]["source"]["snapshot_id"],
+                    config_digest=pattern["provenance"]["source"]["config_digest"],
+                    source_record_ids=list(pattern["source_record_ids"]),
+                    compatibility_signature=pattern["compatibility_signature"],
+                    snapshot_state="compatible" if compatible else "incompatible",
+                    circuit_id=pattern["circuit_id"],
+                    backend_class=pattern["backend_class"],
+                    compatibility_window=pattern["compatibility_window"],
+                    query_signature=query_signature,
+                    query=query,
+                    validation_status={
+                        "compatible": compatible,
+                        "canonical_eligible": compatible,
+                        "selected": False,
+                        "rank": 0,
+                        "incompatibility_reasons": compatibility_checks["incompatibility_reasons"],
+                    },
+                ),
             }
         )
         return candidate

--- a/src/services/neuro-symbolic-service/tests/test_pattern_miner_service.py
+++ b/src/services/neuro-symbolic-service/tests/test_pattern_miner_service.py
@@ -110,6 +110,8 @@ def test_pattern_miner_ingest_is_idempotent_and_deterministic() -> None:
     mined_first = service.mine_patterns(snapshot_id="s1", tenant_id="tenant-a", project_id="project-a")
     mined_second = service.mine_patterns(snapshot_id="s1", tenant_id="tenant-a", project_id="project-a")
     assert mined_first == mined_second
+    assert mined_first["patterns"][0]["provenance"]["source"]["snapshot_id"] == "s1"
+    assert mined_first["patterns"][0]["provenance"]["validation_status"]["state"] == "catalogued"
 
 
 def test_recommendation_payload_has_versioned_contract_and_provenance_links() -> None:
@@ -163,6 +165,13 @@ def test_get_pattern_returns_canonical_template_and_separates_candidates() -> No
     assert result["candidate_patterns"][0]["selected"] is True
     assert result["candidate_patterns"][0]["pattern_family"] == "alpha"
     assert result["candidate_patterns"][0]["rank"] == 1
+    assert result["candidate_patterns"][0]["provenance"]["source"]["snapshot_id"] == "s1"
+    assert result["candidate_patterns"][0]["provenance"]["version"]["contract_version"] == "1.0.0"
+    assert result["candidate_patterns"][0]["provenance"]["compilation_context"]["query_mode"] == "structural"
+    assert result["candidate_patterns"][0]["provenance"]["validation_status"]["state"] == "selected"
+    assert result["candidate_patterns"][0]["provenance"]["validation_status"]["selected"] is True
+    assert result["canonical_pattern"]["provenance"]["validation_status"]["state"] == "canonical"
+    assert result["explanation_pattern"]["provenance"]["validation_status"]["state"] == "explanation"
     assert len(result["candidate_patterns"]) <= 8
     assert any(
         candidate["pattern_family"] == "beta"
@@ -205,6 +214,9 @@ def test_get_pattern_returns_diagnostics_when_no_canonical_pattern_exists() -> N
     assert result["diagnostics"]["fallback_reason"] == "NO_CANONICAL_PATTERN"
     assert "COMPILER_MISMATCH" in result["diagnostics"]["incompatibility_reason_codes"]
     assert all(candidate["selected"] is False for candidate in result["candidate_patterns"])
+    assert result["candidate_patterns"][0]["provenance"]["validation_status"]["state"] == "incompatible"
+    assert result["candidate_patterns"][0]["provenance"]["validation_status"]["selected"] is False
+    assert result["explanation_pattern"]["provenance"]["validation_status"]["state"] == "explanation"
     assert result["explanation_pattern"]["canonical_pattern_id"] == ""
     assert result["candidate_patterns"][0]["pattern_kind"] == "candidate"
 


### PR DESCRIPTION
…nerService

## Summary

- Attached bounded provenance to every KB pattern returned by PatternMinerService.
- Added provenance payloads for source lineage, versioning, compilation context, and validation status to catalogued, candidate, canonical, and explanation pattern records.
- Updated the KB architecture and internal gRPC docs to describe the new PatternRecord.provenance contract.
- Extended pattern miner tests to assert provenance is present and stable.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: API
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Provenance attached to every KB `PatternRecord`, including source lineage, version metadata, compilation context, and validation status.

### Changed
- Pattern retrieval responses now carry richer explainability and audit metadata on each returned pattern.
- KB documentation now defines the provenance sub-structure for pattern records.

### Fixed
- Patterns returned to the compiler are now directly explainable and auditable without relying on external context.