### PR TITLE
Implemented KB traceability for optimizer decisions

### DIFF
--- a/docs/architecture/components/knowledge-base.md
+++ b/docs/architecture/components/knowledge-base.md
@@ -11,7 +11,7 @@ The Knowledge Base exposes two distinct behaviors:
 1. **Public record storage** — CRUD/query for KB records and decision logs.
 2. **Optimization Knowledge Base (OKB) retrieval** — deterministic reuse selection for compiler / AQO workflows.
 
-Runtime decision logs are append-only and MUST preserve the audit trail fields required by the neuro-symbolic compliance contract: caller identity, tenant, policy snapshot version, model version, retrieval sources, final decision, and the final `decision_source` (`symbolic_rules`, `gnn_ranking`, `boosting_ranking`, or `fallback`).
+Runtime decision logs are append-only and MUST preserve the audit trail fields required by the neuro-symbolic compliance contract: caller identity, tenant, policy snapshot version, model version, retrieval sources, final decision, and the final `decision_source` (`symbolic_rules`, `gnn_ranking`, `boosting_ranking`, or `fallback`). Each runtime decision log MUST also expose canonical KB provenance references: `kb://decision-log/<decision_id>`, `kb://replay/<decision_id>`, and `kb://provenance/<decision_id>`.
 
 Compiler traces are indexed into the KB as replay-safe records and decision logs so later queries can bind to trace ID, trace digest, and pattern signature. The canonical rewrite-outcome taxonomy is `accepted`, `rejected`, `equivalent`, and `unsafe`; KB records and model-training corpora MUST use that same label set consistently. Both accepted and rejected rewrite paths MUST be retained, and equivalent/unsafe outcomes MUST be preserved for ranking and safety analysis.
 
@@ -82,7 +82,7 @@ Normative rules:
 - Requests that omit required boundary fields MUST fail closed.
 - The same normalized `knowledge_context` MUST produce the same replay identity, candidate ordering, and provenance fields.
 
-Compiler trace index lookups use the same replay-safe discipline: `QueryRecords` and `QueryDecisionLogs` MAY filter by `trace_id`, `trace_digest_sha256`, and `pattern_signature`, and these fields MUST remain bounded, deterministic, and queryable without introducing model-authored truth.
+Compiler trace index lookups use the same replay-safe discipline: `QueryRecords` and `QueryDecisionLogs` MAY filter by `trace_id`, `trace_digest_sha256`, and `pattern_signature`, and these fields MUST remain bounded, deterministic, and queryable without introducing model-authored truth. Decision-log responses and optimizer candidates MUST carry KB provenance references for replay and explanation, and those references MUST be stable across identical inputs.
 
 ### 2.4.2 `PatternRecord`
 

--- a/docs/reference/api/explain-backend-selection.md
+++ b/docs/reference/api/explain-backend-selection.md
@@ -321,6 +321,12 @@ Required for:
 - Continuous Learning,
 - scheduler validation.
 
+The provenance envelope MUST include the canonical KB bindings for the selected decision artifact, replay bundle, and provenance artifact so that the explanation can be replayed from KB without ad hoc translation:
+
+- `kb://decision-log/<decision_id>`
+- `kb://replay/<decision_id>`
+- `kb://provenance/<decision_id>`
+
 ---
 
 ## 9. Runtime Semantics

--- a/src/rust/crates/resource-manager/src/lib.rs
+++ b/src/rust/crates/resource-manager/src/lib.rs
@@ -1488,9 +1488,17 @@ pub struct ExplainBackendSelectionResponse {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExplainKnowledgeBaseProvenance {
+    pub decision_log_ref: String,
+    pub replay_bundle_ref: String,
+    pub provenance_ref: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExplainDecisionProvenance {
     pub tenant_context: ExplainTenantEvidence,
     pub policy_context: ExplainPolicyEvidence,
+    pub knowledge_base: ExplainKnowledgeBaseProvenance,
     pub evidence_ids: Vec<String>,
 }
 
@@ -3060,6 +3068,11 @@ pub fn explain_backend_selection(
                 fallback_reason: request.policy_context.fallback_reason.clone(),
                 plugin_trace: request.policy_context.plugin_trace.clone(),
             },
+            knowledge_base: ExplainKnowledgeBaseProvenance {
+                decision_log_ref: format!("kb://decision-log/{}", decision.decision_id),
+                replay_bundle_ref: format!("kb://replay/{}", decision.decision_id),
+                provenance_ref: format!("kb://provenance/{}", decision.decision_id),
+            },
             evidence_ids: vec![
                 format!("backend-decision:{}", decision.decision_id),
                 format!("tenant:{}:project:{}", redacted_tenant, redacted_project),
@@ -3069,6 +3082,9 @@ pub fn explain_backend_selection(
                     request.policy_context.policy_bundle_version
                 ),
                 format!("reason:{:?}", request.policy_context.transition_reason_code),
+                format!("kb://decision-log/{}", decision.decision_id),
+                format!("kb://replay/{}", decision.decision_id),
+                format!("kb://provenance/{}", decision.decision_id),
             ],
         },
         confidence: ExplainConfidenceMetadata {

--- a/src/rust/crates/resource-manager/tests/explain_backend_selection_contract.rs
+++ b/src/rust/crates/resource-manager/tests/explain_backend_selection_contract.rs
@@ -173,6 +173,11 @@ fn explain_backend_selection_contract_matches_golden_fixture() {
                 "fallback_reason": response.decision_provenance.policy_context.fallback_reason,
                 "plugin_trace": response.decision_provenance.policy_context.plugin_trace,
             },
+            "knowledge_base": {
+                "decision_log_ref": response.decision_provenance.knowledge_base.decision_log_ref,
+                "replay_bundle_ref": response.decision_provenance.knowledge_base.replay_bundle_ref,
+                "provenance_ref": response.decision_provenance.knowledge_base.provenance_ref,
+            },
             "evidence_ids": response.decision_provenance.evidence_ids,
         },
     });

--- a/src/rust/crates/resource-manager/tests/fixtures/explain_contracts/backend_selection_explain_v1_1_0.json
+++ b/src/rust/crates/resource-manager/tests/fixtures/explain_contracts/backend_selection_explain_v1_1_0.json
@@ -145,8 +145,16 @@
       "backend-decision:backend-selection-decision-001",
       "tenant:tena***:project:proj***",
       "policy:balanced@1.0.0",
-      "reason:DeterministicSelection"
+      "reason:DeterministicSelection",
+      "kb://decision-log/backend-selection-decision-001",
+      "kb://replay/backend-selection-decision-001",
+      "kb://provenance/backend-selection-decision-001"
     ],
+    "knowledge_base": {
+      "decision_log_ref": "kb://decision-log/backend-selection-decision-001",
+      "replay_bundle_ref": "kb://replay/backend-selection-decision-001",
+      "provenance_ref": "kb://provenance/backend-selection-decision-001"
+    },
     "policy_context": {
       "fallback_applied": false,
       "fallback_reason": null,

--- a/src/services/neuro-symbolic-service/src/neuro_symbolic_service/knowledge_base.py
+++ b/src/services/neuro-symbolic-service/src/neuro_symbolic_service/knowledge_base.py
@@ -736,6 +736,15 @@ class KnowledgeBaseService:
         self._validate_decision_log(request.decision_log, context)
         sec_ctx, policy_version = self._retrieval_security_context(context, operation="append_decision_log")
         feature_snapshot = dict(getattr(request.decision_log, "feature_snapshot", {}) or {})
+        decision_log_ref = self._decision_log_ref(str(request.decision_log.decision_id).strip())
+        replay_bundle_ref = self._replay_bundle_ref(str(request.decision_log.decision_id).strip())
+        provenance_ref = self._decision_provenance_ref(str(request.decision_log.decision_id).strip())
+        feature_snapshot.setdefault("kb_decision_log_ref", decision_log_ref)
+        feature_snapshot.setdefault("kb_replay_bundle_ref", replay_bundle_ref)
+        feature_snapshot.setdefault("kb_provenance_ref", provenance_ref)
+        request.decision_log.feature_snapshot.clear()
+        for key, value in feature_snapshot.items():
+            request.decision_log.feature_snapshot[key] = str(value)
         caller_identity = getattr(sec_ctx, "subject", "") or ""
         retrieval_sources = _audit_string_list(
             feature_snapshot.get("retrieval_sources")
@@ -865,6 +874,9 @@ class KnowledgeBaseService:
                     "contract_version": _KB_CONTRACT_VERSION,
                     "candidate_source": item.candidate_source,
                     "source_ref": item.provenance_ref,
+                    "decision_log_ref": item.metadata.get("decision_log_ref", ""),
+                    "replay_bundle_ref": item.metadata.get("replay_bundle_ref", ""),
+                    "provenance_ref": item.metadata.get("provenance_ref", item.provenance_ref),
                     "transformation_ref": item.transformation_ref,
                     "explanation_ref": item.explanation_ref,
                     "compatibility_window": item.compatibility_window,
@@ -967,6 +979,9 @@ class KnowledgeBaseService:
             snapshot["confidence"] = f"{explainability_envelope['confidence']:.6f}"
             snapshot["retrieval_references"] = _stable_json(explainability_envelope["retrieval_references"])
             snapshot["replay_digest"] = explainability_envelope["replay_digest"]
+            snapshot["kb_decision_log_ref"] = self._decision_log_ref(decision_log.decision_id)
+            snapshot["kb_replay_bundle_ref"] = self._replay_bundle_ref(decision_log.decision_id)
+            snapshot["kb_provenance_ref"] = self._decision_provenance_ref(decision_log.decision_id)
             for key, value in snapshot.items():
                 decision_log.feature_snapshot[key] = str(value)
             decided_at = payload.get("decided_at")
@@ -1019,6 +1034,9 @@ class KnowledgeBaseService:
                         "evaluation_bundle_hash": str(payload.get("evaluation_bundle_hash", "")).strip(),
                         "promotion_policy_version": str(payload.get("promotion_policy_version", "")).strip(),
                         "explainability_envelope": explainability_envelope,
+                        "kb_decision_log_ref": self._decision_log_ref(decision_log.decision_id),
+                        "kb_replay_bundle_ref": self._replay_bundle_ref(decision_log.decision_id),
+                        "kb_provenance_ref": self._decision_provenance_ref(decision_log.decision_id),
                     },
                     model_version=decision_log.model_version,
                     training_set_hash=str(payload.get("training_set_hash", "")).strip(),
@@ -2254,9 +2272,15 @@ class KnowledgeBaseService:
     def _candidate_from_decision_log(self, entry: _StoredDecisionLog, query: dict[str, Any]) -> _OptimizationCandidate:
         candidate_id = f"okb-decision-{entry.decision_log.decision_id}"
         compatibility_window = f"{entry.decision_log.model_version or query['optimizer_version']}::{query['backend_profile_id'] or 'any'}"
+        decision_log_ref = self._decision_log_ref(entry.decision_log.decision_id)
+        replay_bundle_ref = self._replay_bundle_ref(entry.decision_log.decision_id)
+        provenance_ref = self._decision_provenance_ref(entry.decision_log.decision_id)
         basis = {
             "kind": "decision_log",
             "decision_id": entry.decision_log.decision_id,
+            "decision_log_ref": decision_log_ref,
+            "replay_bundle_ref": replay_bundle_ref,
+            "provenance_ref": provenance_ref,
             "trace_id": entry.decision_log.trace_id,
             "model_version": entry.decision_log.model_version,
             "component": entry.decision_log.component,
@@ -2270,7 +2294,7 @@ class KnowledgeBaseService:
             candidate_source="decision_log",
             optimization_type="decision-lineage-reuse",
             transformation_ref=entry.decision_log.selected_action or entry.decision_log.decision_id,
-            provenance_ref=entry.decision_log.trace_id or entry.decision_log.decision_id,
+            provenance_ref=provenance_ref,
             compatibility_window=compatibility_window,
             basis=basis,
             query=query,
@@ -2361,6 +2385,9 @@ class KnowledgeBaseService:
             "tenant_id": query["tenant_id"],
             "project_id": query["project_id"],
             "capability_scope": tuple(query.get("capability_scope", ())),
+            "decision_log_ref": basis.get("decision_log_ref", ""),
+            "replay_bundle_ref": basis.get("replay_bundle_ref", ""),
+            "provenance_ref": basis.get("provenance_ref", ""),
         }
         return _OptimizationCandidate(
             candidate_id=candidate_id,
@@ -3063,8 +3090,17 @@ class KnowledgeBaseService:
             "created_before": self._ts_signature(getattr(query_filter, "created_before", None)),
         }
 
+    def _decision_log_ref(self, decision_id: str) -> str:
+        return f"kb://decision-log/{decision_id}"
+
+
     def _replay_bundle_ref(self, record_id: str) -> str:
         return f"kb://replay/{record_id}"
+
+
+    def _decision_provenance_ref(self, decision_id: str) -> str:
+        return f"kb://provenance/{decision_id}"
+
 
     # Reconstructed Missing Internals -------------------------------------
 

--- a/src/services/neuro-symbolic-service/tests/test_knowledge_base_service.py
+++ b/src/services/neuro-symbolic-service/tests/test_knowledge_base_service.py
@@ -273,6 +273,9 @@ def test_decision_log_lineage_validation_and_ordering(grpc_addr: str) -> None:
     )
     assert [item.decision_id for item in query.decision_logs] == ["decision-a", "decision-b"]
     assert [item.selected_action for item in query.decision_logs] == ["backend-alpha", "backend-beta"]
+    assert query.decision_logs[0].feature_snapshot["kb_decision_log_ref"] == "kb://decision-log/decision-a"
+    assert query.decision_logs[0].feature_snapshot["kb_replay_bundle_ref"] == "kb://replay/decision-a"
+    assert query.decision_logs[0].feature_snapshot["kb_provenance_ref"] == "kb://provenance/decision-a"
 
 
 def test_runtime_decision_ingest_persists_explainability_envelope(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
@@ -332,6 +335,9 @@ def test_runtime_decision_ingest_persists_explainability_envelope(monkeypatch: p
     assert snapshot["project_id"] == "project-a"
     assert snapshot["policy_snapshot_version"] == "policy-2026-06-15"
     assert snapshot["final_decision"] == "backend-alpha"
+    assert snapshot["kb_decision_log_ref"] == "kb://decision-log/decision-runtime-1"
+    assert snapshot["kb_replay_bundle_ref"] == "kb://replay/decision-runtime-1"
+    assert snapshot["kb_provenance_ref"] == "kb://provenance/decision-runtime-1"
     assert json.loads(snapshot["retrieval_sources"]) == [
         "nsc://feature-set/tenant-a/project-a/request-1/feature-digest",
         "nsc://policy-snapshot/policy-2026-06-15",
@@ -485,6 +491,7 @@ def test_kb_queries_support_trace_digest_and_pattern_signature_filters(grpc_addr
     assert [item.decision_id for item in decisions.decision_logs] == ["decision-trace-filter"]
     assert decisions.decision_logs[0].selected_action == "symbolic.rewrite_terminal_measurement"
     assert decisions.decision_logs[0].feature_snapshot["rewrite_outcome"] == "accepted"
+    assert decisions.decision_logs[0].feature_snapshot["kb_decision_log_ref"] == "kb://decision-log/decision-trace-filter"
 
 
 def test_kb_records_and_decision_logs_are_project_scoped(grpc_addr: str) -> None:


### PR DESCRIPTION
## Summary

- Implemented KB traceability for optimizer decisions across the service and explainability contract.

## Validation

- [x] Tests added/updated
- [x] Documentation updated (if contracts/behavior changed)

## Versioning & Compatibility (required)

- **Version Impact**: MINOR
- **Affected Interfaces**: API
- **Compatibility**: Backward-compatible
- **Breaking Marker**: false
- **Migration Notes**: None

## Release Notes Draft

### Added
- Canonical KB provenance refs for decision logs: kb://decision-log/<decision_id>, kb://replay/<decision_id>, and kb://provenance/<decision_id>.
- KB-backed provenance fields in optimizer candidate responses for replay and explanation.

### Changed
- Optimizer decision provenance now carries explicit KB bindings alongside existing explainability metadata.
- KnowledgeBaseService now stamps decision-log snapshots and runtime decision evidence with canonical KB refs.

### Fixed
- Mapping decisions can now be replayed and explained directly from KB/provenance without ad hoc translation.
- Explainability contract snapshots now match the KB-backed provenance model.