### PR TITLE
Implemented compile-trace decision source logging for the compiler path

### DIFF
--- a/docs/architecture/components/compiler.md
+++ b/docs/architecture/components/compiler.md
@@ -67,6 +67,7 @@ The compiler metadata contract is also stable and deterministic. The canonical n
 - `compiler_passes_json`
 - `compiler_replay_json`
 - `compiler_replay_sha256`
+- `decision_source`
 - `backend_contract_json`
 - `logical_graph_schema_json`
 - `logical_graph_schema_sha256`
@@ -198,7 +199,7 @@ The semantic rule engine gates `validate_ast`, `rewrite_ir`, and `validate_lower
 
 The compiler also emits a bounded symbolic candidate set for advisory review. Each candidate is produced by the symbolic core, has a stable `candidate_id`, a compact feature map, and a legality flag. The emitted candidate set is serialized in compiler metadata as `symbolic_candidate_set_json`.
 
-The payload also contains `ranked_candidates`, a legal-candidate-only list ordered by deterministic compiler-side advisory ordering. The ML advisor is implemented as a separate sidecar service and does not participate in compiler correctness. Each ranked candidate MUST carry a `rank`, a `confidence` score, the bounded logical graph encoding that the advisor consumed, and an `explanation` object with a human-readable `why_preferred` summary plus bounded `influential_features` and `influential_subgraph` hooks. The ranking surface remains advisory only and may be replaced or disabled without changing AQO output or lowering correctness.
+The payload also contains `ranked_candidates`, a legal-candidate-only list ordered by deterministic compiler-side advisory ordering. The payload records the final `decision_source` as one of `symbolic_rules`, `gnn_ranking`, `boosting_ranking`, or `fallback` so the compile trace can show which advisory path produced the final choice. The ML advisor is implemented as a separate sidecar service and does not participate in compiler correctness. Each ranked candidate MUST carry a `rank`, a `confidence` score, the bounded logical graph encoding that the advisor consumed, and an `explanation` object with a human-readable `why_preferred` summary plus bounded `influential_features` and `influential_subgraph` hooks. The ranking surface remains advisory only and may be replaced or disabled without changing AQO output or lowering correctness.
 
 Ranking layers may only score candidates whose `legal` flag is `true`. They must not invent additional candidates, rename emitted IDs, or treat illegal candidates as admissible.
 
@@ -305,7 +306,7 @@ The compiler must persist:
 - deterministic replay bundle with symbolic rule attribution,
 - advisor influence outcome when present.
 
-Observability records must be bounded and must not leak secrets.
+Observability records must be bounded and must not leak secrets. Every compile trace must record the `decision_source` so downstream replay can distinguish symbolic-rule choices from GNN, boosting, or fallback paths.
 
 ---
 

--- a/docs/architecture/components/knowledge-base.md
+++ b/docs/architecture/components/knowledge-base.md
@@ -11,7 +11,7 @@ The Knowledge Base exposes two distinct behaviors:
 1. **Public record storage** — CRUD/query for KB records and decision logs.
 2. **Optimization Knowledge Base (OKB) retrieval** — deterministic reuse selection for compiler / AQO workflows.
 
-Runtime decision logs are append-only and MUST preserve the audit trail fields required by the neuro-symbolic compliance contract: caller identity, tenant, policy snapshot version, model version, retrieval sources, and final decision.
+Runtime decision logs are append-only and MUST preserve the audit trail fields required by the neuro-symbolic compliance contract: caller identity, tenant, policy snapshot version, model version, retrieval sources, final decision, and the final `decision_source` (`symbolic_rules`, `gnn_ranking`, `boosting_ranking`, or `fallback`).
 
 Compiler traces are indexed into the KB as replay-safe records and decision logs so later queries can bind to trace ID, trace digest, and pattern signature. The canonical rewrite-outcome taxonomy is `accepted`, `rejected`, `equivalent`, and `unsafe`; KB records and model-training corpora MUST use that same label set consistently. Both accepted and rejected rewrite paths MUST be retained, and equivalent/unsafe outcomes MUST be preserved for ranking and safety analysis.
 

--- a/docs/reference/compiler-observability-contract.md
+++ b/docs/reference/compiler-observability-contract.md
@@ -109,8 +109,9 @@ Compiler logs MUST include stable correlation fields:
 - `elapsed_ms`
 - `aqo_sha256`
 - `source_sha256`
+- `decision_source`
 
-When the symbolic rewrite pipeline is executed, logs MUST additionally include `rewrite_stage`, `rewrite_stage_index`, `rewrite_stage_outcome`, and `rewrite_stage_digest`.
+When the symbolic rewrite pipeline is executed, logs MUST additionally include `rewrite_stage`, `rewrite_stage_index`, `rewrite_stage_outcome`, and `rewrite_stage_digest`. For compile-end traces, logs MUST also include `decision_source` with one of `symbolic_rules`, `gnn_ranking`, `boosting_ranking`, or `fallback`.
 
 ---
 
@@ -132,6 +133,7 @@ Required payload fields:
 - `logical_graph_schema_sha256`
 - `telemetry_feature_set_json`
 - `telemetry_feature_set_sha256`
+- `decision_source`
 
 Those payloads MUST remain deterministic for identical inputs and MUST include only bounded trace and metric fields:
 
@@ -139,7 +141,7 @@ Those payloads MUST remain deterministic for identical inputs and MUST include o
 - metric fields: `rpc`, `stage`, `outcome`, `elapsed_ms`
 - label-family bounds: no request, trace, tenant, or project identifiers in metric labels
 
-`compiler_diagnostics_json` MUST summarize the compiler stage order, the resolved workload profile, and the backend contract in a machine-readable payload that remains stable for identical inputs.
+`compiler_diagnostics_json` MUST summarize the compiler stage order, the resolved workload profile, the backend contract, and the final `decision_source` in a machine-readable payload that remains stable for identical inputs.
 
 `symbolic_candidate_set_json` MUST summarize the bounded candidate set emitted by the symbolic core. Each candidate entry MUST expose a stable `candidate_id`, a compact feature map, and a boolean legality flag. The payload MUST also expose `ranked_candidates`, a legal-candidate-only list ordered by deterministic compiler-side advisory ordering. The ML advisor is a separate sidecar service and may be disabled without changing compiler correctness. Each ranked entry MUST expose `rank`, `confidence`, the `graph_encoding` consumed by the advisory layer, and an `explanation` object with a human-readable `why_preferred` summary plus bounded `influential_features` and `influential_subgraph` hooks. `selected_candidate_explanation` MUST mirror the first ranked candidate summary. Advisory layers MUST only score candidates where `legal` is true.
 

--- a/src/services/eigen-compiler/src/eigen_compiler/compiler.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/compiler.py
@@ -55,6 +55,11 @@ _ADVISORY_MODEL_VERSION = "compiler-advisory-v1"
 _ADVISORY_SELECTION_MODE = "deterministic_legal_preference"
 _ADVISORY_FALLBACK_REASON_NO_LEGAL_CANDIDATES = "no_legal_candidates"
 
+_DECISION_SOURCE_SYMBOLIC_RULES = "symbolic_rules"
+_DECISION_SOURCE_GNN_RANKING = "gnn_ranking"
+_DECISION_SOURCE_BOOSTING_RANKING = "boosting_ranking"
+_DECISION_SOURCE_FALLBACK = "fallback"
+
 _REPLAY_MODE_DETERMINISTIC = "deterministic"
 _NEURO_MODEL_VERSION_ENV = "EIGEN_NEURO_SYMBOLIC_MODEL_VERSION"
 _NEURO_POLICY_SNAPSHOT_VERSION_ENV = "EIGEN_NEURO_SYMBOLIC_POLICY_SNAPSHOT_VERSION"
@@ -337,6 +342,7 @@ def _compiler_replay_bundle(
         "workload_profile": workload_profile,
         "compiler_stage_order": compiler_stage_order,
         "handoff_stage_order": handoff_stage_order,
+        "decision_source": symbolic_candidates["decision_source"],
         "symbolic_rules": symbolic_rules,
         "model_snapshot": snapshot["model_snapshot"],
         "knowledge_base_snapshot": snapshot["knowledge_base_snapshot"],
@@ -836,6 +842,25 @@ def _baseline_symbolic_candidate(candidates: list[SymbolicCandidate | str]) -> S
     return legal_candidates[0]
 
 
+def _decision_source_for_ranker(*, model_family: str, fallback_used: bool) -> str:
+    if fallback_used:
+        return _DECISION_SOURCE_FALLBACK
+
+    normalized_family = model_family.strip().lower()
+    if normalized_family in {"gnn", "graph_neural_network"} or "gnn" in normalized_family:
+        return _DECISION_SOURCE_GNN_RANKING
+    if normalized_family in {
+        "boosting",
+        "boosted",
+        "gradient_boosting",
+        "xgboost",
+        "lightgbm",
+        "catboost",
+    } or any(token in normalized_family for token in ("boost", "xgb", "lgbm", "cat")):
+        return _DECISION_SOURCE_BOOSTING_RANKING
+    return _DECISION_SOURCE_SYMBOLIC_RULES
+
+
 def _symbolic_candidate_set_payload(candidate_set: SymbolicCandidateSet) -> dict[str, object]:
     candidates = [_symbolic_candidate_payload(candidate) for candidate in candidate_set.candidates]
     legal_candidates = [candidate for candidate in candidate_set.candidates if isinstance(candidate, SymbolicCandidate) and candidate.legal]
@@ -888,17 +913,21 @@ def _symbolic_candidate_set_payload(candidate_set: SymbolicCandidateSet) -> dict
     selected_candidate_id = str(selected_candidate["candidate_id"]) if selected_candidate else ""
     selected_candidate_explanation = str(selected_candidate["why_preferred"]) if selected_candidate else ""
 
+    decision_source = _decision_source_for_ranker(model_family=_ADVISORY_MODEL_FAMILY, fallback_used=fallback_used)
+
     return {
         "version": candidate_set.version,
         "candidate_budget": candidate_set.candidate_budget,
         "candidate_count": len(candidates),
         "legal_candidate_count": len(legal_candidates),
+        "decision_source": decision_source,
         "ranker": {
             "model_family": _ADVISORY_MODEL_FAMILY,
             "model_version": _ADVISORY_MODEL_VERSION,
             "objective": "stable_legal_candidate_order",
             "explanation_hook": "feature_attribution",
             "selection_mode": selection_mode,
+            "decision_source": decision_source,
             "fallback_used": fallback_used,
             "fallback_reason": fallback_reason,
         },
@@ -1977,6 +2006,7 @@ def compile_eigen_lang(
     symbolic_candidate_set_payload = _symbolic_candidate_set_payload(symbolic_candidate_set)
     symbolic_candidate_set_json = _canonical_json_text(symbolic_candidate_set_payload)
     symbolic_candidate_set_sha256 = hashlib.sha256(symbolic_candidate_set_json.encode("utf-8")).hexdigest()
+    decision_source = str(symbolic_candidate_set_payload.get("decision_source", _DECISION_SOURCE_SYMBOLIC_RULES)).strip() or _DECISION_SOURCE_SYMBOLIC_RULES
     logical_graph_schema_payload = _logical_graph_schema_payload()
     logical_graph_schema_json = _canonical_json_text(logical_graph_schema_payload)
     logical_graph_schema_sha256 = hashlib.sha256(logical_graph_schema_json.encode("utf-8")).hexdigest()
@@ -2102,6 +2132,7 @@ def compile_eigen_lang(
         "aqo_sha256": aqo_digest,
         "request_sha256": request_digest,
         "replay_mode": _REPLAY_MODE_DETERMINISTIC,
+        "decision_source": decision_source,
         "replay_bundle_sha256": replay_bundle_sha256,
         "snapshot_id": snapshot["snapshot_id"],
         "model_snapshot": replay_bundle["model_snapshot"],
@@ -2119,11 +2150,13 @@ def compile_eigen_lang(
             "tenant_ids_in_metrics": False,
             "project_ids_in_metrics": False,
         },
+        "decision_source": decision_source,
         "lineage_sha256": request_digest,
     }
     explainability = {
         "contract_version": "1.0.0",
         "decision": "compiler_to_optimizer_handoff",
+        "decision_source": decision_source,
         "trace_fields": ["request_id", "trace_id", "traceparent"],
         "lineage": decision_lineage,
         "bounded_fields": [
@@ -2169,6 +2202,7 @@ def compile_eigen_lang(
         "aqo_sha256": aqo_digest,
         "request_sha256": request_digest,
         "source_precedence": source_precedence,
+        "decision_source": decision_source,
         "options_json": options_json,
         "options_sha256": hashlib.sha256(options_json.encode("utf-8")).hexdigest(),
         "request_context_json": request_context_json,

--- a/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
@@ -489,6 +489,32 @@ def _selected_candidate_signature(candidate_set: dict[str, object]) -> str:
     return ""
 
 
+def _compiler_decision_source(candidate_set: dict[str, object], *, default: str = "symbolic_rules") -> str:
+    if not isinstance(candidate_set, dict):
+        return default
+
+    explicit = str(candidate_set.get("decision_source", "")).strip()
+    if explicit:
+        return explicit
+
+    ranker = candidate_set.get("ranker", {})
+    if isinstance(ranker, dict):
+        source = str(ranker.get("decision_source", "")).strip()
+        if source:
+            return source
+        model_family = str(ranker.get("model_family", "")).strip().lower()
+        fallback_used = bool(ranker.get("fallback_used", False))
+        if fallback_used:
+            return "fallback"
+        if model_family in {"gnn", "graph_neural_network"} or "gnn" in model_family:
+            return "gnn_ranking"
+        if model_family in {"boosting", "boosted", "gradient_boosting", "xgboost", "lightgbm", "catboost"} or any(
+            token in model_family for token in ("boost", "xgb", "lgbm", "cat")
+        ):
+            return "boosting_ranking"
+    return default
+
+
 def _trace_digest_payload(
     *,
     rpc: str,
@@ -513,6 +539,7 @@ def _trace_digest_payload(
     failure_reason: str = "",
     compiler_replay_sha256: str = "",
     compiler_diagnostics_sha256: str = "",
+    decision_source: str = "",
 ) -> dict[str, str]:
     return {
         "rpc": rpc,
@@ -537,6 +564,7 @@ def _trace_digest_payload(
         "failure_reason": failure_reason,
         "compiler_replay_sha256": compiler_replay_sha256,
         "compiler_diagnostics_sha256": compiler_diagnostics_sha256,
+        "decision_source": decision_source,
     }
 
 
@@ -587,6 +615,10 @@ def _kb_index_compiler_trace(
         policy_snapshot_id = str(metadata.get("policy_snapshot_id", policy_snapshot_version) if metadata else policy_snapshot_version).strip() or policy_snapshot_version
         policy_digest = str(metadata.get("policy_digest", "") if metadata else "").strip()
         candidate_set = json.loads(candidate_set_json) if candidate_set_json else {"candidate_count": 0, "candidates": []}
+        decision_source = _compiler_decision_source(
+            candidate_set,
+            default=str(metadata.get("decision_source", "") if metadata else "").strip() or "symbolic_rules",
+        )
         candidate_entries = candidate_set.get("candidates", []) if isinstance(candidate_set, dict) else []
         pattern_signature = _selected_candidate_signature(candidate_set) if result is not None else f"failure:{failure_stage or 'compile'}"
         trace_payload = _trace_digest_payload(
@@ -612,6 +644,7 @@ def _kb_index_compiler_trace(
             failure_reason=failure_reason,
             compiler_replay_sha256=compiler_replay_sha256,
             compiler_diagnostics_sha256=compiler_diagnostics_sha256,
+            decision_source=decision_source,
         )
         trace_digest = _canonical_compiler_trace_digest(trace_payload)
 
@@ -645,6 +678,7 @@ def _kb_index_compiler_trace(
                 "trace_digest_sha256": trace_digest,
                 "pattern_signature": pattern_signature,
                 "compiler_status": "success" if result is not None else "failure",
+                "decision_source": decision_source,
                 "failure_stage": failure_stage,
                 "failure_reason": failure_reason,
                 "source_sha256": source_digest,
@@ -740,6 +774,7 @@ def _kb_index_compiler_trace(
                 "telemetry_feature_set_json": telemetry_feature_set_json,
                 "telemetry_feature_set_sha256": telemetry_feature_set_sha256,
                 "compiler_status": "success" if result is not None else "failure",
+                "decision_source": decision_source,
                 "accepted_rewrite_ids": _stable_json(accepted),
                 "rejected_rewrite_ids": _stable_json(rejected),
                 "failure_stage": failure_stage,
@@ -1720,6 +1755,7 @@ def _log_end(
             "traceparent": request_context.get("traceparent", ""),
             "stage": "rpc",
             "outcome": "success",
+            "decision_source": metadata.get("decision_source", ""),
             "source_sha256": metadata.get("source_sha256", ""),
             "aqo_sha256": metadata.get("aqo_sha256", ""),
         },

--- a/src/services/eigen-compiler/tests/test_compilation_rpc.py
+++ b/src/services/eigen-compiler/tests/test_compilation_rpc.py
@@ -142,6 +142,7 @@ def _trace_digest_payload(
     failure_reason: str = "",
     compiler_replay_sha256: str = "",
     compiler_diagnostics_sha256: str = "",
+    decision_source: str = "",
 ) -> dict[str, str]:
     return {
         "rpc": rpc,
@@ -166,6 +167,7 @@ def _trace_digest_payload(
         "failure_reason": failure_reason,
         "compiler_replay_sha256": compiler_replay_sha256,
         "compiler_diagnostics_sha256": compiler_diagnostics_sha256,
+        "decision_source": decision_source,
     }
 
 
@@ -217,18 +219,21 @@ def test_compile_circuit_happy_path(grpc_addr: str) -> None:
     assert resp.metadata["compiler_replay_json"]
     assert len(resp.metadata["compiler_replay_sha256"]) == 64
     assert len(resp.metadata["symbolic_candidate_set_sha256"]) == 64
+    assert resp.metadata["decision_source"] == "symbolic_rules"
 
     candidate_set = json.loads(resp.metadata["symbolic_candidate_set_json"])
     assert candidate_set["version"] == "1.0.0"
     assert candidate_set["candidate_budget"] == 8
     assert candidate_set["candidate_count"] == len(candidate_set["candidates"])
     assert candidate_set["candidate_count"] <= candidate_set["candidate_budget"]
+    assert candidate_set["decision_source"] == "symbolic_rules"
     assert candidate_set["ranker"] == {
         "model_family": "deterministic",
         "model_version": "compiler-advisory-v1",
         "objective": "stable_legal_candidate_order",
         "explanation_hook": "feature_attribution",
         "selection_mode": "deterministic_legal_preference",
+        "decision_source": "symbolic_rules",
         "fallback_used": False,
         "fallback_reason": "",
     }
@@ -252,6 +257,8 @@ def test_compile_circuit_happy_path(grpc_addr: str) -> None:
         "graph_features",
         "rank_projection",
     ]
+    decision_lineage = json.loads(resp.metadata["decision_lineage_json"])
+    assert decision_lineage["decision_source"] == "symbolic_rules"
 
 
 def test_deterministic_advisor_prefers_terminal_measurement_candidates() -> None:
@@ -336,6 +343,7 @@ def test_deterministic_advisor_prefers_terminal_measurement_candidates() -> None
         "objective": "stable_legal_candidate_order",
         "explanation_hook": "feature_attribution",
         "selection_mode": "deterministic_legal_preference",
+        "decision_source": "symbolic_rules",
         "fallback_used": False,
         "fallback_reason": "",
     }
@@ -474,6 +482,7 @@ def test_compile_job_indexes_trace_and_rewrite_paths_in_kb(
         policy_digest=resp.metadata["policy_digest"],
         compiler_replay_sha256=resp.metadata["compiler_replay_sha256"],
         compiler_diagnostics_sha256=hashlib.sha256(resp.metadata["compiler_diagnostics_json"].encode("utf-8")).hexdigest(),
+        decision_source=resp.metadata["decision_source"],
     )
     trace_digest = hashlib.sha256(_stable_json(trace_payload).encode("utf-8")).hexdigest()
 


### PR DESCRIPTION
## Summary

- Implemented compile-trace decision source logging for the compiler path. Every compile now carries a bounded decision_source field through compiler metadata, replay/lineage payloads, structured RPC-end logs, and KB indexing records. The trace source is recorded as one of symbolic_rules, gnn_ranking, boosting_ranking, or fallback, and the compiler test coverage was updated accordingly.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: API | Metrics
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- decision_source recorded in compiler trace metadata and KB indexing payloads.

### Changed
- Compiler replay, lineage, explainability, and diagnostics now include the final trace source classification.
- Structured RPC-end logs now include decision_source.

### Fixed
- Compile traces now expose whether the final choice came from symbolic rules, GNN ranking, boosting ranking, or fallback.