### PR TITLE
Define graph schema for logical compiler structures

### DIFF
--- a/docs/architecture/components/compiler.md
+++ b/docs/architecture/components/compiler.md
@@ -57,6 +57,8 @@ The compiler metadata contract is also stable and deterministic. The canonical n
 - `compiler_replay_json`
 - `compiler_replay_sha256`
 - `backend_contract_json`
+- `logical_graph_schema_json`
+- `logical_graph_schema_sha256`
 
 These are compiler metadata fields, not AQO top-level fields.
 
@@ -186,6 +188,8 @@ The semantic rule engine gates `validate_ast`, `rewrite_ir`, and `validate_lower
 The compiler also emits a bounded symbolic candidate set for model ranking. Each candidate is produced by the symbolic core, has a stable `candidate_id`, a compact feature map, and a legality flag. The emitted candidate set is serialized in compiler metadata as `symbolic_candidate_set_json`.
 
 Ranking layers may only score candidates whose `legal` flag is `true`. They must not invent additional candidates, rename emitted IDs, or treat illegal candidates as admissible.
+
+The compiler also emits one canonical logical graph schema for AST, IR, and DPDA-state structures. The schema is serialized in compiler metadata as `logical_graph_schema_json` and hashed as `logical_graph_schema_sha256`. It is the same schema used for training and inference, and it defines bounded node and edge fields, canonical labels, and deterministic ordering rules for all logical compiler graph representations.
 
 Optional deterministic rewrite or hardware-adaptation work may be added as long as it remains replay-safe and does not change the meaning of canonical AQO. Workload-family specific validation happens before lowering and may reject a valid-looking source when the selected profile forbids it.
 

--- a/docs/reference/compiler-observability-contract.md
+++ b/docs/reference/compiler-observability-contract.md
@@ -128,6 +128,8 @@ Required payload fields:
 - `compiler_diagnostics_json`
 - `symbolic_candidate_set_json`
 - `symbolic_candidate_set_sha256`
+- `logical_graph_schema_json`
+- `logical_graph_schema_sha256`
 
 Those payloads MUST remain deterministic for identical inputs and MUST include only bounded trace and metric fields:
 
@@ -138,6 +140,8 @@ Those payloads MUST remain deterministic for identical inputs and MUST include o
 `compiler_diagnostics_json` MUST summarize the compiler stage order, the resolved workload profile, and the backend contract in a machine-readable payload that remains stable for identical inputs.
 
 `symbolic_candidate_set_json` MUST summarize the bounded candidate set emitted by the symbolic core. Each candidate entry MUST expose a stable `candidate_id`, a compact feature map, and a boolean legality flag. Model ranking layers MUST only score candidates where `legal` is true.
+
+`logical_graph_schema_json` MUST describe the canonical graph schema used by the compiler for AST, IR, and DPDA state graphs. The schema MUST be shared by training and inference consumers, MUST define bounded node and edge fields, MUST define stable labels for each graph kind, and MUST preserve deterministic ordering semantics. `logical_graph_schema_sha256` MUST be the SHA-256 digest of that canonical JSON payload.
 
 Validation failures MUST also carry structured gRPC details with:
 

--- a/src/services/eigen-compiler/src/eigen_compiler/compiler.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/compiler.py
@@ -210,6 +210,7 @@ def _compiler_replay_bundle(
     handoff_stage_order: list[str],
     pass_pipeline: CompilerPassPipeline,
     symbolic_candidate_set: SymbolicCandidateSet,
+    logical_graph_schema: dict[str, object],
 ) -> tuple[dict[str, object], str]:
     snapshot = _compiler_replay_snapshot()
     symbolic_rules = []
@@ -253,6 +254,7 @@ def _compiler_replay_bundle(
         "symbolic_rules": symbolic_rules,
         "model_snapshot": snapshot,
         "symbolic_candidate_set": symbolic_candidates,
+        "logical_graph_schema": logical_graph_schema,
         "model_recommendations": [],
     }
     replay_bundle_json = _canonical_json_text(replay_bundle)
@@ -505,6 +507,93 @@ def _symbolic_candidate_set_payload(candidate_set: SymbolicCandidateSet) -> dict
         "candidate_count": len(candidates),
         "legal_candidate_count": sum(1 for candidate in candidate_set.candidates if candidate.legal),
         "candidates": candidates,
+    }
+
+
+def _logical_graph_schema_payload() -> dict[str, object]:
+    """Return the canonical logical graph schema shared by training and inference.
+
+    The schema intentionally stays bounded and declarative: it specifies the
+    required node/edge fields, the allowed label taxonomies, and the
+    deterministic ordering rules used when logical compiler structures are
+    serialized for downstream consumers.
+    """
+
+    return {
+        "contract_version": "1.0.0",
+        "schema_version": "logical-compiler-graph-v1",
+        "canonical_format": "eigen.logical-graph-json",
+        "shared_between_training_and_inference": True,
+        "graph_kinds": ["ast", "ir", "dpda_state"],
+        "nodes": {
+            "required_fields": ["id", "kind", "label", "attributes"],
+            "optional_fields": ["metadata"],
+            "attribute_contract": {
+                "type": "bounded_json_object",
+                "value_types": ["string", "integer", "number", "boolean", "array", "object"],
+                "ordering": "deterministic",
+                "unknown_fields": "allowed_but_bounded",
+            },
+        },
+        "edges": {
+            "required_fields": ["id", "source", "target", "kind", "label", "attributes"],
+            "optional_fields": ["metadata"],
+            "attribute_contract": {
+                "type": "bounded_json_object",
+                "value_types": ["string", "integer", "number", "boolean", "array", "object"],
+                "ordering": "deterministic",
+                "unknown_fields": "allowed_but_bounded",
+            },
+        },
+        "labels": {
+            "ast": [
+                "module",
+                "function",
+                "async_function",
+                "decorator",
+                "call",
+                "name",
+                "constant",
+                "assign",
+                "argument",
+                "keyword",
+            ],
+            "ir": [
+                "program",
+                "operation",
+                "parameter",
+                "observable",
+                "measurement",
+                "rewrite_candidate",
+                "validation_gate",
+            ],
+            "dpda_state": [
+                "parse",
+                "normalize",
+                "candidate_generation",
+                "legality_check",
+                "rewrite",
+                "emit_aqo",
+                "accept",
+                "reject",
+            ],
+        },
+        "edge_kinds": {
+            "ast": ["child", "decorator_of", "argument_of", "keyword_of", "binding"],
+            "ir": ["sequence", "dataflow", "control", "rewrite", "validation"],
+            "dpda_state": ["transition", "accept", "reject", "fallback"],
+        },
+        "ordering": {
+            "nodes": ["id"],
+            "edges": ["id"],
+            "labels": ["graph_kind", "kind", "label"],
+        },
+        "provenance": {
+            "source": "eigen-compiler",
+            "replay_safe": True,
+            "training_safe": True,
+            "inference_safe": True,
+        },
     }
 
 
@@ -1374,7 +1463,10 @@ def compile_eigen_lang(
     symbolic_candidate_set_payload = _symbolic_candidate_set_payload(symbolic_candidate_set)
     symbolic_candidate_set_json = _canonical_json_text(symbolic_candidate_set_payload)
     symbolic_candidate_set_sha256 = hashlib.sha256(symbolic_candidate_set_json.encode("utf-8")).hexdigest()
-
+    logical_graph_schema_payload = _logical_graph_schema_payload()
+    logical_graph_schema_json = _canonical_json_text(logical_graph_schema_payload)
+    logical_graph_schema_sha256 = hashlib.sha256(logical_graph_schema_json.encode("utf-8")).hexdigest()
+    
     def _build_pass_pipeline() -> CompilerPassPipeline:
         try:
             return _build_compiler_pass_pipeline(
@@ -1450,6 +1542,7 @@ def compile_eigen_lang(
         handoff_stage_order=handoff_stage_order,
         pass_pipeline=pass_pipeline,
         symbolic_candidate_set=symbolic_candidate_set,
+        logical_graph_schema=logical_graph_schema_payload,
     )
 
     decision_lineage = {
@@ -1515,6 +1608,7 @@ def compile_eigen_lang(
             },
         },
         "symbolic_candidate_set": symbolic_candidate_set_payload,
+        "logical_graph_schema": logical_graph_schema_payload,
     }
 
     metadata = {
@@ -1566,6 +1660,8 @@ def compile_eigen_lang(
         "compiler_diagnostics_json": _canonical_json_text(compiler_diagnostics),
         "symbolic_candidate_set_json": symbolic_candidate_set_json,
         "symbolic_candidate_set_sha256": symbolic_candidate_set_sha256,
+        "logical_graph_schema_json": logical_graph_schema_json,
+        "logical_graph_schema_sha256": logical_graph_schema_sha256,
     }
     if has_minimize:
         metadata["hybrid_plan_marker"] = "minimize"

--- a/src/services/eigen-compiler/tests/test_handoff_contract.py
+++ b/src/services/eigen-compiler/tests/test_handoff_contract.py
@@ -92,6 +92,8 @@ def _build_handoff_bundle(result, *, optimizer_contract_version: str = "1.0.0") 
         "decision_lineage_json": result.metadata["decision_lineage_json"],
         "observability_json": result.metadata["observability_json"],
         "explainability_json": result.metadata["explainability_json"],
+        "logical_graph_schema_json": result.metadata["logical_graph_schema_json"],
+        "logical_graph_schema_sha256": result.metadata["logical_graph_schema_sha256"],
     }
     return {"envelope": envelope, "input_aqo": aqo_json, "compiler_metadata": compiler_metadata}
 
@@ -141,10 +143,12 @@ def test_handoff_schema_is_versioned_and_bounded() -> None:
     decision_lineage = json.loads(handoff["compiler_metadata"]["decision_lineage_json"])
     observability = json.loads(handoff["compiler_metadata"]["observability_json"])
     explainability = json.loads(handoff["compiler_metadata"]["explainability_json"])
-    
+    logical_graph_schema = json.loads(handoff["compiler_metadata"]["logical_graph_schema_json"])
+
     assert replay_bundle["replay_mode"] == "deterministic"
     assert replay_bundle["model_snapshot"] == {"model_version": "", "policy_snapshot_version": ""}
     assert replay_bundle["symbolic_rules"][0]["rule"] == "compiler.source.lower_to_ir"
+    assert replay_bundle["logical_graph_schema"]["shared_between_training_and_inference"] is True
     assert pass_pipeline["version"] == "1.0.0"
     assert [item["name"] for item in pass_pipeline["passes"]] == [
         "lower_to_ir",
@@ -187,6 +191,11 @@ def test_handoff_schema_is_versioned_and_bounded() -> None:
         "request_sha256",
         "replay_bundle_sha256",
     ]
+    assert logical_graph_schema["schema_version"] == "logical-compiler-graph-v1"
+    assert logical_graph_schema["graph_kinds"] == ["ast", "ir", "dpda_state"]
+    assert logical_graph_schema["nodes"]["required_fields"] == ["id", "kind", "label", "attributes"]
+    assert logical_graph_schema["edges"]["required_fields"] == ["id", "source", "target", "kind", "label", "attributes"]
+    assert logical_graph_schema["labels"]["ast"][0] == "module"
 
 
 def test_stable_identifier_propagation_across_boundary_is_deterministic() -> None:
@@ -203,6 +212,8 @@ def test_stable_identifier_propagation_across_boundary_is_deterministic() -> Non
     for key in ("compiler_passes_json", "compiler_replay_json", "compiler_replay_sha256", "decision_lineage_json", "observability_json", "explainability_json"):
         assert first.metadata[key] == second.metadata[key]
         assert first_handoff["compiler_metadata"][key] == second_handoff["compiler_metadata"][key]
+    assert first.metadata["logical_graph_schema_json"] == second.metadata["logical_graph_schema_json"]
+    assert first.metadata["logical_graph_schema_sha256"] == second.metadata["logical_graph_schema_sha256"]
 
     assert first_handoff == second_handoff
     assert _canonical_handoff_digest(first_handoff) == _canonical_handoff_digest(second_handoff)


### PR DESCRIPTION
## Summary

- Implemented as a patch that adds a canonical logical graph schema (logical_graph_schema_json / logical_graph_schema_sha256) to the compiler metadata and documents the schema in the compiler and observability contracts. The issue explicitly calls for one canonical graph schema for AST / IR / DPDA state graphs, shared by training and inference, and the repo already uses bounded compiler metadata and graph-encoding contract surfaces for this boundary.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: API
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Canonical logical graph schema for compiler AST / IR / DPDA state graphs.
- Canonical graph schema metadata hash for deterministic replay and training/inference parity.

### Changed
- Compiler metadata now carries a bounded logical graph schema payload alongside existing replay metadata.
- Compiler and observability contracts now describe the shared graph schema boundary.

### Fixed
- None