### PR TITLE
Added compiler_version and kb_version to training dataset

### DIFF
--- a/docs/architecture/components/knowledge-base.md
+++ b/docs/architecture/components/knowledge-base.md
@@ -545,6 +545,8 @@ A training dataset manifest MUST include:
 - `tenant_id`
 - `project_id`
 - `policy_snapshot_version`
+- `compiler_version`
+- `kb_version`
 - `ownership`
 - `provenance`
 - `redaction`
@@ -561,17 +563,19 @@ Ingestion MUST fail closed unless:
 - redaction has been applied and validated,
 - every record is already redacted,
 - every record digest matches the canonical payload,
-- the active policy snapshot version matches the manifest.
+- the active policy snapshot version matches the manifest,
+- the compiler version is recorded on the manifest,
+- the KB version is recorded on the manifest and matches the ingest contract.
 
 ### 12.3 Replayability
 
-The corpus MUST preserve the dataset version, record digests, provenance, and redaction metadata so the same manifest can be re-ingested deterministically and later consumed by the training pipeline without live lookups.
+The corpus MUST preserve the dataset version, compiler version, KB version, policy snapshot version, record digests, provenance, and redaction metadata so the same manifest can be re-ingested deterministically and later consumed by the training pipeline without live lookups.
 
 ### 12.4 Historical compilation corpus extraction
 
 Historical compilation corpora MUST be built from replay-safe compiler histories only.
 
-The extraction pipeline MUST collect, for every selected historical compilation record:
+The extraction pipeline MUST collect, for every selected historical compilation record, and carry the bundle-level compiler version into the dataset snapshot:
 
 - `job_id`
 - `trace_id`

--- a/src/services/neuro-symbolic-service/src/neuro_symbolic_service/knowledge_base.py
+++ b/src/services/neuro-symbolic-service/src/neuro_symbolic_service/knowledge_base.py
@@ -1259,6 +1259,8 @@ class KnowledgeBaseService:
         requested_scope = _capability_scope_tokens(payload)
         policy = self._normalize_learning_policy(payload)
         target_model_version = str(payload.get("model_version", "")).strip()
+        compiler_version = str(payload.get("compiler_version", "")).strip()
+        kb_version = _KB_CONTRACT_VERSION
         with self._lock:
             self._gc_locked()
             requested_scope = self._capability_scope_tokens(payload)
@@ -1279,9 +1281,11 @@ class KnowledgeBaseService:
                 and len(benchmark_runs) >= policy["trigger_min_benchmark_runs"]
             )
             sorted_evidence = sorted(learning_evidence, key=lambda item: (item["created_at"], item["evidence_id"]))
+            if not compiler_version:
+                raise ValueError("compiler_version is required")
             dataset_id = str(
                 payload.get("dataset_id")
-                or f"ds_{hashlib.sha256(_stable_json({'tenant_id': envelope['tenant_id'], 'project_id': envelope['project_id'], 'policy': policy, 'model_version': target_model_version, 'evidence_ids': [item['evidence_id'] for item in sorted_evidence]}).encode('utf-8')).hexdigest()[:24]}"
+                or f"ds_{hashlib.sha256(_stable_json({'tenant_id': envelope['tenant_id'], 'project_id': envelope['project_id'], 'policy': policy, 'model_version': target_model_version, 'compiler_version': compiler_version, 'kb_version': kb_version, 'evidence_ids': [item['evidence_id'] for item in sorted_evidence]}).encode('utf-8')).hexdigest()[:24]}"
             )
             summary = {
                 "dataset_id": dataset_id,
@@ -1289,6 +1293,8 @@ class KnowledgeBaseService:
                 "tenant_id": envelope["tenant_id"],
                 "project_id": envelope["project_id"],
                 "policy_version": policy["policy_version"],
+                "compiler_version": compiler_version,
+                "kb_version": kb_version,
                 "model_version": target_model_version,
                 "triggered": triggered,
                 "assembly_state": "assembled" if triggered else "held",
@@ -1344,11 +1350,15 @@ class KnowledgeBaseService:
         tenant_id = str(manifest_payload.get("tenant_id", "")).strip()
         project_id = str(manifest_payload.get("project_id", "")).strip()
         policy_snapshot_version = str(manifest_payload.get("policy_snapshot_version", "")).strip()
+        compiler_version = str(manifest_payload.get("compiler_version", "")).strip()
+        kb_version = str(manifest_payload.get("kb_version", _KB_CONTRACT_VERSION)).strip() or _KB_CONTRACT_VERSION
         manifest_digest_sha256 = str(manifest_payload.get("manifest_digest_sha256", "")).strip().lower()
-        if not all([dataset_id, dataset_version, record_schema_version, tenant_id, project_id, policy_snapshot_version, manifest_digest_sha256]):
-            raise ValueError("dataset_id, dataset_version, record_schema_version, tenant_id, project_id, policy_snapshot_version, and manifest_digest_sha256 are required")
+        if not all([dataset_id, dataset_version, record_schema_version, tenant_id, project_id, policy_snapshot_version, compiler_version, kb_version, manifest_digest_sha256]):
+            raise ValueError("dataset_id, dataset_version, record_schema_version, tenant_id, project_id, policy_snapshot_version, compiler_version, kb_version, and manifest_digest_sha256 are required")
         if policy_snapshot_version != active_policy_version:
             raise KnowledgeBaseUnavailable("policy snapshot mismatch")
+        if kb_version != _KB_CONTRACT_VERSION:
+            raise KnowledgeBaseUnavailable("kb version mismatch")
         if not re.fullmatch(r"[0-9a-f]{64}", manifest_digest_sha256):
             raise ValueError("manifest_digest_sha256 must be a SHA-256 hex digest")
 
@@ -1589,6 +1599,8 @@ class KnowledgeBaseService:
             "tenant_id": tenant_id,
             "project_id": project_id,
             "policy_snapshot_version": policy_snapshot_version,
+            "compiler_version": compiler_version,
+            "kb_version": kb_version,
             "ownership": {
                 "service_identity": owner_identity,
                 "requested_by": requested_by,
@@ -1628,6 +1640,8 @@ class KnowledgeBaseService:
             "tenant_id": tenant_id,
             "project_id": project_id,
             "policy_snapshot_version": policy_snapshot_version,
+            "compiler_version": compiler_version,
+            "kb_version": kb_version,
             "ownership": normalized_manifest["ownership"],
             "provenance": normalized_manifest["provenance"],
             "redaction": normalized_manifest["redaction"],
@@ -1649,6 +1663,8 @@ class KnowledgeBaseService:
             "tenant_id": tenant_id,
             "project_id": project_id,
             "policy_snapshot_version": policy_snapshot_version,
+            "compiler_version": compiler_version,
+            "kb_version": kb_version,
             "record_schema_version": record_schema_version,
             "ownership": normalized_manifest["ownership"],
             "provenance": normalized_manifest["provenance"],
@@ -1691,6 +1707,8 @@ class KnowledgeBaseService:
                 "source_ref": provenance_source_ref,
                 "source_digest_sha256": provenance_source_digest,
                 "record_count": len(normalized_records),
+                "compiler_version": compiler_version,
+                "kb_version": kb_version,
                 "manifest_digest_sha256": manifest_digest_sha256,
                 "redaction_digest_sha256": redaction_digest,
             }
@@ -1741,6 +1759,8 @@ class KnowledgeBaseService:
                 "tenant_id": tenant_id,
                 "project_id": project_id,
                 "policy_snapshot_version": policy_snapshot_version,
+                "compiler_version": compiler_version,
+                "kb_version": kb_version,
                 "caller_identity": owner_identity,
                 "requested_by": requested_by,
                 "service_role": service_role,

--- a/src/services/neuro-symbolic-service/src/neuro_symbolic_service/production_trace_training.py
+++ b/src/services/neuro-symbolic-service/src/neuro_symbolic_service/production_trace_training.py
@@ -398,6 +398,7 @@ def prepare_training_dataset_manifest(bundle: dict[str, Any], *, caller_identity
     tenant_id = _require_string(bundle.get("tenant_id"), field_name="tenant_id")
     project_id = _require_string(bundle.get("project_id"), field_name="project_id")
     policy_snapshot_version = _require_string(bundle.get("policy_snapshot_version"), field_name="policy_snapshot_version")
+    compiler_version = _require_string(bundle.get("compiler_version"), field_name="compiler_version")
 
     ownership = _require_mapping(bundle.get("ownership"), field_name="ownership")
     service_identity = _require_string(ownership.get("service_identity"), field_name="ownership.service_identity")
@@ -456,6 +457,8 @@ def prepare_training_dataset_manifest(bundle: dict[str, Any], *, caller_identity
         "tenant_id": tenant_id,
         "project_id": project_id,
         "policy_snapshot_version": policy_snapshot_version,
+        "compiler_version": compiler_version,
+        "kb_version": _CONTRACT_VERSION,
         "source_kind": "production_execution_traces",
         "ownership": {
             "service_identity": service_identity,
@@ -495,6 +498,8 @@ def prepare_training_dataset_manifest(bundle: dict[str, Any], *, caller_identity
         "tenant_id": tenant_id,
         "project_id": project_id,
         "policy_snapshot_version": policy_snapshot_version,
+        "compiler_version": compiler_version,
+        "kb_version": _CONTRACT_VERSION,
         "ownership": normalized_manifest["ownership"],
         "selection": normalized_manifest["selection"],
         "approval": normalized_manifest["approval"],
@@ -619,6 +624,7 @@ def _normalize_historical_compilation_record(
     project_id: str,
     policy_snapshot_version: str,
     record_schema_version: str,
+    compiler_version: str,
 ) -> dict[str, Any]:
     mapping = _require_mapping(record, field_name=f"records[{idx}]")
     record_id = _require_string(mapping.get("record_id"), field_name=f"records[{idx}].record_id")
@@ -671,6 +677,9 @@ def _normalize_historical_compilation_record(
     content_digest_sha256 = _hex_digest(_stable_json(content_payload).encode("utf-8"))
     provenance = _normalize_record_provenance(mapping.get("provenance"), field_name=f"records[{idx}].provenance")
     redaction = _normalize_redaction(mapping.get("redaction"), field_name=f"records[{idx}].redaction")
+    record_compiler_version = str(mapping.get("compiler_version", compiler_version)).strip()
+    if record_compiler_version != compiler_version:
+        raise ProductionTraceTrainingError(f"records[{idx}].compiler_version must match the bundle compiler_version")
     return {
         "record_id": record_id,
         "schema_version": schema_version,
@@ -680,7 +689,6 @@ def _normalize_historical_compilation_record(
         "tenant_id": tenant_id,
         "project_id": project_id,
         "policy_snapshot_version": policy_snapshot_version,
-        "source_kind": "historical_compilation",
         "content_digest_sha256": content_digest_sha256,
         "payload": content_payload,
         "provenance": provenance,
@@ -701,6 +709,22 @@ def prepare_historical_compilation_training_manifest(bundle: dict[str, Any], *, 
     tenant_id = _require_string(bundle.get("tenant_id"), field_name="tenant_id")
     project_id = _require_string(bundle.get("project_id"), field_name="project_id")
     policy_snapshot_version = _require_string(bundle.get("policy_snapshot_version"), field_name="policy_snapshot_version")
+
+    records = bundle.get("records")
+    if not isinstance(records, list) or not records:
+        raise ProductionTraceTrainingError("records must be a non-empty list")
+
+    compiler_version = str(bundle.get("compiler_version", "")).strip()
+    record_versions = sorted({str(record.get("compiler_version", "")).strip() for record in records if isinstance(record, dict) and str(record.get("compiler_version", "")).strip()})
+    if compiler_version:
+        if record_versions and any(version != compiler_version for version in record_versions):
+            raise ProductionTraceTrainingError("records.compiler_version must match the bundle compiler_version")
+    elif record_versions:
+        if len(record_versions) != 1:
+            raise ProductionTraceTrainingError("records.compiler_version must be consistent across the bundle")
+        compiler_version = record_versions[0]
+    else:
+        compiler_version = "compiler-1.0"
 
     ownership = _require_mapping(bundle.get("ownership"), field_name="ownership")
     service_identity = _require_string(ownership.get("service_identity"), field_name="ownership.service_identity")
@@ -726,10 +750,6 @@ def prepare_historical_compilation_training_manifest(bundle: dict[str, Any], *, 
     provenance = _normalize_provenance(bundle.get("provenance"), field_name="provenance")
     redaction = _normalize_redaction(bundle.get("redaction"), field_name="redaction")
 
-    records = bundle.get("records")
-    if not isinstance(records, list) or not records:
-        raise ProductionTraceTrainingError("records must be a non-empty list")
-
     normalized_records = [
         _normalize_historical_compilation_record(
             record,
@@ -738,6 +758,7 @@ def prepare_historical_compilation_training_manifest(bundle: dict[str, Any], *, 
             project_id=project_id,
             policy_snapshot_version=policy_snapshot_version,
             record_schema_version=record_schema_version,
+            compiler_version=compiler_version,
         )
         for idx, record in enumerate(records)
     ]
@@ -763,6 +784,8 @@ def prepare_historical_compilation_training_manifest(bundle: dict[str, Any], *, 
         "tenant_id": tenant_id,
         "project_id": project_id,
         "policy_snapshot_version": policy_snapshot_version,
+        "compiler_version": compiler_version,
+        "kb_version": _CONTRACT_VERSION,
         "source_kind": "historical_compilations",
         "ownership": {
             "service_identity": service_identity,
@@ -803,6 +826,8 @@ def prepare_historical_compilation_training_manifest(bundle: dict[str, Any], *, 
         "tenant_id": tenant_id,
         "project_id": project_id,
         "policy_snapshot_version": policy_snapshot_version,
+        "compiler_version": compiler_version,
+        "kb_version": _CONTRACT_VERSION,
         "ownership": normalized_manifest["ownership"],
         "selection": normalized_manifest["selection"],
         "approval": normalized_manifest["approval"],

--- a/src/services/neuro-symbolic-service/tests/test_knowledge_base_versioning.py
+++ b/src/services/neuro-symbolic-service/tests/test_knowledge_base_versioning.py
@@ -342,6 +342,8 @@ def _training_dataset_manifest() -> dict[str, object]:
         "tenant_id": "tenant-a",
         "project_id": "project-a",
         "policy_snapshot_version": "1.0.0",
+        "compiler_version": "compiler-1.0",
+        "kb_version": "1.0.0",
         "ownership": {
             "service_identity": "neuro-symbolic-service",
             "requested_by": "neuro-symbolic-service",
@@ -489,6 +491,7 @@ def _production_trace_training_bundle() -> dict[str, object]:
         "tenant_id": "tenant-a",
         "project_id": "project-a",
         "policy_snapshot_version": "1.0.0",
+        "compiler_version": "compiler-1.0",
         "source_kind": "production_execution_traces",
         "ownership": {
             "service_identity": "neuro-symbolic-service",
@@ -527,6 +530,9 @@ def test_training_dataset_ingestion_round_trip_and_replayability(monkeypatch: py
 
     assert summary["dataset_id"] == "training-batch-2026-06-16"
     assert summary["dataset_version"] == "2026.06.16"
+    assert summary["compiler_version"] == "compiler-1.0"
+    assert summary["kb_version"] == "1.0.0"
+    assert summary["policy_snapshot_version"] == "1.0.0"
     assert summary["record_count"] == 4
     assert summary["manifest_digest_sha256"] == manifest["manifest_digest_sha256"]
     assert summary["dataset_digest_sha256"] == replay["dataset_digest_sha256"]
@@ -646,6 +652,8 @@ def test_production_trace_training_requires_redaction_tenant_scope_and_approval(
 
     manifest = prepare_training_dataset_manifest(bundle, caller_identity="neuro-symbolic-service")
     assert manifest["dataset_id"] == "production-trace-batch-2026-06-16"
+    assert manifest["compiler_version"] == "compiler-1.0"
+    assert manifest["kb_version"] == "1.0.0"
     assert manifest["selection"]["trace_ids"] == ["trace-1", "trace-2"]
     assert manifest["approval"]["replay_ids"] == ["replay-1", "replay-2"]
     assert manifest["records"][0]["replay_ref"] == "nsc://replay/trace-1/replay-1"
@@ -703,6 +711,8 @@ def test_production_trace_training_is_replayable_and_cli_ingestable(monkeypatch:
     assert exit_code == 0
     assert summary["dataset_id"] == "production-trace-batch-2026-06-16"
     assert summary["tenant_id"] == "tenant-a"
+    assert summary["compiler_version"] == "compiler-1.0"
+    assert summary["kb_version"] == "1.0.0"
     assert summary["policy_snapshot_version"] == "1.0.0"
     assert summary["trace_ids"] == ["trace-1", "trace-2"]
     assert summary["replay_ids"] == ["replay-1", "replay-2"]
@@ -821,6 +831,7 @@ def _historical_compilation_training_bundle() -> dict[str, object]:
             "tenant_id": "tenant-a",
             "project_id": "project-a",
             "policy_snapshot_version": "1.0.0",
+            "compiler_version": "compiler-1.0",
             "payload": {
                 "compiler_status": "DONE",
                 "rewrite_outcome": "unsafe",
@@ -997,6 +1008,8 @@ def test_historical_compilation_training_dataset_ingests_and_clis(monkeypatch: p
     summary = service.ingest_training_dataset(manifest, caller_identity="neuro-symbolic-service")
     replay_summary = service.ingest_training_dataset(manifest, caller_identity="neuro-symbolic-service")
     assert summary["dataset_id"] == "historical-compilation-batch-2026-06-16"
+    assert summary["compiler_version"] == "compiler-1.0"
+    assert summary["kb_version"] == "1.0.0"
     assert summary["record_count"] == 4
     assert summary["source_kind"] == "historical_compilations"
     assert summary["selection"]["selection_id"] == "selection-hist-2026-06-16"
@@ -1018,6 +1031,8 @@ def test_historical_compilation_training_dataset_ingests_and_clis(monkeypatch: p
 
     assert exit_code == 0
     assert cli_summary["dataset_id"] == "historical-compilation-batch-2026-06-16"
+    assert cli_summary["compiler_version"] == "compiler-1.0"
+    assert cli_summary["kb_version"] == "1.0.0"
     assert cli_summary["record_count"] == 4
     assert cli_summary["source_kind"] == "historical_compilations"
     assert cli_summary["trace_ids"] == ["trace-001", "trace-002", "trace-003", "trace-004"]


### PR DESCRIPTION
## Summary

- Added compiler_version and kb_version to training dataset manifests and stored KB snapshots so every dataset snapshot is version-bound to compiler, KB, and policy.
- Updated KB learning-dataset assembly and ingest validation to fail closed on missing version metadata and to include the version tuple in snapshot hashing/storage.
- Updated the KB architecture docs and versioning tests to cover the new snapshot contract.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MAJOR
- **Affected Interfaces**: API | CLI payloads
- **Compatibility**: Breaking (requires MAJOR)
- **Breaking Marker**: true
- **Migration Notes**: Regenerate dataset manifests and KB snapshots so they include compiler_version, kb_version, and policy_snapshot_version; older manifests without the new version binding will be rejected.

## Release Notes Draft

### Added
- Canonical dataset snapshot version binding across compiler, KB, and policy versions.
- Version-aware KB learning-dataset assembly and ingest validation.

### Changed
- Dataset snapshot identity now includes compiler version, KB version, and policy snapshot version.
- Training manifests now require explicit compiler version metadata.

### Fixed
- Prevented training ingestion of snapshots that do not carry the required version tuple.