### PR TITLE
Implemented compiler evaluation observability

### DIFF
--- a/docs/architecture/components/compiler.md
+++ b/docs/architecture/components/compiler.md
@@ -221,6 +221,7 @@ Pass ordering and pass outputs must remain stable for identical normalized input
 - Duplicate / replay compiles must be observable.
 - Stage failures must be attributable to a named stage and a structured violation.
 - Advisor influence must be recorded as accepted, rejected, or transformed into a deterministic compiler action.
+- Evaluation dashboards must slice `eigen_compiler_evaluation_total` and `eigen_compiler_evaluation_latency_seconds_*` by `compiler_version` and `job_type` to show model-assisted acceptance rate, fallback rate, and latency.
 
 ---
 

--- a/docs/reference/compiler-observability-contract.md
+++ b/docs/reference/compiler-observability-contract.md
@@ -43,6 +43,9 @@ The compiler observability surface MUST include:
 - `eigen_compiler_validation_failures_total{stage,reason}`
 - `eigen_compiler_aqo_digest_emitted_total{kind}`
 - `eigen_compiler_replay_compiles_total{kind}`
+- `eigen_compiler_evaluation_total{compiler_version,job_type,decision_source}`
+- `eigen_compiler_evaluation_latency_seconds_count{compiler_version,job_type,decision_source}`
+- `eigen_compiler_evaluation_latency_seconds_sum{compiler_version,job_type,decision_source}`
 - `eigen_compiler_symbolic_rewrite_stage_duration_seconds_count{stage,outcome}`
 - `eigen_compiler_symbolic_rewrite_stage_duration_seconds_sum{stage,outcome}`
 
@@ -91,7 +94,29 @@ The compiler observability surface MUST include:
 - `aqo`
 - `duplicate`
 
+**compiler_version**
+
+- bounded compiler contract version string emitted in compile metadata (for example, `1.0.0`)
+
+**job_type**
+
+- `QuantumJob`
+- `HybridWorkflow`
+- `DistributedJob`
+- `BenchmarkJob`
+- `PipelineJob`
+- `ReplayJob`
+
+**decision_source**
+
+- `symbolic_rules`
+- `gnn_ranking`
+- `boosting_ranking`
+- `fallback`
+
 Trace IDs, request IDs, tenant IDs, project IDs, and job IDs MUST NOT be exposed in metric labels.
+
+The evaluation metric families above MUST record successful compile traces and expose the final decision source and latency sliced by compiler version and job type so dashboards can compute model-assisted acceptance rate, fallback rate, and latency.
 
 ---
 

--- a/monitoring/dashboards/compiler_evaluation_dashboard.json
+++ b/monitoring/dashboards/compiler_evaluation_dashboard.json
@@ -1,0 +1,232 @@
+{
+  "title": "Eigen Compiler \u2014 Evaluation Dashboard",
+  "uid": "eigen-compiler-evaluation-v1",
+  "tags": [
+    "eigen",
+    "compiler",
+    "evaluation",
+    "observability"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "templating": {
+    "list": [
+      {
+        "name": "compiler_version",
+        "label": "Compiler Version",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "DS_PROMETHEUS"
+        },
+        "query": "label_values(eigen_compiler_evaluation_total, compiler_version)",
+        "definition": "label_values(eigen_compiler_evaluation_total, compiler_version)",
+        "refresh": 2,
+        "sort": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        }
+      },
+      {
+        "name": "job_type",
+        "label": "Job Type",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "DS_PROMETHEUS"
+        },
+        "query": "label_values(eigen_compiler_evaluation_total, job_type)",
+        "definition": "label_values(eigen_compiler_evaluation_total, job_type)",
+        "refresh": 2,
+        "sort": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Model-assisted Acceptance Rate (5m)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "DS_PROMETHEUS"
+      },
+      "targets": [
+        {
+          "expr": "100 * sum(rate(eigen_compiler_evaluation_total{compiler_version=~\"$compiler_version\",job_type=~\"$job_type\",decision_source=~\"gnn_ranking|boosting_ranking\"}[5m])) / clamp_min(sum(rate(eigen_compiler_evaluation_total{compiler_version=~\"$compiler_version\",job_type=~\"$job_type\"}[5m])), 1e-9)",
+          "legendFormat": "accepted %"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Fallback Rate (5m)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "DS_PROMETHEUS"
+      },
+      "targets": [
+        {
+          "expr": "100 * sum(rate(eigen_compiler_evaluation_total{compiler_version=~\"$compiler_version\",job_type=~\"$job_type\",decision_source=\"fallback\"}[5m])) / clamp_min(sum(rate(eigen_compiler_evaluation_total{compiler_version=~\"$compiler_version\",job_type=~\"$job_type\"}[5m])), 1e-9)",
+          "legendFormat": "fallback %"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 30
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Average Compile Latency (ms, 5m)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "DS_PROMETHEUS"
+      },
+      "targets": [
+        {
+          "expr": "1000 * sum(rate(eigen_compiler_evaluation_latency_seconds_sum{compiler_version=~\"$compiler_version\",job_type=~\"$job_type\"}[5m])) / clamp_min(sum(rate(eigen_compiler_evaluation_latency_seconds_count{compiler_version=~\"$compiler_version\",job_type=~\"$job_type\"}[5m])), 1e-9)",
+          "legendFormat": "avg latency"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "orange",
+                "value": 500
+              },
+              {
+                "color": "red",
+                "value": 1500
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Decision Source Mix (5m)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "DS_PROMETHEUS"
+      },
+      "targets": [
+        {
+          "expr": "sum by (decision_source) (rate(eigen_compiler_evaluation_total{compiler_version=~\"$compiler_version\",job_type=~\"$job_type\"}[5m]))",
+          "legendFormat": "{{decision_source}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "stacking": {
+            "mode": "normal",
+            "group": "A"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
+++ b/src/services/eigen-compiler/src/eigen_compiler/grpc_impl.py
@@ -16,6 +16,7 @@ import re
 import sys
 import threading
 import types
+from time import perf_counter
 from typing import Callable
 
 import grpc
@@ -91,6 +92,9 @@ _STAGE_SECONDS_TOTALS: defaultdict[tuple[tuple[str, str], ...], float] = default
 _VALIDATION_FAILURE_TOTALS: Counter[tuple[tuple[str, str], ...]] = Counter()
 _AQO_DIGEST_TOTALS: Counter[tuple[tuple[str, str], ...]] = Counter()
 _REPLAY_TOTALS: Counter[tuple[tuple[str, str], ...]] = Counter()
+_EVALUATION_TOTALS: Counter[tuple[tuple[str, str], ...]] = Counter()
+_EVALUATION_LATENCY_SECONDS_COUNT_TOTALS: Counter[tuple[tuple[str, str], ...]] = Counter()
+_EVALUATION_LATENCY_SECONDS_SUM_TOTALS: defaultdict[tuple[tuple[str, str], ...], float] = defaultdict(float)
 _SEEN_AQO_DIGESTS: set[str] = set()
 _OBSERVABILITY_CONTRACT_VERSION = "1.0.0"
 _REWRITE_OUTCOME_TAXONOMY = ("accepted", "rejected", "equivalent", "unsafe")
@@ -291,6 +295,24 @@ def _record_replay(kind: str = "duplicate") -> None:
     _bump(_REPLAY_TOTALS, kind=kind)
 
 
+def _record_evaluation_metrics(
+    *,
+    compiler_version: str,
+    job_type: str,
+    decision_source: str,
+    elapsed_seconds: float,
+) -> None:
+    labels = _label_tuple(
+        compiler_version=compiler_version,
+        job_type=job_type,
+        decision_source=decision_source,
+    )
+    with _METRIC_LOCK:
+        _EVALUATION_TOTALS[labels] += 1
+        _EVALUATION_LATENCY_SECONDS_COUNT_TOTALS[labels] += 1
+        _EVALUATION_LATENCY_SECONDS_SUM_TOTALS[labels] += elapsed_seconds
+
+
 def reset_metrics() -> None:
     with _METRIC_LOCK:
         _RPC_TOTALS.clear()
@@ -299,6 +321,9 @@ def reset_metrics() -> None:
         _VALIDATION_FAILURE_TOTALS.clear()
         _AQO_DIGEST_TOTALS.clear()
         _REPLAY_TOTALS.clear()
+        _EVALUATION_TOTALS.clear()
+        _EVALUATION_LATENCY_SECONDS_COUNT_TOTALS.clear()
+        _EVALUATION_LATENCY_SECONDS_SUM_TOTALS.clear()
         _SEEN_AQO_DIGESTS.clear()
 
 
@@ -343,6 +368,11 @@ def render_metrics_text() -> str:
         lines.extend(_render_counter_family("eigen_compiler_validation_failures_total", _VALIDATION_FAILURE_TOTALS))
         lines.extend(_render_counter_family("eigen_compiler_aqo_digest_emitted_total", _AQO_DIGEST_TOTALS))
         lines.extend(_render_counter_family("eigen_compiler_replay_compiles_total", _REPLAY_TOTALS))
+        lines.extend(_render_counter_family("eigen_compiler_evaluation_total", _EVALUATION_TOTALS))
+        lines.extend(_render_counter_family("eigen_compiler_evaluation_latency_seconds_count", _EVALUATION_LATENCY_SECONDS_COUNT_TOTALS))
+        lines.append("# TYPE eigen_compiler_evaluation_latency_seconds_sum counter")
+        for labels, value in sorted(_EVALUATION_LATENCY_SECONDS_SUM_TOTALS.items(), key=lambda item: item[0]):
+            lines.append(f"eigen_compiler_evaluation_latency_seconds_sum{_fmt_labels(labels)} {value:.9f}")
         return "\n".join(lines) + "\n"
 
 
@@ -1077,6 +1107,7 @@ class CompilationService:
         options = _request_metadata_workload_options(getattr(request, "request_metadata", None))
         options.update({str(k): str(v) for k, v in dict(request.options).items()})
         try:
+            compile_started = perf_counter()
             resp = self._compile_response(
                 rpc="CompileCircuit",
                 source=source,
@@ -1086,6 +1117,13 @@ class CompilationService:
             )
 
             _record_rpc("CompileCircuit", "success")
+
+            _record_evaluation_metrics(
+                compiler_version=str(resp.metadata.get("compiler_contract_version", "1.0.0")).strip() or "1.0.0",
+                job_type=str(resp.metadata.get("workload_profile", "unknown")).strip() or "unknown",
+                decision_source=str(resp.metadata.get("decision_source", "symbolic_rules")).strip() or "symbolic_rules",
+                elapsed_seconds=perf_counter() - compile_started,
+            )
 
             aqo_sha = resp.metadata.get("aqo_sha256", "")
 
@@ -1164,6 +1202,7 @@ class CompilationService:
         options = _request_metadata_workload_options(getattr(request, "request_metadata", None))
         options.update({str(k): str(v) for k, v in dict(request.options).items()})
         try:
+            compile_started = perf_counter()
             compiled = self._compile_response(
                 rpc="CompileJob",
                 source=source,
@@ -1194,6 +1233,13 @@ class CompilationService:
 
         _record_rpc("CompileJob", "success")
 
+        _record_evaluation_metrics(
+            compiler_version=str(compiled.metadata.get("compiler_contract_version", "1.0.0")).strip() or "1.0.0",
+            job_type=str(compiled.metadata.get("workload_profile", "unknown")).strip() or "unknown",
+            decision_source=str(compiled.metadata.get("decision_source", "symbolic_rules")).strip() or "symbolic_rules",
+            elapsed_seconds=perf_counter() - compile_started,
+        )
+        
         aqo_sha = compiled.metadata.get("aqo_sha256", "")
 
         if aqo_sha:

--- a/src/services/eigen-compiler/tests/test_compilation_rpc.py
+++ b/src/services/eigen-compiler/tests/test_compilation_rpc.py
@@ -43,7 +43,7 @@ from eigen.internal.v1 import kernel_gateway_pb2 as kernel_pb  # noqa: E402
 from eigen.internal.v1 import neuro_symbolic_service_pb2_grpc as nsc_pb_grpc  # noqa: E402
 from eigen.internal.v1 import types_pb2 as types_pb  # noqa: E402
 
-from eigen_compiler.grpc_impl import _rewrite_outcome_for_candidate  # noqa: E402
+from eigen_compiler.grpc_impl import _rewrite_outcome_for_candidate, render_metrics_text, reset_metrics  # noqa: E402
 
 
 def _enum_value(module, *names: str) -> int:
@@ -259,6 +259,62 @@ def test_compile_circuit_happy_path(grpc_addr: str) -> None:
     ]
     decision_lineage = json.loads(resp.metadata["decision_lineage_json"])
     assert decision_lineage["decision_source"] == "symbolic_rules"
+
+
+def test_evaluation_metrics_are_labeled_by_compiler_version_and_job_type(grpc_addr: str) -> None:
+    reset_metrics()
+
+    channel = grpc.insecure_channel(grpc_addr)
+    stub = comp_pb_grpc.CompilationServiceStub(channel)
+
+    circuit_source = (
+        b"from eigen_lang import hybrid_program\n\n"
+        b"@hybrid_program()\n"
+        b"def main():\n"
+        b"    ry(0, theta=1.0)\n"
+    )
+
+    circuit_resp = stub.CompileCircuit(
+        comp_pb.CompileCircuitRequest(
+            language="eigen-lang",
+            source=circuit_source,
+        )
+    )
+    assert circuit_resp.metadata["compiler_contract_version"] == "1.0.0"
+    assert circuit_resp.metadata["workload_profile"] == "QuantumJob"
+
+    request_metadata = kernel_pb.RequestMetadata()
+    request_metadata.contract_version = "1.0.0"
+    request_metadata.request_id = "req-metrics-001"
+    request_metadata.trace_id = "trace-metrics-001"
+    request_metadata.traceparent = "00-11111111111111111111111111111111-2222222222222222-01"
+    request_metadata.deadline.seconds = 60
+    request_metadata.retry_policy = "retry-none"
+    request_metadata.security_context = "compiler-test"
+    request_metadata.tenant_id = "tenant-a"
+    request_metadata.project_id = "project-a"
+    request_metadata.workload.kind = kernel_pb.WORKLOAD_FAMILY_KIND_HYBRID_WORKFLOW
+    request_metadata.workload.execution_profile = "hybrid"
+    request_metadata.workload.backend_target = "sim:local"
+
+    job_resp = stub.CompileJob(
+        comp_pb.CompileJobRequest(
+            job_id="job-metrics-001",
+            language="eigen-lang",
+            source=circuit_source,
+            request_metadata=request_metadata,
+        )
+    )
+    assert job_resp.metadata["compiler_contract_version"] == "1.0.0"
+    assert job_resp.metadata["workload_profile"] == "HybridWorkflow"
+
+    metrics = render_metrics_text()
+    assert 'eigen_compiler_evaluation_total{compiler_version="1.0.0",decision_source="symbolic_rules",job_type="QuantumJob"} 1' in metrics
+    assert 'eigen_compiler_evaluation_total{compiler_version="1.0.0",decision_source="symbolic_rules",job_type="HybridWorkflow"} 1' in metrics
+    assert 'eigen_compiler_evaluation_latency_seconds_count{compiler_version="1.0.0",decision_source="symbolic_rules",job_type="QuantumJob"} 1' in metrics
+    assert 'eigen_compiler_evaluation_latency_seconds_count{compiler_version="1.0.0",decision_source="symbolic_rules",job_type="HybridWorkflow"} 1' in metrics
+    assert 'eigen_compiler_evaluation_latency_seconds_sum{compiler_version="1.0.0",decision_source="symbolic_rules",job_type="QuantumJob"}' in metrics
+    assert 'eigen_compiler_evaluation_latency_seconds_sum{compiler_version="1.0.0",decision_source="symbolic_rules",job_type="HybridWorkflow"}' in metrics
 
 
 def test_deterministic_advisor_prefers_terminal_measurement_candidates() -> None:

--- a/src/services/eigen-compiler/tests/test_conformance_suite.py
+++ b/src/services/eigen-compiler/tests/test_conformance_suite.py
@@ -449,3 +449,17 @@ def test_metrics_expose_contract_marker() -> None:
     text = render_metrics_text()
     assert 'eigen_observability_contract_info{version="1.0.0"} 1' in text
     assert 'eigen_compiler_contract_info{version="1.0.0"} 1' in text
+
+
+def test_compiler_evaluation_dashboard_targets_version_and_job_type() -> None:
+    dashboard = json.loads((Path(__file__).resolve().parents[4] / "monitoring" / "dashboards" / "compiler_evaluation_dashboard.json").read_text(encoding="utf-8"))
+
+    assert dashboard["title"] == "Eigen Compiler — Evaluation Dashboard"
+    variable_names = {item["name"] for item in dashboard["templating"]["list"]}
+    assert {"compiler_version", "job_type"} <= variable_names
+
+    exprs = "\n".join(target["expr"] for panel in dashboard["panels"] for target in panel["targets"])
+    assert "eigen_compiler_evaluation_total" in exprs
+    assert 'compiler_version=~"$compiler_version"' in exprs
+    assert 'job_type=~"$job_type"' in exprs
+    assert 'decision_source="fallback"' in exprs


### PR DESCRIPTION
## Summary

- Implemented compiler evaluation observability

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: Metrics
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Compiler evaluation metrics labeled by compiler version, job type, and decision source.
- A Grafana dashboard for compiler acceptance rate, fallback rate, and latency.

### Changed
- Compiler observability contract now includes evaluation metric families for successful compile traces.
- Compiler architecture docs now reference the evaluation dashboard slice by compiler version and job type.

### Fixed
- Dashboard consumers can now query compiler evaluation data per version and per job type without relying on ad hoc labels.