### PR TITLE
Added a docs-only evaluation dashboard spec

### DIFF
--- a/docs/architecture/components/compiler.md
+++ b/docs/architecture/components/compiler.md
@@ -222,6 +222,8 @@ Pass ordering and pass outputs must remain stable for identical normalized input
 - Stage failures must be attributable to a named stage and a structured violation.
 - Advisor influence must be recorded as accepted, rejected, or transformed into a deterministic compiler action.
 - Evaluation dashboards must slice `eigen_compiler_evaluation_total` and `eigen_compiler_evaluation_latency_seconds_*` by `compiler_version` and `job_type` to show model-assisted acceptance rate, fallback rate, and latency.
+- The canonical dashboard specification lives in `docs/reference/compiler-evaluation-dashboard.md`.
+- For the current A/B / shadow comparison, `QuantumJob` is the baseline symbolic-core slice and `HybridWorkflow` is the hybrid-mode slice.
 
 ---
 

--- a/docs/reference/compiler-evaluation-dashboard.md
+++ b/docs/reference/compiler-evaluation-dashboard.md
@@ -1,0 +1,96 @@
+# Compiler Evaluation Dashboard
+
+- **Document status:** Normative reference
+- **Subsystem:** Compiler Service
+- **Contract version:** `1.0.0`
+- **Applies to:** A/B and shadow evaluations for baseline symbolic core versus hybrid mode
+
+This document defines the dashboard slice for issue #781. The compiler already emits bounded evaluation metrics with `compiler_version`, `job_type`, and `decision_source` labels. The dashboard uses those metrics to compare the baseline symbolic core against hybrid mode without introducing any new labels or unbounded trace identifiers.
+
+---
+
+## 1. Comparison model
+
+For current compiler traffic:
+
+- `QuantumJob` is the baseline symbolic-core slice.
+- `HybridWorkflow` is the hybrid-mode slice.
+
+The dashboard SHOULD compare both slices over the same time window and the same compiler version whenever possible.
+
+The primary signals are:
+
+- acceptance rate,
+- fallback rate,
+- decision-source mix,
+- average latency.
+
+Acceptance rate and fallback rate are quality proxies. Lower fallback rate and higher acceptance rate are stronger signals that hybrid mode is helping.
+
+---
+
+## 2. Required panels
+
+### 2.1 Acceptance rate
+
+This panel shows the share of compile traces whose final decision source is symbolic rules.
+
+```promql
+sum by (compiler_version, job_type) (
+  rate(eigen_compiler_evaluation_total{decision_source="symbolic_rules"}[5m])
+)
+/
+sum by (compiler_version, job_type) (
+  rate(eigen_compiler_evaluation_total[5m])
+)
+```
+
+### 2.2 Fallback rate
+
+This panel shows the share of compile traces that had to fall back to the safe default path.
+
+```promql
++sum by (compiler_version, job_type) (
+  rate(eigen_compiler_evaluation_total{decision_source="fallback"}[5m])
+)
+/
+sum by (compiler_version, job_type) (
+  rate(eigen_compiler_evaluation_total[5m])
+)
+```
+
+### 2.3 Average latency
+
+The contract exposes latency as count and sum, so the dashboard SHOULD render average latency as `sum / count`.
+
+```promql
+sum by (compiler_version, job_type, decision_source) (
+  rate(eigen_compiler_evaluation_latency_seconds_sum[5m])
+)
+/
+sum by (compiler_version, job_type, decision_source) (
+  rate(eigen_compiler_evaluation_latency_seconds_count[5m])
+)
+```
+
+### 2.4 Decision-source mix
+
+This panel should show how the final choice is distributed across symbolic rules, GNN ranking, boosting ranking, and fallback. It helps verify whether hybrid mode is changing the decision surface or merely adding latency.
+
+```promql
+sum by (compiler_version, job_type, decision_source) (
+  rate(eigen_compiler_evaluation_total[5m])
+)
+```
+
+---
+
+## 3. Interpretation
+
+Hybrid mode is considered better when, for the same compiler version and comparable workload mix, it improves one or more of the following:
+
+- increases acceptance rate,
+- decreases fallback rate,
+- decreases average latency.
+
+The dashboard SHOULD use the same dashboard time range for both slices and SHOULD keep the grouping bounded to `compiler_version`, `job_type`, and `decision_source`.

--- a/docs/reference/compiler-observability-contract.md
+++ b/docs/reference/compiler-observability-contract.md
@@ -118,6 +118,12 @@ Trace IDs, request IDs, tenant IDs, project IDs, and job IDs MUST NOT be exposed
 
 The evaluation metric families above MUST record successful compile traces and expose the final decision source and latency sliced by compiler version and job type so dashboards can compute model-assisted acceptance rate, fallback rate, and latency.
 
+### 3.1 Evaluation dashboards
+
+For A/B or shadow evaluations, dashboards MUST compare the baseline symbolic core against hybrid mode using the metric families above. For current compiler traffic, `QuantumJob` is the baseline symbolic-core slice and `HybridWorkflow` is the hybrid-mode slice.
+
+The canonical dashboard specification lives in `docs/reference/compiler-evaluation-dashboard.md`.
+
 ---
 
 ## 4. Structured logs


### PR DESCRIPTION
## Summary

- Added a docs-only evaluation dashboard spec for issue #781 and linked it from the compiler architecture and compiler observability contract. The new reference defines the baseline symbolic-core vs hybrid-mode comparison, with QuantumJob as the baseline slice and HybridWorkflow as the hybrid slice, and gives PromQL panels for acceptance rate, fallback rate, decision-source mix, and average latency.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: PATCH
- **Affected Interfaces**: Metrics
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Compiler evaluation dashboard specification for baseline symbolic-core vs hybrid-mode comparison.
- Canonical PromQL panels for acceptance rate, fallback rate, decision-source mix, and average latency.

### Changed
- Compiler observability and architecture docs now point to the evaluation dashboard reference.
- The baseline/hybrid comparison convention is now documented as QuantumJob vs HybridWorkflow.

### Fixed
- Clear, bounded guidance now exists for evaluating whether hybrid mode improves quality, latency, or both.