### PR TITLE
Added bounded per-RPC timeout handling for the compiler’s KB advisory

### DIFF
--- a/docs/architecture/components/neuro-symbolic-advisory-boundary.md
+++ b/docs/architecture/components/neuro-symbolic-advisory-boundary.md
@@ -10,7 +10,9 @@ The normative source of truth for the full symbolic-core / KB / ML-advisor bound
 
 The compiler must treat neuro-symbolic output as advisory only. Deterministic validation, normalization, lowering, AQO contract checks, and workload-profile resolution remain authoritative.
 
-If model output is missing, malformed, low-confidence, or invalid, the compiler must ignore it and continue with the symbolic baseline.
+If model output is missing, malformed, low-confidence, invalid, or delayed past the request budget, the compiler must ignore it and continue with the symbolic baseline.
+
+Any advisory-side or KB-side effect used for ranking, tracing, or telemetry must be bounded by the active request deadline (or the configured service timeout when no deadline is available). `UNAVAILABLE` and `DEADLINE_EXCEEDED` responses must degrade gracefully and must not fail compilation on their own.
 
 Neuro-symbolic suggestions must not be able to produce invalid IR, bypass semantic validation, infer compiler legality, or relax lowering constraints.
 

--- a/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
@@ -364,6 +364,48 @@ def _kb_timeout_seconds() -> float:
     return max(0.1, value)
 
 
+def _request_timeout_seconds(request_context: dict[str, str]) -> float:
+    """Return a bounded timeout for best-effort KB RPCs.
+
+    The compiler must not let slow advisory side effects exceed the request
+    deadline when one is available, but it also must keep a minimum budget so
+    very small deadlines do not result in an immediate failure path.
+    """
+
+    deadline = str(request_context.get("deadline", "")).strip()
+    timeout = _kb_timeout_seconds()
+    if not deadline:
+        return timeout
+
+    parsed_deadline: float | None = None
+    if deadline.endswith("s"):
+        try:
+            parsed_deadline = float(deadline[:-1])
+        except ValueError:
+            parsed_deadline = None
+    elif ":" in deadline:
+        try:
+            days = 0
+            time_part = deadline
+            if " day" in deadline:
+                day_part, time_part = deadline.split(",", 1)
+                days = int(day_part.split()[0])
+                time_part = time_part.strip()
+            hours, minutes, seconds = time_part.split(":", 2)
+            parsed_deadline = (
+                days * 86400
+                + int(hours) * 3600
+                + int(minutes) * 60
+                + float(seconds)
+            )
+        except Exception:
+            parsed_deadline = None
+
+    if parsed_deadline is None:
+        return timeout
+    return max(0.1, min(timeout, parsed_deadline))
+
+
 def _kb_call_metadata(request_context: dict[str, str]) -> tuple[tuple[str, str], ...]:
     token = os.getenv(_KB_AUTH_TOKEN_ENV, os.getenv("SYSTEM_API_AUTH_TOKEN", "")).strip()
     roles = os.getenv(_KB_ROLES_ENV, "kb:read,kb:write").strip() or "kb:read,kb:write"
@@ -481,9 +523,11 @@ def _kb_index_compiler_trace(
     if not endpoint:
         return
 
+    timeout_seconds = _request_timeout_seconds(request_context)
+
     try:
         channel = grpc.insecure_channel(endpoint)
-        grpc.channel_ready_future(channel).result(timeout=_kb_timeout_seconds())
+        grpc.channel_ready_future(channel).result(timeout=timeout_seconds)
         stub = kb_pb_grpc.KnowledgeBaseServiceStub(channel)
     except Exception as exc:  # pragma: no cover - best-effort indexing
         _LOG.debug("compiler KB channel unavailable: %s", exc)
@@ -584,14 +628,19 @@ def _kb_index_compiler_trace(
 
         request_envelope = _kb_request_envelope(request_context)
 
-        stub.UpsertRecord(
-            kb_pb.UpsertRecordRequest(
-                envelope=request_envelope,
-                record=record,
-                allow_overwrite=True,
-            ),
-            metadata=_kb_call_metadata(request_context),
-        )
+        try:
+            stub.UpsertRecord(
+                kb_pb.UpsertRecordRequest(
+                    envelope=request_envelope,
+                    record=record,
+                    allow_overwrite=True,
+                ),
+                metadata=_kb_call_metadata(request_context),
+                timeout=timeout_seconds,
+            )
+        except Exception as exc:  # pragma: no cover - best-effort indexing
+            _LOG.debug("compiler KB upsert timed out or failed: %s", exc)
+            return
 
         for candidate in candidates:
             if not isinstance(candidate, dict):
@@ -640,13 +689,18 @@ def _kb_index_compiler_trace(
                 feature_snapshot=feature_snapshot,
                 decided_at=_timestamp_now(),
             )
-            stub.AppendDecisionLog(
-                kb_pb.AppendDecisionLogRequest(
-                    envelope=request_envelope,
-                    decision_log=decision_log,
-                ),
-                metadata=_kb_call_metadata(request_context),
-            )
+            try:
+                stub.AppendDecisionLog(
+                    kb_pb.AppendDecisionLogRequest(
+                        envelope=request_envelope,
+                        decision_log=decision_log,
+                    ),
+                    metadata=_kb_call_metadata(request_context),
+                    timeout=timeout_seconds,
+                )
+            except Exception as exc:  # pragma: no cover - best-effort indexing
+                _LOG.debug("compiler KB decision log append timed out or failed: %s", exc)
+                return
     except Exception as exc:  # pragma: no cover - best-effort indexing
         _LOG.debug("compiler KB indexing failed: %s", exc)
     finally:

--- a/src/services/eigen-compiler/tests/test_compilation_rpc.py
+++ b/src/services/eigen-compiler/tests/test_compilation_rpc.py
@@ -514,6 +514,77 @@ def test_compile_job_indexes_trace_and_rewrite_paths_in_kb(
     assert rejected_logs.decision_logs[0].feature_snapshot["trace_digest_sha256"] == trace_digest
 
 
+def test_compile_job_gracefully_degrades_when_kb_is_slow(
+    grpc_addr: str,
+    kb_server: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EIGEN_KB_GRPC_ENDPOINT", kb_server)
+    monkeypatch.setenv("EIGEN_KB_AUTH_TOKEN", "kb-test-token")
+    monkeypatch.setenv("EIGEN_KB_SERVICE_IDENTITY", "eigen-compiler")
+    monkeypatch.setenv("EIGEN_KB_SERVICE_ROLE", "compiler")
+    monkeypatch.setenv("EIGEN_KB_ROLES", "kb:read,kb:write")
+    monkeypatch.setenv("EIGEN_KB_TIMEOUT_SECONDS", "0.1")
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_MODEL_VERSION", "model-2026-06-23")
+    monkeypatch.setenv("EIGEN_NEURO_SYMBOLIC_POLICY_SNAPSHOT_VERSION", "policy-2026-06-15")
+
+    from neuro_symbolic_service import knowledge_base as kb_mod
+
+    original_upsert = kb_mod.KnowledgeBaseService.UpsertRecord
+    original_append = kb_mod.KnowledgeBaseService.AppendDecisionLog
+
+    def slow_upsert(self, request, context):
+        time.sleep(3.0)
+        return original_upsert(self, request, context)
+
+    def slow_append(self, request, context):
+        time.sleep(3.0)
+        return original_append(self, request, context)
+
+    monkeypatch.setattr(kb_mod.KnowledgeBaseService, "UpsertRecord", slow_upsert)
+    monkeypatch.setattr(kb_mod.KnowledgeBaseService, "AppendDecisionLog", slow_append)
+
+    channel = grpc.insecure_channel(grpc_addr)
+    stub = comp_pb_grpc.CompilationServiceStub(channel)
+
+    request_metadata = kernel_pb.RequestMetadata()
+    request_metadata.contract_version = "1.0.0"
+    request_metadata.request_id = "req-kb-slow-001"
+    request_metadata.trace_id = "trace-kb-slow-001"
+    request_metadata.traceparent = "00-11111111111111111111111111111111-2222222222222222-01"
+    request_metadata.deadline.seconds = 60
+    request_metadata.retry_policy = "retry-none"
+    request_metadata.security_context = "compiler-test"
+    request_metadata.tenant_id = "tenant-a"
+    request_metadata.project_id = "project-a"
+    request_metadata.workload.kind = kernel_pb.WORKLOAD_FAMILY_KIND_HYBRID_WORKFLOW
+    request_metadata.workload.execution_profile = "hybrid"
+    request_metadata.workload.backend_target = "sim:local"
+
+    start = time.perf_counter()
+    resp = stub.CompileJob(
+        comp_pb.CompileJobRequest(
+            job_id="job-kb-slow-001",
+            language="eigen-lang",
+            source=(
+                b"from eigen_lang import hybrid_program, ry\n\n"
+                b"@hybrid_program(target=\"sim\", shots=1000)\n"
+                b"def main():\n"
+                b"    ry(0, theta=1.0)\n"
+            ),
+            request_metadata=request_metadata,
+        )
+    )
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 1.5
+    assert resp.metadata["workload_profile"] == "HybridWorkflow"
+    assert resp.metadata["compiler_replay_json"]
+    assert resp.metadata["aqo_sha256"]
+    candidate_set = json.loads(resp.metadata["symbolic_candidate_set_json"])
+    assert candidate_set["selected_candidate_id"] == "symbolic.rewrite_terminal_measurement"
+
+
 def test_compile_job_uses_request_metadata_workload_profile(grpc_addr: str) -> None:
     channel = grpc.insecure_channel(grpc_addr)
     stub = comp_pb_grpc.CompilationServiceStub(channel)


### PR DESCRIPTION
## Summary

- Added bounded per-RPC timeout handling for the compiler’s KB advisory side effects so slow or unavailable advisory infrastructure degrades gracefully instead of blocking compilation. The compiler still completes with the symbolic path, and the new regression test proves a deliberately slow KB write does not make compile fail.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: API | Metrics
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Regression coverage for slow KB advisory side effects during compile.

### Changed
- Compiler KB indexing now uses bounded request/response timeouts and degrades gracefully on advisory service slowness or unavailability.

### Fixed
- Compilation no longer waits indefinitely on slow KB advisory writes, and compile completion is no longer coupled to advisory service availability.