### PR TITLE
Added a canonical rewrite-outcome taxonomy

### DIFF
--- a/docs/architecture/components/knowledge-base.md
+++ b/docs/architecture/components/knowledge-base.md
@@ -13,7 +13,7 @@ The Knowledge Base exposes two distinct behaviors:
 
 Runtime decision logs are append-only and MUST preserve the audit trail fields required by the neuro-symbolic compliance contract: caller identity, tenant, policy snapshot version, model version, retrieval sources, and final decision.
 
-Compiler traces are indexed into the KB as replay-safe records and decision logs so later queries can bind to trace ID, trace digest, and pattern signature. Both accepted and rejected rewrite paths MUST be retained.
+Compiler traces are indexed into the KB as replay-safe records and decision logs so later queries can bind to trace ID, trace digest, and pattern signature. The canonical rewrite-outcome taxonomy is `accepted`, `rejected`, `equivalent`, and `unsafe`; KB records and model-training corpora MUST use that same label set consistently. Both accepted and rejected rewrite paths MUST be retained, and equivalent/unsafe outcomes MUST be preserved for ranking and safety analysis.
 
 This document defines the retrieval semantics for both candidate similarity search and canonical pattern lookup.
 The boundary between KB retrieval, deterministic replay, and ML-advisor consumption is defined in `docs/architecture/components/neuro-symbolic-core.md`.

--- a/docs/architecture/contract-map.md
+++ b/docs/architecture/contract-map.md
@@ -210,9 +210,10 @@ The stable KB request/response contract used by compiler queries is defined in `
 #### Responsibilities
 
 - store circuit/task records and traces,
+- store canonical rewrite-outcome labels with provenance,
 - similarity search (vector index),
 - structural queries (metrics filtering),
-- training dataset assembly and governance.
+- training dataset assembly and governance using the canonical rewrite-outcome taxonomy in `docs/reference/rewrite-outcome-taxonomy.md`.
 
 ---
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -382,11 +382,14 @@ Responsibilities:
 
 The Knowledge Base (KB) stores reusable execution intelligence and records used by the platform and developer tooling.
 
+The canonical rewrite-outcome taxonomy is defined in `reference/rewrite-outcome-taxonomy.md`; KB annotation, ranking, and review workflows MUST use the same label set without aliases or intermediate values.
+
 KB-facing APIs now live in `neuro-symbolic-service` and are no longer owned by `system-api`.
 
 Target capabilities:
 
 - circuit and artifact reuse,
+- rewrite-outcome labeling for ranking and safety,
 - optimization reuse,
 - analytics and trace-backed auditability,
 - future integration with intelligent scheduling.
@@ -398,6 +401,7 @@ Target capabilities:
 Eigen OS architecture includes forward-compatible services for:
 
 - dataset ingestion and caching (Dataset Pipeline),
+- model-training corpora that preserve the canonical rewrite-outcome taxonomy,
 - continuous learning signals and model refresh,
 - optimizer integration (e.g., GNN optimizer).
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -12,6 +12,7 @@ They should stay precise, explicit, and implementation-agnostic.
 - Benchmark Run API: [`api/benchmark-run.md`](api/benchmark-run.md)
 - Benchmark observability contract: [`benchmark-observability-contract.md`](benchmark-observability-contract.md)
 - Internal API: [`api/grpc-internal.md`](api/grpc-internal.md)
+- Rewrite outcome taxonomy: [`rewrite-outcome-taxonomy.md`](rewrite-outcome-taxonomy.md)
 - Error model: [`error-model.md`](error-model.md)
 - Error mapping: [`error-mapping.md`](error-mapping.md)
 - Multi-device execution (split/merge): [`multi-device-execution-contract.md`](multi-device-execution-contract.md)

--- a/docs/reference/rewrite-outcome-taxonomy.md
+++ b/docs/reference/rewrite-outcome-taxonomy.md
@@ -1,0 +1,42 @@
+# Rewrite Outcome Taxonomy
+
+**Document status:** Normative  
+**Subsystem:** Knowledge Base, Ranking, Model Training  
+**Contract version:** `1.0.0`
+
+This document defines the canonical rewrite-outcome labels used by KB records, ranking pipelines, review tooling, and model-training datasets.
+
+The canonical label set is exhaustive. Implementations MUST use exactly one of the following labels for each rewrite-outcome record:
+
+| Label | Meaning |
+|---|---|
+| `accepted` | The rewrite preserves intent and satisfies product, quality, and policy constraints. |
+| `rejected` | The rewrite must not be used because it fails product or quality constraints. |
+| `equivalent` | The rewrite is semantically equivalent to the source for downstream use. |
+| `unsafe` | The rewrite violates safety, policy, or harm-prevention constraints and MUST be excluded from positive serving or training signals. |
+
+---
+
+## 1. Normative requirements
+
+- Labels MUST be stored as lower-case ASCII strings.
+- Labels MUST NOT be aliased, translated, camel-cased, or expanded into intermediate values.
+- One record MUST carry exactly one canonical rewrite-outcome label.
+- Unknown labels MUST be rejected at ingestion.
+- Derived analytics MAY group labels, but the source-of-truth record MUST preserve the canonical label.
+
+---
+
+## 2. Usage across KB and model training
+
+- KB records and annotation tools MUST use the same four labels.
+- Model training datasets MUST consume the same labels without renaming them.
+- `unsafe` MUST be treated as a hard safety exclusion in ranking and training pipelines.
+- `accepted`, `rejected`, and `equivalent` MAY be used as supervised signals only when provenance is preserved.
+
+---
+
+## 3. Compatibility
+
+- Adding this taxonomy is backward-compatible for consumers that already treat labels as opaque strings.
+- Consumers that validate label enums MUST be updated before new data is ingested.

--- a/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
@@ -93,6 +93,7 @@ _AQO_DIGEST_TOTALS: Counter[tuple[tuple[str, str], ...]] = Counter()
 _REPLAY_TOTALS: Counter[tuple[tuple[str, str], ...]] = Counter()
 _SEEN_AQO_DIGESTS: set[str] = set()
 _OBSERVABILITY_CONTRACT_VERSION = "1.0.0"
+_REWRITE_OUTCOME_TAXONOMY = ("accepted", "rejected", "equivalent", "unsafe")
 
 _REDACTED_VALUE = "[REDACTED]"
 _MASKED_EMAIL_VALUE = "[REDACTED_EMAIL]"
@@ -236,6 +237,33 @@ def _bump(counter: Counter[tuple[tuple[str, str], ...]], **labels: str) -> None:
 
 def _stable_json(value: object) -> str:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+
+
+def _normalize_rewrite_outcome(value: object, *, field_name: str) -> str:
+    text = str(value).strip().lower()
+    if text not in _REWRITE_OUTCOME_TAXONOMY:
+        allowed = ", ".join(_REWRITE_OUTCOME_TAXONOMY)
+        raise ValueError(f"{field_name} must be one of: {allowed}")
+    return text
+
+
+def _rewrite_outcome_for_candidate(
+    candidate: dict[str, object],
+    *,
+    selected: bool,
+    result_present: bool,
+    candidate_legal: bool,
+) -> str:
+    explicit = candidate.get("rewrite_outcome")
+    if explicit not in (None, ""):
+        return _normalize_rewrite_outcome(explicit, field_name="candidate.rewrite_outcome")
+    if bool(candidate.get("unsafe", False)) or str(candidate.get("safety_status", "")).strip().lower() == "unsafe":
+        return "unsafe"
+    if bool(candidate.get("equivalent", False)) or str(candidate.get("rewrite_relation", "")).strip().lower() == "equivalent":
+        return "equivalent"
+    if selected and candidate_legal and result_present:
+        return "accepted"
+    return "rejected"
 
 
 def _bump_stage(stage: str, elapsed_seconds: float, outcome: str) -> None:
@@ -572,7 +600,12 @@ def _kb_index_compiler_trace(
             if not candidate_id:
                 continue
             candidate_legal = bool(candidate.get("legal", False))
-            rewrite_outcome = "accepted" if candidate_id == pattern_signature and candidate_legal and result is not None else "rejected"
+            rewrite_outcome = _rewrite_outcome_for_candidate(
+                candidate,
+                selected=candidate_id == pattern_signature,
+                result_present=result is not None,
+                candidate_legal=candidate_legal,
+            )
             feature_snapshot = {
                 "trace_id": request_context.get("trace_id", "").strip(),
                 "request_id": request_context.get("request_id", "").strip(),

--- a/src/services/eigen-compiler/tests/test_compilation_rpc.py
+++ b/src/services/eigen-compiler/tests/test_compilation_rpc.py
@@ -43,12 +43,41 @@ from eigen.internal.v1 import kernel_gateway_pb2 as kernel_pb  # noqa: E402
 from eigen.internal.v1 import neuro_symbolic_service_pb2_grpc as nsc_pb_grpc  # noqa: E402
 from eigen.internal.v1 import types_pb2 as types_pb  # noqa: E402
 
+from eigen_compiler.grpc_impl import _rewrite_outcome_for_candidate  # noqa: E402
+
 
 def _enum_value(module, *names: str) -> int:
     for name in names:
         if hasattr(module, name):
             return int(getattr(module, name))
     raise AttributeError(f"None of enum names exist: {names}")
+
+
+def test_rewrite_outcome_helper_covers_canonical_taxonomy() -> None:
+    assert _rewrite_outcome_for_candidate(
+        {"rewrite_outcome": "accepted"},
+        selected=True,
+        result_present=True,
+        candidate_legal=True,
+    ) == "accepted"
+    assert _rewrite_outcome_for_candidate(
+        {"rewrite_outcome": "rejected"},
+        selected=False,
+        result_present=True,
+        candidate_legal=False,
+    ) == "rejected"
+    assert _rewrite_outcome_for_candidate(
+        {"rewrite_outcome": "equivalent"},
+        selected=False,
+        result_present=True,
+        candidate_legal=True,
+    ) == "equivalent"
+    assert _rewrite_outcome_for_candidate(
+        {"rewrite_outcome": "unsafe"},
+        selected=False,
+        result_present=False,
+        candidate_legal=False,
+    ) == "unsafe"
 
 
 def _extract_bad_request(err: grpc.RpcError) -> error_details_pb2.BadRequest:

--- a/src/services/neuro-symbolic-service/src/neuro_symbolic_service/knowledge_base.py
+++ b/src/services/neuro-symbolic-service/src/neuro_symbolic_service/knowledge_base.py
@@ -47,6 +47,8 @@ _REDACTED_VALUE = "[REDACTED]"
 _MASKED_EMAIL_VALUE = "[REDACTED_EMAIL]"
 _MASKED_PHONE_VALUE = "[REDACTED_PHONE]"
 _MASKED_IDENTIFIER_VALUE = "[REDACTED_ID]"
+_REWRITE_OUTCOME_TAXONOMY = ("accepted", "rejected", "equivalent", "unsafe")
+_TRAINING_POSITIVE_REWRITE_OUTCOMES = {"accepted", "equivalent"}
 _REDACT_DELETE_KEYS = {
     "authorization",
     "auth_header",
@@ -97,6 +99,47 @@ _EMAIL_RE = re.compile(r"(?i)\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}\b")
 _PHONE_RE = re.compile(r"(?i)(?<!\d)(?:\+?\d{1,3}[-.\s]?)?(?:\(?\d{2,4}\)?[-.\s]?){1,3}\d{2,4}(?!\d)")
 _BEARER_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{8,}\b")
 _UUID_RE = re.compile(r"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b")
+
+def _normalize_rewrite_outcome(value: Any, *, field_name: str) -> str:
+    text = str(value).strip().lower()
+    if text not in _REWRITE_OUTCOME_TAXONOMY:
+        allowed = ", ".join(_REWRITE_OUTCOME_TAXONOMY)
+        raise ValueError(f"{field_name} must be one of: {allowed}")
+    return text
+
+
+def _training_dataset_record_count(records: list[dict[str, Any]]) -> int:
+    labeled_count = 0
+    saw_label = False
+    for record in records:
+        payload = record.get("payload")
+        if not isinstance(payload, dict):
+            continue
+        if "rewrite_outcome" not in payload:
+            continue
+        saw_label = True
+        if _normalize_rewrite_outcome(payload["rewrite_outcome"], field_name="records[].payload.rewrite_outcome") in _TRAINING_POSITIVE_REWRITE_OUTCOMES:
+            labeled_count += 1
+    return labeled_count if saw_label else len(records)
+
+
+def _normalize_rewrite_outcome_tree(value: Any, *, field_name: str) -> Any:
+    if isinstance(value, dict):
+        normalized: dict[str, Any] = {}
+        for key, nested in value.items():
+            nested_field = f"{field_name}.{key}" if field_name else str(key)
+            if str(key).strip().lower() == "rewrite_outcome":
+                normalized[key] = _normalize_rewrite_outcome(nested, field_name=nested_field)
+            else:
+                normalized[key] = _normalize_rewrite_outcome_tree(nested, field_name=nested_field)
+        return normalized
+    if isinstance(value, list):
+        return [
+            _normalize_rewrite_outcome_tree(item, field_name=f"{field_name}[{idx}]")
+            for idx, item in enumerate(value)
+        ]
+    return value
+
 
 def _redact_scalar_text(text: str, path: str, redactions: set[str]) -> str:
     original = text
@@ -1444,10 +1487,16 @@ class KnowledgeBaseService:
             redacted_payload = _redact_json_value(payload, "$", set())
             if redacted_payload != payload:
                 raise KnowledgeBaseUnavailable(f"records[{idx}] must be redacted before ingestion")
+            normalized_payload = _normalize_rewrite_outcome_tree(redacted_payload, field_name=f"records[{idx}].payload")
+            if isinstance(redacted_payload, dict) and "rewrite_outcome" in redacted_payload:
+                redacted_payload = dict(redacted_payload)
+                redacted_payload["rewrite_outcome"] = _normalize_rewrite_outcome(
+                    redacted_payload["rewrite_outcome"],
+                    field_name=f"records[{idx}].payload.rewrite_outcome"),
             content_digest = str(record.get("content_digest_sha256", "")).strip().lower()
             if not re.fullmatch(r"[0-9a-f]{64}", content_digest):
                 raise ValueError(f"records[{idx}].content_digest_sha256 must be a SHA-256 hex digest")
-            computed_content_digest = hashlib.sha256(_stable_json(redacted_payload).encode("utf-8")).hexdigest()
+            computed_content_digest = hashlib.sha256(_stable_json(normalized_payload).encode("utf-8")).hexdigest()
             if computed_content_digest != content_digest:
                 raise KnowledgeBaseUnavailable(f"records[{idx}] content digest mismatch")
 
@@ -1482,7 +1531,7 @@ class KnowledgeBaseService:
                 "record_id": record_id,
                 "schema_version": record_schema,
                 "content_digest_sha256": content_digest,
-                "payload": redacted_payload,
+                "payload": normalized_payload,
                 "provenance": {
                     "source_ref": record_provenance_ref,
                     "captured_at": record_provenance_captured_at,
@@ -1778,7 +1827,7 @@ class KnowledgeBaseService:
                     "dataset_version": dataset["dataset_version"],
                     "dataset_digest_sha256": dataset["dataset_digest_sha256"],
                     "dataset_manifest_digest_sha256": dataset["manifest_digest_sha256"],
-                    "dataset_record_count": dataset["record_count"],
+                    "dataset_record_count": _training_dataset_record_count(dataset["records"]),
                 }
             )
         record_kb_query("learning_models", hit=True)
@@ -2763,6 +2812,19 @@ class KnowledgeBaseService:
             violations.append(FieldViolation(field="decision_log.decision_id", description="decision_id is required"))
         if not str(getattr(decision_log, "trace_id", "")).strip():
             violations.append(FieldViolation(field="decision_log.trace_id", description="trace_id is required"))
+        feature_snapshot = dict(getattr(decision_log, "feature_snapshot", {}) or {})
+        rewrite_outcome = feature_snapshot.get("rewrite_outcome")
+        if rewrite_outcome not in (None, ""):
+            try:
+                normalized_rewrite_outcome = _normalize_rewrite_outcome(
+                    rewrite_outcome,
+                    field_name="decision_log.feature_snapshot.rewrite_outcome",
+                )
+            except ValueError as exc:
+                violations.append(FieldViolation(field="decision_log.feature_snapshot.rewrite_outcome", description=str(exc)))
+            else:
+                if hasattr(decision_log, "feature_snapshot"):
+                    decision_log.feature_snapshot["rewrite_outcome"] = normalized_rewrite_outcome
         if violations:
             abort_invalid_argument(context, "validation failed", violations)
 

--- a/src/services/neuro-symbolic-service/src/neuro_symbolic_service/production_trace_training.py
+++ b/src/services/neuro-symbolic-service/src/neuro_symbolic_service/production_trace_training.py
@@ -18,6 +18,7 @@ _REDACTED_VALUE = "[REDACTED]"
 _MASKED_EMAIL_VALUE = "[REDACTED_EMAIL]"
 _MASKED_PHONE_VALUE = "[REDACTED_PHONE]"
 _MASKED_IDENTIFIER_VALUE = "[REDACTED_ID]"
+_REWRITE_OUTCOME_TAXONOMY = ("accepted", "rejected", "equivalent", "unsafe")
 
 _REDACT_DELETE_KEYS = {
     "authorization",
@@ -173,6 +174,32 @@ def _require_string(value: Any, *, field_name: str) -> str:
     if not text or text.lower() == "none":
         raise ProductionTraceTrainingError(f"{field_name} is required")
     return text
+
+
+def _normalize_rewrite_outcome(value: Any, *, field_name: str) -> str:
+    outcome = _require_string(value, field_name=field_name).lower()
+    if outcome not in _REWRITE_OUTCOME_TAXONOMY:
+        allowed = ", ".join(_REWRITE_OUTCOME_TAXONOMY)
+        raise ProductionTraceTrainingError(f"{field_name} must be one of: {allowed}")
+    return outcome
+
+
+def _normalize_rewrite_outcome_tree(value: Any, *, field_name: str) -> Any:
+    if isinstance(value, dict):
+        normalized: dict[str, Any] = {}
+        for key, nested in value.items():
+            nested_field = f"{field_name}.{key}" if field_name else str(key)
+            if str(key).strip().lower() == "rewrite_outcome":
+                normalized[key] = _normalize_rewrite_outcome(nested, field_name=nested_field)
+            else:
+                normalized[key] = _normalize_rewrite_outcome_tree(nested, field_name=nested_field)
+        return normalized
+    if isinstance(value, list):
+        return [
+            _normalize_rewrite_outcome_tree(item, field_name=f"{field_name}[{idx}]")
+            for idx, item in enumerate(value)
+        ]
+    return value
 
 
 def _require_digest(value: Any, *, field_name: str) -> str:
@@ -333,8 +360,9 @@ def _normalize_trace_record(record: Any, *, idx: int, tenant_id: str, project_id
         raise ProductionTraceTrainingError(f"records[{idx}].payload must be JSON-serializable")
     if not _is_redacted_payload(payload):
         raise ProductionTraceTrainingError(f"records[{idx}] must be redacted before ingestion")
+    normalized_payload = _normalize_rewrite_outcome_tree(payload, field_name=f"records[{idx}].payload")
     content_digest_sha256 = _require_digest(mapping.get("content_digest_sha256"), field_name=f"records[{idx}].content_digest_sha256")
-    computed_content_digest = hashlib.sha256(_stable_json(payload).encode("utf-8")).hexdigest()
+    computed_content_digest = hashlib.sha256(_stable_json(normalized_payload).encode("utf-8")).hexdigest()
     if computed_content_digest != content_digest_sha256:
         raise ProductionTraceTrainingError(f"records[{idx}].content_digest_sha256 mismatch")
     provenance = _normalize_record_provenance(mapping.get("provenance"), field_name=f"records[{idx}].provenance")
@@ -615,11 +643,12 @@ def _normalize_historical_compilation_record(
         raise ProductionTraceTrainingError(f"records[{idx}] must be redacted before ingestion")
     if not isinstance(payload, dict):
         raise ProductionTraceTrainingError(f"records[{idx}].payload must be an object for historical compilation corpora")
-    compiler_status = _require_string(payload.get("compiler_status"), field_name=f"records[{idx}].payload.compiler_status")
-    rewrite_outcome = _require_string(payload.get("rewrite_outcome"), field_name=f"records[{idx}].payload.rewrite_outcome")
-    accepted_rewrite_ids = _normalize_string_list(payload.get("accepted_rewrite_ids"), field_name=f"records[{idx}].payload.accepted_rewrite_ids", allow_empty=True)
-    rejected_rewrite_ids = _normalize_string_list(payload.get("rejected_rewrite_ids"), field_name=f"records[{idx}].payload.rejected_rewrite_ids", allow_empty=True)
-    timing_ms = payload.get("timing_ms")
+    normalized_payload = _normalize_rewrite_outcome_tree(payload, field_name=f"records[{idx}].payload")
+    compiler_status = _require_string(normalized_payload.get("compiler_status"), field_name=f"records[{idx}].payload.compiler_status")
+    rewrite_outcome = _normalize_rewrite_outcome(normalized_payload.get("rewrite_outcome"), field_name=f"records[{idx}].payload.rewrite_outcome")
+    accepted_rewrite_ids = _normalize_string_list(normalized_payload.get("accepted_rewrite_ids"), field_name=f"records[{idx}].payload.accepted_rewrite_ids", allow_empty=True)
+    rejected_rewrite_ids = _normalize_string_list(normalized_payload.get("rejected_rewrite_ids"), field_name=f"records[{idx}].payload.rejected_rewrite_ids", allow_empty=True)
+    timing_ms = normalized_payload.get("timing_ms")
     if timing_ms is None:
         timing_ms = payload.get("stage_timings_ms")
     if timing_ms is None:
@@ -628,11 +657,11 @@ def _normalize_historical_compilation_record(
         raise ProductionTraceTrainingError(f"records[{idx}].payload.timing_ms is required")
     final_aqo = payload.get("final_aqo")
     if final_aqo is None:
-        final_aqo = payload.get("final_aqo_json")
+        final_aqo = normalized_payload.get("final_aqo_json")
     if final_aqo is None:
         raise ProductionTraceTrainingError(f"records[{idx}].payload.final_aqo is required")
     final_aqo_sha256 = _hex_digest(_stable_json(final_aqo).encode("utf-8"))
-    content_payload = dict(payload)
+    content_payload = dict(normalized_payload)
     content_payload["accepted_rewrite_ids"] = list(accepted_rewrite_ids)
     content_payload["rejected_rewrite_ids"] = list(rejected_rewrite_ids)
     content_payload["timing_ms"] = _normalize_numeric_tree(timing_ms)

--- a/src/services/neuro-symbolic-service/tests/test_knowledge_base_service.py
+++ b/src/services/neuro-symbolic-service/tests/test_knowledge_base_service.py
@@ -357,6 +357,71 @@ def test_runtime_decision_ingest_persists_explainability_envelope(monkeypatch: p
     assert audit["immutable"] is True
 
 
+@pytest.mark.parametrize("rewrite_outcome", ["accepted", "rejected", "equivalent", "unsafe"])
+def test_decision_log_accepts_canonical_rewrite_outcomes(grpc_addr: str, rewrite_outcome: str) -> None:
+    channel = grpc.insecure_channel(grpc_addr)
+    stub = kb_pb_grpc.KnowledgeBaseServiceStub(channel)
+    envelope = _envelope(request_id=f"kb-rewrite-{rewrite_outcome}")
+
+    stub.AppendDecisionLog(
+        kb_pb.AppendDecisionLogRequest(
+            envelope=envelope,
+            decision_log=kb_pb.DecisionLog(
+                decision_id=f"decision-{rewrite_outcome}",
+                trace_id=f"trace-{rewrite_outcome}",
+                model_version="m1",
+                component="compiler",
+                policy_branch="symbolic_rewrite",
+                selected_action="rewrite-1",
+                fallback_used=False,
+                feature_snapshot={
+                    "rewrite_outcome": rewrite_outcome,
+                    "trace_digest_sha256": "sha256:trace-digest",
+                    "pattern_signature": "rewrite-1",
+                },
+                decided_at=_ts("2026-06-11T12:01:00+00:00"),
+            ),
+        )
+    )
+
+    decisions = stub.QueryDecisionLogs(
+        kb_pb.QueryDecisionLogsRequest(
+            envelope=envelope,
+            trace_id=f"trace-{rewrite_outcome}",
+            model_version="m1",
+            page_size=10,
+        )
+    )
+    assert len(decisions.decision_logs) == 1
+    assert decisions.decision_logs[0].feature_snapshot["rewrite_outcome"] == rewrite_outcome
+
+
+def test_decision_log_rejects_unknown_rewrite_outcome(grpc_addr: str) -> None:
+    channel = grpc.insecure_channel(grpc_addr)
+    stub = kb_pb_grpc.KnowledgeBaseServiceStub(channel)
+    envelope = _envelope(request_id="kb-rewrite-invalid")
+
+    with pytest.raises(grpc.RpcError) as excinfo:
+        stub.AppendDecisionLog(
+            kb_pb.AppendDecisionLogRequest(
+                envelope=envelope,
+                decision_log=kb_pb.DecisionLog(
+                    decision_id="decision-invalid",
+                    trace_id="trace-invalid",
+                    model_version="m1",
+                    component="compiler",
+                    policy_branch="symbolic_rewrite",
+                    selected_action="rewrite-1",
+                    fallback_used=False,
+                    feature_snapshot={"rewrite_outcome": "maybe"},
+                    decided_at=_ts("2026-06-11T12:01:00+00:00"),
+                ),
+            )
+        )
+
+    assert excinfo.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+
+
 def test_kb_queries_support_trace_digest_and_pattern_signature_filters(grpc_addr: str) -> None:
     channel = grpc.insecure_channel(grpc_addr)
     stub = kb_pb_grpc.KnowledgeBaseServiceStub(channel)

--- a/src/services/neuro-symbolic-service/tests/test_knowledge_base_versioning.py
+++ b/src/services/neuro-symbolic-service/tests/test_knowledge_base_versioning.py
@@ -193,18 +193,47 @@ def _training_dataset_manifest() -> dict[str, object]:
     record_payload_1 = {
         "feature": "stable",
         "value": 7,
-        "tags": ["clean", "redacted"],
+        "rewrite_outcome": "accepted",
     }
     record_payload_2 = {
         "feature": "stable",
         "value": 9,
         "tags": ["clean", "redacted"],
+        "rewrite_outcome": "equivalent",
+    }
+    record_payload_3 = {
+        "feature": "stable",
+        "value": 11,
+        "tags": ["clean", "redacted"],
+        "rewrite_outcome": "rejected",
+    }
+    record_payload_4 = {
+        "feature": "stable",
+        "value": 13,
+        "tags": ["clean", "redacted"],
+        "rewrite_outcome": "unsafe",
     }
 
     record_provenance_1 = _with_digest(
         {
             "source_ref": "qfs://datasets/raw/sample-1.json",
             "captured_at": "2026-06-16T08:00:00+00:00",
+            "requested_by": "neuro-symbolic-service",
+        },
+        "source_digest_sha256",
+    )
+    record_provenance_3 = _with_digest(
+        {
+            "source_ref": "qfs://datasets/raw/sample-3.json",
+            "captured_at": "2026-06-16T08:02:00+00:00",
+            "requested_by": "neuro-symbolic-service",
+        },
+        "source_digest_sha256",
+    )
+    record_provenance_4 = _with_digest(
+        {
+            "source_ref": "qfs://datasets/raw/sample-4.json",
+            "captured_at": "2026-06-16T08:03:00+00:00",
             "requested_by": "neuro-symbolic-service",
         },
         "source_digest_sha256",
@@ -233,6 +262,22 @@ def _training_dataset_manifest() -> dict[str, object]:
         },
         "redaction_digest_sha256",
     )
+    record_redaction_3 = _with_digest(
+        {
+            "applied": True,
+            "validated": True,
+            "rules": ["secret", "pii"],
+        },
+        "redaction_digest_sha256",
+    )
+    record_redaction_4 = _with_digest(
+        {
+            "applied": True,
+            "validated": True,
+            "rules": ["secret", "pii"],
+        },
+        "redaction_digest_sha256",
+    )
 
     records = [
         {
@@ -250,6 +295,22 @@ def _training_dataset_manifest() -> dict[str, object]:
             "provenance": record_provenance_2,
             "redaction": record_redaction_2,
             "content_digest_sha256": _json_digest(record_payload_2),
+        },
+        {
+            "record_id": "sample-3",
+            "schema_version": "training-record.v1",
+            "payload": record_payload_3,
+            "provenance": record_provenance_3,
+            "redaction": record_redaction_3,
+            "content_digest_sha256": _json_digest(record_payload_3),
+        },
+        {
+            "record_id": "sample-4",
+            "schema_version": "training-record.v1",
+            "payload": record_payload_4,
+            "provenance": record_provenance_4,
+            "redaction": record_redaction_4,
+            "content_digest_sha256": _json_digest(record_payload_4),
         },
     ]
 
@@ -466,7 +527,7 @@ def test_training_dataset_ingestion_round_trip_and_replayability(monkeypatch: py
 
     assert summary["dataset_id"] == "training-batch-2026-06-16"
     assert summary["dataset_version"] == "2026.06.16"
-    assert summary["record_count"] == 2
+    assert summary["record_count"] == 4
     assert summary["manifest_digest_sha256"] == manifest["manifest_digest_sha256"]
     assert summary["dataset_digest_sha256"] == replay["dataset_digest_sha256"]
     assert summary["evidence_id"] == replay["evidence_id"]
@@ -576,7 +637,7 @@ def test_training_dataset_cli_ingest_command(monkeypatch: pytest.MonkeyPatch, tm
     assert exit_code == 0
     assert summary["dataset_id"] == "training-batch-2026-06-16"
     assert summary["dataset_version"] == "2026.06.16"
-    assert summary["record_count"] == 2
+    assert summary["record_count"] == 4
     assert summary["evidence_ref"].startswith("kb://learning/")
 
 
@@ -750,6 +811,64 @@ def _historical_compilation_training_bundle() -> dict[str, object]:
                 "timing_ms": {"parse": 5.0, "rewrite": 9.5, "emit": 2.5},
             }),
         },
+        {
+            "record_id": "hist-004",
+            "schema_version": "neuro-symbolic.historical-compilation-training.record.v1",
+            "job_id": "job-004",
+            "trace_id": "trace-004",
+            "replay_id": "replay-004",
+            "request_id": "request-004",
+            "tenant_id": "tenant-a",
+            "project_id": "project-a",
+            "policy_snapshot_version": "1.0.0",
+            "payload": {
+                "compiler_status": "DONE",
+                "rewrite_outcome": "unsafe",
+                "accepted_rewrite_ids": [],
+                "rejected_rewrite_ids": ["rewrite-reject-004a"],
+                "timing_ms": {"parse": 6.0, "rewrite": 11.0, "emit": 3.5},
+                "final_aqo": aqo_2,
+            },
+            "provenance": record_provenance_2,
+            "redaction": record_redaction,
+            "content_digest_sha256": _json_digest({
+                "accepted_rewrite_ids": [],
+                "compiler_status": "DONE",
+                "final_aqo": aqo_2,
+                "rejected_rewrite_ids": ["rewrite-reject-004a"],
+                "rewrite_outcome": "unsafe",
+                "timing_ms": {"parse": 6.0, "rewrite": 11.0, "emit": 3.5},
+            }),
+        },
+        {
+            "record_id": "hist-003",
+            "schema_version": "neuro-symbolic.historical-compilation-training.record.v1",
+            "job_id": "job-003",
+            "trace_id": "trace-003",
+            "replay_id": "replay-003",
+            "request_id": "request-003",
+            "tenant_id": "tenant-a",
+            "project_id": "project-a",
+            "policy_snapshot_version": "1.0.0",
+            "payload": {
+                "compiler_status": "DONE",
+                "rewrite_outcome": "equivalent",
+                "accepted_rewrite_ids": ["rewrite-equivalent-003a"],
+                "rejected_rewrite_ids": [],
+                "timing_ms": {"parse": 4.25, "rewrite": 7.5, "emit": 2.0},
+                "final_aqo": aqo_1,
+            },
+            "provenance": record_provenance_1,
+            "redaction": record_redaction,
+            "content_digest_sha256": _json_digest({
+                "accepted_rewrite_ids": ["rewrite-equivalent-003a"],
+                "compiler_status": "DONE",
+                "final_aqo": aqo_1,
+                "rejected_rewrite_ids": [],
+                "rewrite_outcome": "equivalent",
+                "timing_ms": {"parse": 4.25, "rewrite": 7.5, "emit": 2.0},
+            }),
+        },
     ]
     provenance = _with_digest(
         {
@@ -773,9 +892,9 @@ def _historical_compilation_training_bundle() -> dict[str, object]:
         "selection_id": "selection-hist-2026-06-16",
         "selected_by": "neuro-symbolic-service",
         "selection_reason": "historical compiler runs selected for pass-path corpus extraction",
-        "job_ids": ["job-002", "job-001"],
-        "trace_ids": ["trace-002", "trace-001"],
-        "replay_ids": ["replay-002", "replay-001"],
+        "job_ids": ["job-002", "job-001", "job-004", "job-003"],
+        "trace_ids": ["trace-002", "trace-001", "trace-004", "trace-003"],
+        "replay_ids": ["replay-002", "replay-001", "replay-004", "replay-003"],
         "tenant_id": "tenant-a",
         "project_id": "project-a",
         "policy_snapshot_version": "1.0.0",
@@ -790,7 +909,7 @@ def _historical_compilation_training_bundle() -> dict[str, object]:
         "tenant_id": "tenant-a",
         "project_id": "project-a",
         "policy_snapshot_version": "1.0.0",
-        "replay_ids": ["replay-002", "replay-001"],
+        "replay_ids": ["replay-002", "replay-001", "replay-004", "replay-003"],
     }
     approval["approval_digest_sha256"] = _json_digest(approval)
     bundle = {
@@ -845,9 +964,9 @@ def test_historical_compilation_training_dataset_is_reproducible(monkeypatch: py
 
     assert first["schema_version"] == "neuro-symbolic.training-dataset.manifest.v1"
     assert first["source_kind"] == "historical_compilations"
-    assert first["selection"]["job_ids"] == ["job-001", "job-002"]
-    assert first["selection"]["trace_ids"] == ["trace-001", "trace-002"]
-    assert first["selection"]["replay_ids"] == ["replay-001", "replay-002"]
+    assert first["selection"]["job_ids"] == ["job-001", "job-002", "job-003", "job-004"]
+    assert first["selection"]["trace_ids"] == ["trace-001", "trace-002", "trace-003", "trace-004"]
+    assert first["selection"]["replay_ids"] == ["replay-001", "replay-002", "replay-003", "replay-004"]
     assert first["records"][0]["job_id"] == "job-001"
     assert first["records"][0]["trace_ref"] == "nsc://trace/trace-001"
     assert first["records"][0]["replay_ref"] == "nsc://replay/trace-001/replay-001"
@@ -878,11 +997,12 @@ def test_historical_compilation_training_dataset_ingests_and_clis(monkeypatch: p
     summary = service.ingest_training_dataset(manifest, caller_identity="neuro-symbolic-service")
     replay_summary = service.ingest_training_dataset(manifest, caller_identity="neuro-symbolic-service")
     assert summary["dataset_id"] == "historical-compilation-batch-2026-06-16"
-    assert summary["record_count"] == 2
+    assert summary["record_count"] == 4
     assert summary["source_kind"] == "historical_compilations"
     assert summary["selection"]["selection_id"] == "selection-hist-2026-06-16"
     assert summary["approval"]["approval_id"] == "approval-hist-2026-06-16"
     assert summary["records"][0]["payload"]["compiler_status"] == "DONE"
+    assert sorted(record["payload"]["rewrite_outcome"] for record in summary["records"]) == ["accepted", "equivalent", "rejected", "unsafe"]
     assert summary["dataset_digest_sha256"] == replay_summary["dataset_digest_sha256"]
     assert summary["evidence_id"] == replay_summary["evidence_id"]
 
@@ -898,7 +1018,7 @@ def test_historical_compilation_training_dataset_ingests_and_clis(monkeypatch: p
 
     assert exit_code == 0
     assert cli_summary["dataset_id"] == "historical-compilation-batch-2026-06-16"
-    assert cli_summary["record_count"] == 2
+    assert cli_summary["record_count"] == 4
     assert cli_summary["source_kind"] == "historical_compilations"
-    assert cli_summary["trace_ids"] == ["trace-001", "trace-002"]
-    assert cli_summary["replay_ids"] == ["replay-001", "replay-002"]
+    assert cli_summary["trace_ids"] == ["trace-001", "trace-002", "trace-003", "trace-004"]
+    assert cli_summary["replay_ids"] == ["replay-001", "replay-002", "replay-003", "replay-004"]


### PR DESCRIPTION
## Summary

- Added a canonical rewrite-outcome taxonomy (accepted, rejected, equivalent, unsafe) in docs and enforced it in KB/training ingestion.
- Extended compiler rewrite-outcome emission to support the full taxonomy when candidate metadata provides it, while preserving existing behavior for current candidates.
- Added validation tests for canonical labels and unknown-label rejection.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: API
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Canonical rewrite-outcome taxonomy for KB and model-training workflows.
- Validation that rejects unknown rewrite-outcome labels.
- Coverage for accepted / rejected / equivalent / unsafe labels in service tests.

### Changed
- Knowledge base decision-log validation now normalizes and enforces the canonical rewrite-outcome label set.
- Compiler rewrite-outcome selection now supports explicit canonical outcomes from candidate metadata.

### Fixed
- KB and training ingestion no longer accept non-canonical rewrite-outcome labels.